### PR TITLE
Add unit tests for getCollection in crud.lib.js

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -2,5 +2,6 @@ import './helpers/colors/getLegibleTextColor.test.js';
 import './helpers/colors/getLuminance.test.js';
 import './helpers/colors/hexToRgb.test.js';
 import './helpers/colors/parseColor.test.js';
+import './server/getCollection.test.js';
 import './server/permissions.test.js';
 import './server/validation.test.js';

--- a/tests/server/getCollection.test.js
+++ b/tests/server/getCollection.test.js
@@ -1,0 +1,61 @@
+/* global describe, it */
+import assert from 'node:assert';
+
+// Use require() instead of import to avoid circular dependency issues
+// between crud.lib.js and main.js during module initialization.
+// By the time tests run, all modules are fully initialized.
+function loadGetCollection() {
+  return require('../../server/crud.lib').getCollection;
+}
+
+const VALID_COLLECTIONS = [
+  'attendances',
+  'discoveryTypes',
+  'events',
+  'eventTypes',
+  'logs',
+  'medals',
+  'members',
+  'positions',
+  'profilePictures',
+  'questionnaires',
+  'questionnaireResponses',
+  'ranks',
+  'registrations',
+  'roles',
+  'specializations',
+  'squads',
+  'tasks',
+  'taskStatus',
+];
+
+describe('getCollection', () => {
+  for (const name of VALID_COLLECTIONS) {
+    it(`returns a collection for '${name}'`, () => {
+      const getCollection = loadGetCollection();
+      const collection = getCollection(name);
+      assert.ok(collection, `Expected a collection for '${name}'`);
+      assert.strictEqual(typeof collection.find, 'function', `Collection '${name}' should have a find method`);
+    });
+  }
+
+  it('throws Meteor.Error(400) for null input', () => {
+    const getCollection = loadGetCollection();
+    assert.throws(() => getCollection(null), error => error.error === 400);
+  });
+
+  it('throws Meteor.Error(400) for undefined input', () => {
+    const getCollection = loadGetCollection();
+    assert.throws(() => getCollection(undefined), error => error.error === 400);
+  });
+
+  it('throws Meteor.Error(400) for empty string', () => {
+    const getCollection = loadGetCollection();
+    assert.throws(() => getCollection(''), error => error.error === 400);
+  });
+
+  it('throws Meteor.Error(404) for unknown collection name', () => {
+    const getCollection = loadGetCollection();
+    assert.throws(() => getCollection('nonExistent'), error => error.error === 404);
+  });
+});


### PR DESCRIPTION
## Summary
- 22 new unit tests for `getCollection` switch in `server/crud.lib.js`
- Verifies all 18 collection names return valid collections with `find` method
- Verifies error cases: null, undefined, empty string (400), unknown name (404)

Closes #83

## Test plan
- [x] All 138 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)