### PR TITLE
Add logs permission to roles form

### DIFF
--- a/imports/ui/members/roles/RolesForm.jsx
+++ b/imports/ui/members/roles/RolesForm.jsx
@@ -59,6 +59,7 @@ const RolesForm = ({ setOpen }) => {
       <RuleInput name="registrations" label="Registrations" />
       <RuleInput name="discoveryTypes" label="Discovery Types" />
       <RuleInput name="roles" label="Roles" />
+      <RuleInput name="logs" label="Logs" />
       <RuleInput name="settings" label="Settings" />
       <FormFooter setOpen={setOpen} />
     </Form>


### PR DESCRIPTION
## Summary
- Add logs permission toggle to RolesForm so admins can grant access to the Logs page

This was missing from PR #41.