### PR TITLE
Add null checks to prevent server crashes

### DIFF
--- a/server/apis/members.server.js
+++ b/server/apis/members.server.js
@@ -54,7 +54,9 @@ if (Meteor.isServer) {
       validateUserId(this.userId);
       validateObject(filter, false);
       validateObject(options, false);
-      return await MembersCollection.findOneAsync(filter, options);
+      const member = await MembersCollection.findOneAsync(filter, options);
+      if (!member) throw new Meteor.Error(404, 'Member not found');
+      return member;
     },
     'members.insert': async function (payload = {}) {
       validateUserId(this.userId);

--- a/server/apis/settings.server.js
+++ b/server/apis/settings.server.js
@@ -39,8 +39,10 @@ if (Meteor.isServer) {
       validateString(filter, false);
       try {
         const setting = await SettingsCollection.findOneAsync(filter);
+        if (!setting) throw new Meteor.Error(404, 'Setting not found');
         return setting.value;
       } catch (error) {
+        if (error.error === 404) throw error;
         throw new Meteor.Error(error.message);
       }
     },


### PR DESCRIPTION
## Summary
- Add null check in `settings.findOne` before accessing `.value` property
- Add null check in `members.findOne` before returning result
- Both methods now throw `Meteor.Error(404, ...)` when records are not found

## Changes
- `server/apis/settings.server.js`: Check if setting exists before accessing `.value`, properly re-throw 404 errors
- `server/apis/members.server.js`: Check if member exists before returning

## Risk Mitigation
- Prevents server crashes from unhandled null pointer exceptions
- Prevents stack trace exposure in production
- Returns proper HTTP 404 error codes for missing resources

## Test plan
- [ ] Call `settings.findOne` with a non-existent key - should return 404 error
- [ ] Call `members.findOne` with a non-existent filter - should return 404 error
- [ ] Verify existing functionality still works with valid keys/filters

Closes #53