### PR TITLE
Add revoke and ignore functionality for questionnaire responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Members (Meteor.users), Events, Attendances, Tasks, TaskStatus, Squads, Ranks, S
 - `questions[]: { text, type ('text'|'textarea'|'number'|'select'|'multiselect'|'rating'), required, options[] }`
 
 **QuestionnaireResponses**
-- `questionnaireId, respondentId (null if anonymous), answers[], submittedAt, createdAt`
+- `questionnaireId, respondentId (null if anonymous), answers[], ignored, submittedAt, createdAt`
 - `answers[]: { questionIndex, questionText, questionType, value }`
 
 **Attendances** - `{ [eventId]: { [memberId]: points } }`

--- a/imports/ui/questionnaires/questionnaireResponse.columns.jsx
+++ b/imports/ui/questionnaires/questionnaireResponse.columns.jsx
@@ -1,15 +1,20 @@
-import { EyeOutlined } from '@ant-design/icons';
-import { Button, Tag, Tooltip } from 'antd';
+import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
+import { Button, Space, Tag, Tooltip } from 'antd';
 import React from 'react';
 
-const getQuestionnaireResponseColumns = handleViewDetails => {
+const getQuestionnaireResponseColumns = (handleViewDetails, handleToggleIgnored = null, canUpdate = false) => {
   return [
     {
       title: 'Respondent',
       dataIndex: 'respondentName',
       key: 'respondentName',
       ellipsis: true,
-      render: (name, record) => (record.respondentId ? name : <Tag color="blue">Anonymous</Tag>),
+      render: (name, record) => (
+        <Space>
+          {record.respondentId ? name : <Tag color="blue">Anonymous</Tag>}
+          {record.ignored && <Tag color="orange">Ignored</Tag>}
+        </Space>
+      ),
     },
     {
       title: 'Submitted At',
@@ -35,9 +40,21 @@ const getQuestionnaireResponseColumns = handleViewDetails => {
       dataIndex: '_id',
       key: 'actions',
       render: (id, record) => (
-        <Tooltip title="View Details">
-          <Button type="text" icon={<EyeOutlined />} onClick={e => handleViewDetails(e, record)} />
-        </Tooltip>
+        <Space>
+          <Tooltip title="View Details">
+            <Button type="text" icon={<EyeOutlined />} onClick={e => handleViewDetails(e, record)} />
+          </Tooltip>
+          {canUpdate && handleToggleIgnored && (
+            <Tooltip title={record.ignored ? 'Unignore' : 'Ignore'}>
+              <Button
+                type="text"
+                danger={!record.ignored}
+                icon={<EyeInvisibleOutlined />}
+                onClick={e => handleToggleIgnored(e, record)}
+              />
+            </Tooltip>
+          )}
+        </Space>
       ),
     },
   ];


### PR DESCRIPTION
## Summary

- Users can revoke their own non-anonymous questionnaire responses
- Admins with update permission can ignore/unignore responses
- Ignored responses are visually marked in the admin responses view

## Changes

- Added `questionnaireResponses.revoke` server method for users to delete their own responses
- Added `questionnaireResponses.setIgnored` server method for admins to mark responses as ignored
- Updated My Questionnaires to show "Revoke" button for completed non-anonymous questionnaires
- Updated admin responses table with "Ignore" toggle button and status tag
- All actions are logged for audit trail

## Test plan

- [ ] Submit a response to a non-anonymous questionnaire
- [ ] Verify "Revoke" button appears on the completed card
- [ ] Click Revoke and confirm - verify response is deleted
- [ ] As admin, view responses and click the ignore button
- [ ] Verify "Ignored" tag appears on the response
- [ ] Click again to unignore and verify tag is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)