### PR TITLE
Add unit tests for questionnaire interval helpers

### DIFF
--- a/server/apis/questionnaireResponses.server.js
+++ b/server/apis/questionnaireResponses.server.js
@@ -5,7 +5,7 @@ import MembersCollection from '../../imports/api/collections/members.collection'
 import { checkPermission, validateString, validateArray, validateObject } from '../main';
 import { createLog } from './logs.server';
 
-function getIntervalCutoffDate(interval) {
+export function getIntervalCutoffDate(interval) {
   if (!interval || interval === 'once') return null;
   if (interval === 'unlimited') return new Date(0);
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -4,4 +4,5 @@ import './helpers/colors/hexToRgb.test.js';
 import './helpers/colors/parseColor.test.js';
 import './server/getCollection.test.js';
 import './server/permissions.test.js';
+import './server/questionnaireInterval.test.js';
 import './server/validation.test.js';

--- a/tests/server/questionnaireInterval.test.js
+++ b/tests/server/questionnaireInterval.test.js
@@ -1,0 +1,68 @@
+/* global describe, it */
+import assert from 'node:assert';
+
+// Use require() to avoid circular dependency issues during module initialization.
+function loadHelpers() {
+  return require('../../server/apis/questionnaireResponses.server');
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const TOLERANCE_MS = 1000; // 1 second tolerance for timing
+
+describe('getIntervalCutoffDate', () => {
+  it('returns null for null input', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    assert.strictEqual(getIntervalCutoffDate(null), null);
+  });
+
+  it('returns null for undefined input', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    assert.strictEqual(getIntervalCutoffDate(undefined), null);
+  });
+
+  it('returns null for empty string', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    assert.strictEqual(getIntervalCutoffDate(''), null);
+  });
+
+  it('returns null for "once"', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    assert.strictEqual(getIntervalCutoffDate('once'), null);
+  });
+
+  it('returns epoch date for "unlimited"', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    const result = getIntervalCutoffDate('unlimited');
+    assert.strictEqual(result.getTime(), 0);
+  });
+
+  it('returns ~24 hours ago for "daily"', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    const before = Date.now() - ONE_DAY_MS;
+    const result = getIntervalCutoffDate('daily');
+    const after = Date.now() - ONE_DAY_MS;
+    assert.ok(result instanceof Date);
+    assert.ok(Math.abs(result.getTime() - before) < TOLERANCE_MS);
+  });
+
+  it('returns ~7 days ago for "weekly"', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    const expected = Date.now() - 7 * ONE_DAY_MS;
+    const result = getIntervalCutoffDate('weekly');
+    assert.ok(result instanceof Date);
+    assert.ok(Math.abs(result.getTime() - expected) < TOLERANCE_MS);
+  });
+
+  it('returns ~30 days ago for "monthly"', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    const expected = Date.now() - 30 * ONE_DAY_MS;
+    const result = getIntervalCutoffDate('monthly');
+    assert.ok(result instanceof Date);
+    assert.ok(Math.abs(result.getTime() - expected) < TOLERANCE_MS);
+  });
+
+  it('returns null for unknown interval', () => {
+    const { getIntervalCutoffDate } = loadHelpers();
+    assert.strictEqual(getIntervalCutoffDate('biweekly'), null);
+  });
+});


### PR DESCRIPTION
## Summary
- 9 new unit tests for `getIntervalCutoffDate` in `questionnaireResponses.server.js`
- Covers all interval types: once, unlimited, daily, weekly, monthly
- Tests edge cases: null, undefined, empty string, unknown interval
- Exported `getIntervalCutoffDate` for testability

Closes #84

## Test plan
- [x] All 147 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)