### PR TITLE
refactor(ui): migrate orbat, dashboard, backup to TypeScript (M7/1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ e2e/.auth/
 e2e/test-results/
 e2e/playwright-report/
 e2e/blob-report/
+
+# Git worktrees
+.worktrees/

--- a/imports/ui/backup/Backup.tsx
+++ b/imports/ui/backup/Backup.tsx
@@ -30,13 +30,9 @@ interface BackupData {
 }
 
 // Wire format: mirrors the return shape of backup.validate
-interface ValidationResult {
-  valid: boolean;
-  error?: string;
-  version?: string;
-  timestamp?: string;
-  meta?: BackupMeta;
-}
+type ValidationResult =
+  | { valid: true; version: string; timestamp: string; meta: BackupMeta }
+  | { valid: false; error: string };
 
 // Wire format: mirrors RestoreResult from server/apis/backup.server.ts
 interface RestoreResult {
@@ -51,7 +47,7 @@ export default function Backup() {
   const [loading, setLoading] = useState(false);
   const [restoreModalOpen, setRestoreModalOpen] = useState(false);
   const [backupData, setBackupData] = useState<BackupData | null>(null);
-  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+  const [validationResult, setValidationResult] = useState<Extract<ValidationResult, { valid: true }> | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [createSafetyBackup, setCreateSafetyBackup] = useState(true);
   const [safetyBackupData, setSafetyBackupData] = useState<BackupData | null>(null);
@@ -87,7 +83,7 @@ export default function Backup() {
     }
   }, [t]);
 
-  const handleFileUpload = useCallback(async (file: RcFile) => {
+  const handleFileUpload = useCallback(async (file: RcFile): Promise<false | undefined> => {
     // Validate file size
     if (file.size > MAX_BACKUP_SIZE) {
       message.error(t('backup.fileTooLarge'));
@@ -274,7 +270,7 @@ function BackupSection({ loading, onBackup, t }: BackupSectionProps) {
 }
 
 interface RestoreSectionProps {
-  onFileUpload: (file: RcFile) => boolean | Promise<boolean | undefined>;
+  onFileUpload: (file: RcFile) => Promise<false | undefined>;
   t: LanguageContextValue['t'];
 }
 
@@ -313,7 +309,7 @@ function RestoreSection({ onFileUpload, t }: RestoreSectionProps) {
 
 interface RestoreConfirmModalProps {
   open: boolean;
-  validationResult: ValidationResult | null;
+  validationResult: Extract<ValidationResult, { valid: true }> | null;
   restoring: boolean;
   createSafetyBackup: boolean;
   onCreateSafetyBackupChange: (checked: boolean) => void;
@@ -361,11 +357,11 @@ function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBa
             <Descriptions bordered size="small" column={1}>
               <Descriptions.Item label={t('backup.version')}>{validationResult.version}</Descriptions.Item>
               <Descriptions.Item label={t('backup.created')}>{validationResult.timestamp ? dayjs(validationResult.timestamp).format('YYYY-MM-DD HH:mm:ss') : 'Unknown'}</Descriptions.Item>
-              <Descriptions.Item label={t('backup.totalDocuments')}>{validationResult.meta?.totalDocuments || 0}</Descriptions.Item>
+              <Descriptions.Item label={t('backup.totalDocuments')}>{validationResult.meta.totalDocuments || 0}</Descriptions.Item>
             </Descriptions>
           </Col>
         )}
-        {validationResult?.meta?.collectionCounts && (
+        {validationResult && validationResult.meta.collectionCounts && (
           <Col span={24}>
             <Typography.Title level={5}>{t('backup.collectionCounts')}</Typography.Title>
             <Descriptions bordered size="small" column={2}>

--- a/imports/ui/backup/Backup.tsx
+++ b/imports/ui/backup/Backup.tsx
@@ -1,5 +1,5 @@
 import { CloudDownloadOutlined, CloudUploadOutlined, InboxOutlined, SafetyOutlined, WarningOutlined } from '@ant-design/icons';
-import { Alert, Button, Checkbox, Col, Descriptions, Modal, Progress, Row, Space, Typography, message } from 'antd';
+import { Alert, App, Button, Checkbox, Col, Descriptions, Modal, Progress, Row, Space, Typography } from 'antd';
 import Dragger from 'antd/es/upload/Dragger';
 import type { RcFile } from 'antd/es/upload/interface';
 import dayjs from 'dayjs';
@@ -43,6 +43,7 @@ interface RestoreResult {
 }
 
 export default function Backup() {
+  const { message } = App.useApp();
   const backupRef = useTourRef('backup-section');
   const [loading, setLoading] = useState(false);
   const [restoreModalOpen, setRestoreModalOpen] = useState(false);

--- a/imports/ui/backup/Backup.tsx
+++ b/imports/ui/backup/Backup.tsx
@@ -1,10 +1,12 @@
 import { CloudDownloadOutlined, CloudUploadOutlined, InboxOutlined, SafetyOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert, Button, Checkbox, Col, Descriptions, Modal, Progress, Row, Space, Typography, message } from 'antd';
 import Dragger from 'antd/es/upload/Dragger';
+import type { RcFile } from 'antd/es/upload/interface';
 import dayjs from 'dayjs';
 import JSZip from 'jszip';
 import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useState } from 'react';
+import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import { useTranslation } from '../../i18n/LanguageContext';
 import SectionCard from '../section/SectionCard';
 import { useTourRef } from '../tour/TourContext';
@@ -12,21 +14,53 @@ import { useTourRef } from '../tour/TourContext';
 // Maximum backup file size: 50MB
 const MAX_BACKUP_SIZE = 50 * 1024 * 1024;
 
+// Wire format: mirrors BackupData from server/apis/backup.server.ts
+interface BackupMeta {
+  totalDocuments: number;
+  collectionCounts: Record<string, number>;
+  isSafetyBackup?: boolean;
+}
+
+interface BackupData {
+  version: string;
+  timestamp: string;
+  appName: string;
+  collections: Record<string, unknown[]>;
+  meta: BackupMeta;
+}
+
+// Wire format: mirrors the return shape of backup.validate
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+  version?: string;
+  timestamp?: string;
+  meta?: BackupMeta;
+}
+
+// Wire format: mirrors RestoreResult from server/apis/backup.server.ts
+interface RestoreResult {
+  success: boolean;
+  restored: Record<string, number>;
+  errors: Array<{ collection: string; error: string }>;
+  safetyBackup: BackupData | null;
+}
+
 export default function Backup() {
   const backupRef = useTourRef('backup-section');
   const [loading, setLoading] = useState(false);
   const [restoreModalOpen, setRestoreModalOpen] = useState(false);
-  const [backupData, setBackupData] = useState(null);
-  const [validationResult, setValidationResult] = useState(null);
+  const [backupData, setBackupData] = useState<BackupData | null>(null);
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [createSafetyBackup, setCreateSafetyBackup] = useState(true);
-  const [safetyBackupData, setSafetyBackupData] = useState(null);
+  const [safetyBackupData, setSafetyBackupData] = useState<BackupData | null>(null);
   const { t } = useTranslation();
 
   const handleBackup = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await Meteor.callAsync('backup.create');
+      const data = (await Meteor.callAsync('backup.create')) as BackupData;
 
       // Create ZIP archive
       const zip = new JSZip();
@@ -46,13 +80,14 @@ export default function Backup() {
       URL.revokeObjectURL(url);
       message.success(t('backup.backupDownloaded'));
     } catch (error) {
-      message.error(error.reason || error.message || t('backup.backupFailed'));
+      const err = error as Meteor.Error;
+      message.error(err.reason || err.message || t('backup.backupFailed'));
     } finally {
       setLoading(false);
     }
   }, [t]);
 
-  const handleFileUpload = useCallback(async file => {
+  const handleFileUpload = useCallback(async (file: RcFile) => {
     // Validate file size
     if (file.size > MAX_BACKUP_SIZE) {
       message.error(t('backup.fileTooLarge'));
@@ -60,7 +95,7 @@ export default function Backup() {
     }
 
     try {
-      let data;
+      let data: BackupData;
 
       // Check if it's a ZIP file or JSON file
       if (file.name.endsWith('.zip')) {
@@ -74,18 +109,18 @@ export default function Backup() {
         }
 
         const text = await jsonFile.async('string');
-        data = JSON.parse(text);
+        data = JSON.parse(text) as BackupData;
       } else if (file.name.endsWith('.json')) {
         // Legacy support for plain JSON files
         const text = await file.text();
-        data = JSON.parse(text);
+        data = JSON.parse(text) as BackupData;
       } else {
         message.error(t('backup.invalidFileType'));
         return false;
       }
 
       // Validate the backup
-      const validation = await Meteor.callAsync('backup.validate', data);
+      const validation = (await Meteor.callAsync('backup.validate', data)) as ValidationResult;
 
       if (!validation.valid) {
         message.error(validation.error);
@@ -99,7 +134,8 @@ export default function Backup() {
       if (error instanceof SyntaxError) {
         message.error(t('backup.invalidBackupJson'));
       } else {
-        message.error(error.reason || error.message || t('backup.fileReadFailed'));
+        const err = error as Meteor.Error;
+        message.error(err.reason || err.message || t('backup.fileReadFailed'));
       }
     }
     return false; // Prevent default upload behavior
@@ -110,7 +146,7 @@ export default function Backup() {
 
     setRestoring(true);
     try {
-      const result = await Meteor.callAsync('backup.restore', backupData, { createSafetyBackup });
+      const result = (await Meteor.callAsync('backup.restore', backupData, { createSafetyBackup })) as RestoreResult;
 
       if (result.success) {
         message.success(t('backup.restoreSuccess'));
@@ -129,7 +165,8 @@ export default function Backup() {
         }
       }
     } catch (error) {
-      message.error(error.reason || error.message || t('backup.restoreFailed'));
+      const err = error as Meteor.Error;
+      message.error(err.reason || err.message || t('backup.restoreFailed'));
     } finally {
       setRestoring(false);
     }
@@ -177,7 +214,7 @@ export default function Backup() {
   }, []);
 
   return (
-    <div ref={backupRef}>
+    <div ref={backupRef as React.RefObject<HTMLDivElement>}>
       <SectionCard title={t('backup.title')} ready={true}>
         <Row gutter={[24, 24]}>
           <Col xs={24} lg={12}>
@@ -210,7 +247,13 @@ export default function Backup() {
   );
 }
 
-function BackupSection({ loading, onBackup, t }) {
+interface BackupSectionProps {
+  loading: boolean;
+  onBackup: () => void;
+  t: LanguageContextValue['t'];
+}
+
+function BackupSection({ loading, onBackup, t }: BackupSectionProps) {
   return (
     <Row gutter={[16, 16]}>
       <Col span={24}>
@@ -230,7 +273,12 @@ function BackupSection({ loading, onBackup, t }) {
   );
 }
 
-function RestoreSection({ onFileUpload, t }) {
+interface RestoreSectionProps {
+  onFileUpload: (file: RcFile) => boolean | Promise<boolean | undefined>;
+  t: LanguageContextValue['t'];
+}
+
+function RestoreSection({ onFileUpload, t }: RestoreSectionProps) {
   return (
     <Row gutter={[16, 16]}>
       <Col span={24}>
@@ -263,7 +311,18 @@ function RestoreSection({ onFileUpload, t }) {
   );
 }
 
-function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel, t }) {
+interface RestoreConfirmModalProps {
+  open: boolean;
+  validationResult: ValidationResult | null;
+  restoring: boolean;
+  createSafetyBackup: boolean;
+  onCreateSafetyBackupChange: (checked: boolean) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  t: LanguageContextValue['t'];
+}
+
+function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel, t }: RestoreConfirmModalProps) {
   return (
     <Modal
       title={
@@ -329,7 +388,14 @@ function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBa
   );
 }
 
-function SafetyBackupModal({ open, onDownload, onClose, t }) {
+interface SafetyBackupModalProps {
+  open: boolean;
+  onDownload: () => void;
+  onClose: () => void;
+  t: LanguageContextValue['t'];
+}
+
+function SafetyBackupModal({ open, onDownload, onClose, t }: SafetyBackupModalProps) {
   return (
     <Modal
       title={

--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -1,20 +1,51 @@
 import { App, Button, Card, Col, Collapse, Descriptions, Row, Statistic, Tag, Typography } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { useTourRef } from '../tour/TourContext';
 
+interface Specialization {
+  name: string;
+  linkToFile: string | null;
+}
+
+interface ProfileStatsData {
+  'profile picture'?: string;
+  name?: string;
+  id?: number | string;
+  rank?: string;
+  rankColor?: string | null;
+  navyRank?: string;
+  squad?: string;
+  role?: string;
+  'entry date'?: string;
+  'attendance points'?: number;
+  'inactivity points'?: number;
+  description?: string;
+  specializations?: Specialization[];
+  medals?: string;
+  steamProfileLink?: string;
+  discordTag?: string;
+  position?: string;
+  positionColor?: string | null;
+}
+
+interface DashboardStats {
+  profile?: ProfileStatsData;
+  [key: string]: number | Record<string, number> | ProfileStatsData | undefined;
+}
+
 export default function Dashboard() {
   const { message } = App.useApp();
-  const [stats, setStats] = useState({});
+  const [stats, setStats] = useState<DashboardStats>({});
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
   const statsRef = useTourRef('dashboard-stats');
   const fetchStats = useCallback(function () {
     setLoading(true);
     Meteor.callAsync('dashboard.stats')
-      .then(setStats)
+      .then((data: DashboardStats) => setStats(data))
       .catch(() => {
         message.error('Failed to load dashboard stats');
       })
@@ -25,7 +56,7 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <div ref={statsRef}>
+    <div ref={statsRef as React.RefObject<HTMLDivElement>}>
       <Card
         type="inner"
         loading={loading}
@@ -58,19 +89,19 @@ export default function Dashboard() {
                 {Object.entries(stats)
                   .filter(([key]) => key !== 'profile')
                   .map(([key, value]) => {
-                    const translateStatKey = k => t(`dashboard.stats.${k}`) || k;
+                    const translateStatKey = (k: string) => t(`dashboard.stats.${k}`) || k;
                     return typeof value === 'object' ? (
-                      Object.keys(value).map(childKey => (
+                      Object.keys(value as Record<string, number>).map(childKey => (
                         <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
                           <Card variant="outlined">
-                            <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={value[childKey]} />
+                            <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={(value as Record<string, number>)[childKey]} />
                           </Card>
                         </Col>
                       ))
                     ) : (
                       <Col xs={24} md={12} lg={8} xxl={6} key={key}>
                         <Card variant="outlined">
-                          <Statistic title={translateStatKey(key)} value={value} />
+                          <Statistic title={translateStatKey(key)} value={value as number} />
                         </Card>
                       </Col>
                     );
@@ -85,12 +116,17 @@ export default function Dashboard() {
   );
 }
 
-export function ProfileStats({ profileStats, t }) {
+interface ProfileStatsProps {
+  profileStats?: ProfileStatsData;
+  t: LanguageContextValue['t'];
+}
+
+export function ProfileStats({ profileStats, t }: ProfileStatsProps) {
   const fullWidthKeys = useMemo(() => ['description', 'specializations', 'medals'], []);
   const oneThirdWidthKeys = useMemo(() => ['rank', 'id', 'name', 'entry date', 'squad', 'role', 'attendance points', 'inactivity points'], []);
 
   const translateLabel = useCallback(
-    key => (t ? t(`dashboard.profileLabels.${key}`) : key),
+    (key: string) => (t ? t(`dashboard.profileLabels.${key}`) : key),
     [t]
   );
 
@@ -121,7 +157,7 @@ export function ProfileStats({ profileStats, t }) {
             .filter(([key]) => oneThirdWidthKeys.includes(key))
             .map(([key, value]) => ({
               label: translateLabel(key),
-              children: value,
+              children: value as React.ReactNode,
             }))}
           bordered
         />
@@ -140,7 +176,7 @@ export function ProfileStats({ profileStats, t }) {
               label: translateLabel(key),
               children:
                 key === 'specializations' && Array.isArray(value) && value.length > 0
-                  ? value.map((spec, i) =>
+                  ? (value as Specialization[]).map((spec, i) =>
                       spec.linkToFile ? (
                         <a key={i} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
                           <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
@@ -151,7 +187,7 @@ export function ProfileStats({ profileStats, t }) {
                     )
                   : key === 'specializations'
                     ? '-'
-                    : value,
+                    : value as React.ReactNode,
             }))}
           bordered
         />
@@ -159,7 +195,3 @@ export function ProfileStats({ profileStats, t }) {
     </Row>
   );
 }
-ProfileStats.propTypes = {
-  profileStats: PropTypes.object,
-  t: PropTypes.func,
-};

--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -1,19 +1,34 @@
 import { App, Card, Descriptions, Empty, Popover, Select, Space, Typography } from 'antd';
+import type { DescriptionsProps } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Tree, TreeNode } from 'react-organizational-chart';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
 import { useTranslation } from '../../i18n/LanguageContext';
+import type { LanguageContextValue } from '../../i18n/LanguageContext';
+import type { Squad } from '/imports/api/types';
 import { turnBase64ToImage } from '../profile-picture-input/ProfilePictureInput';
 import useTheme from '../theme/theme.hook';
 import { useTourRef } from '../tour/TourContext';
 
+interface OrbatNode {
+  id: string;
+  name: string;
+  descritpion: string;
+  info?: string;
+  parentId?: string;
+  src: string | null;
+  color?: string;
+  children: OrbatNode[];
+}
+
+type OrbatPopoverItem = NonNullable<DescriptionsProps['items']>[number];
+
 export default function Orbat() {
   const { message } = App.useApp();
   const [ready, setReady] = useState(true);
-  const [squads, setSquads] = useState([]);
-  const [options, setOptions] = useState([]);
+  const [squads, setSquads] = useState<Squad[]>([]);
+  const [options, setOptions] = useState<OrbatNode[]>([]);
   const [viewType, setViewType] = useState('simple');
   const { t } = useTranslation();
   const { theme } = useTheme();
@@ -22,7 +37,7 @@ export default function Orbat() {
   useEffect(() => {
     setReady(false);
     Meteor.callAsync('orbat.squads')
-      .then(squads => {
+      .then((squads: Squad[]) => {
         setSquads(squads);
         setReady(true);
       })
@@ -32,27 +47,21 @@ export default function Orbat() {
       });
   }, [message]);
 
-  const findParentRecursive = useCallback((options, parentId) => {
-    if (!parentId) {
-      return null;
-    }
+  const findParentRecursive = useCallback((options: OrbatNode[], parentId: string | undefined): OrbatNode | null => {
+    if (!parentId) return null;
     for (const o of options) {
-      if (o.id === parentId) {
-        return o;
-      }
+      if (o.id === parentId) return o;
       const found = findParentRecursive(o.children, parentId);
-      if (found) {
-        return found;
-      }
+      if (found) return found;
     }
     return null;
   }, []);
 
-  const getOptions = useCallback(async () => {
-    const preparedOrbatOptions = [];
-    const roots = [];
-    const parents = [];
-    const children = [];
+  const getOptions = useCallback(async (): Promise<OrbatNode[]> => {
+    const preparedOrbatOptions: OrbatNode[] = [];
+    const roots: Squad[] = [];
+    const parents: Squad[] = [];
+    const children: Squad[] = [];
     for (const squad of squads) {
       if (!squad.parentSquadId && !roots.find(s => s._id === squad._id)) {
         roots.push(squad);
@@ -63,10 +72,10 @@ export default function Orbat() {
       }
     }
 
-    const prepareData = async squad => {
+    const prepareData = async (squad: Squad) => {
       const src = squad.image ? (await turnBase64ToImage(squad.image)).src : null;
-      const data = {
-        id: squad._id,
+      const data: OrbatNode = {
+        id: squad._id ?? '',
         name: squad.name,
         descritpion: `(SR: ${squad.shortRangeFrequency || 'N/A'} Mhz)`,
         info: squad.description,
@@ -86,7 +95,6 @@ export default function Orbat() {
     for (const squad of [...roots, ...parents, ...children]) {
       await prepareData(squad);
     }
-
     return preparedOrbatOptions;
   }, [squads, findParentRecursive]);
 
@@ -95,7 +103,7 @@ export default function Orbat() {
   }, [getOptions]);
 
   const mapOption = useCallback(
-    option => {
+    (option: OrbatNode) => {
       return (
         <TreeNode key={option.id} label={<ORBAT_Label option={option} viewType={viewType} />}>
           {option.children?.map(mapOption)}
@@ -106,7 +114,7 @@ export default function Orbat() {
   );
 
   return (
-    <div ref={chartRef}>
+    <div ref={chartRef as React.RefObject<HTMLDivElement>}>
       <Card
         loading={!ready}
         title={<Typography.Title level={3}>{t('orbat.title')}</Typography.Title>}
@@ -127,7 +135,13 @@ export default function Orbat() {
   );
 }
 
-const OrbatViewSelector = ({ viewType, handleChange, t }) => {
+interface OrbatViewSelectorProps {
+  viewType: string;
+  handleChange: (value: string) => void;
+  t: LanguageContextValue['t'];
+}
+
+const OrbatViewSelector = ({ viewType, handleChange, t }: OrbatViewSelectorProps) => {
   const viewTypes = useMemo(
     () => [
       { value: 'simple', label: t('orbat.simple') },
@@ -137,19 +151,19 @@ const OrbatViewSelector = ({ viewType, handleChange, t }) => {
   );
   return <Select style={{ minWidth: 125 }} value={viewType} onChange={handleChange} options={viewTypes} optionFilterProp="label" showSearch />;
 };
-OrbatViewSelector.propTypes = {
-  viewType: PropTypes.string,
-  handleChange: PropTypes.func,
-  t: PropTypes.func,
-};
 
-const ORBAT_Label = ({ option, viewType }) => {
-  const [items, setItems] = useState([]);
+interface ORBAT_LabelProps {
+  option: OrbatNode;
+  viewType: string;
+}
+
+const ORBAT_Label = ({ option, viewType }: ORBAT_LabelProps) => {
+  const [items, setItems] = useState<OrbatPopoverItem[]>([]);
 
   useEffect(() => {
     let isMounted = true;
     Meteor.callAsync('orbat.popover.items', option.id)
-      .then(data => {
+      .then((data: OrbatPopoverItem[]) => {
         if (isMounted) setItems(data);
       })
       .catch(() => {});
@@ -163,12 +177,13 @@ const ORBAT_Label = ({ option, viewType }) => {
   }
   return <ORBAT_SimpleLabel option={option} items={items} />;
 };
-ORBAT_Label.propTypes = {
-  option: PropTypes.object,
-  viewType: PropTypes.string,
-};
 
-const ORBAT_SimpleLabel = ({ option, items }) => {
+interface ORBAT_SimpleLabelProps {
+  option: OrbatNode;
+  items: OrbatPopoverItem[];
+}
+
+const ORBAT_SimpleLabel = ({ option, items }: ORBAT_SimpleLabelProps) => {
   const hoverStyle = { cursor: 'pointer' };
 
   return (
@@ -188,7 +203,7 @@ const ORBAT_SimpleLabel = ({ option, items }) => {
       >
         <img
           style={{ ...hoverStyle, maxWidth: '128px', aspectRatio: '1/1', objectFit: 'contain' }}
-          src={option.src}
+          src={option.src ?? undefined}
           alt="-"
           title={option.info || option.name}
         />
@@ -204,12 +219,13 @@ const ORBAT_SimpleLabel = ({ option, items }) => {
     </div>
   );
 };
-ORBAT_SimpleLabel.propTypes = {
-  option: PropTypes.object,
-  items: PropTypes.array,
-};
 
-const ORBAT_AdvancedLabel = ({ option, items }) => {
+interface ORBAT_AdvancedLabelProps {
+  option: OrbatNode;
+  items: OrbatPopoverItem[];
+}
+
+const ORBAT_AdvancedLabel = ({ option, items }: ORBAT_AdvancedLabelProps) => {
   const { t } = useTranslation();
   const bgColor = option.color;
   const textColor = bgColor ? getLegibleTextColor(bgColor) : undefined;
@@ -236,8 +252,4 @@ const ORBAT_AdvancedLabel = ({ option, items }) => {
       </Space>
     </Card>
   );
-};
-ORBAT_AdvancedLabel.propTypes = {
-  option: PropTypes.object,
-  items: PropTypes.array,
 };

--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -1,5 +1,4 @@
 import { App, Card, Descriptions, Empty, Popover, Select, Space, Typography } from 'antd';
-import type { DescriptionsProps } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Tree, TreeNode } from 'react-organizational-chart';
@@ -22,7 +21,10 @@ interface OrbatNode {
   children: OrbatNode[];
 }
 
-type OrbatPopoverItem = NonNullable<DescriptionsProps['items']>[number];
+interface OrbatPopoverItem {
+  label: string;
+  children: string;
+}
 
 export default function Orbat() {
   const { message } = App.useApp();


### PR DESCRIPTION
## Summary

First batch of Milestone 7 (feature folders) in the ongoing TypeScript migration. Converts the three smallest feature folders to TypeScript, establishing the pattern for the larger batches that follow.

- `imports/ui/orbat/Orbat.jsx` → `Orbat.tsx` (4 sub-components, typed against `Squad` + locally-designed `OrbatNode` tree shape, popover items narrowed to the server wire format `{ label: string; children: string }`)
- `imports/ui/dashboard/Dashboard.jsx` → `Dashboard.tsx` (adds `DashboardStats` and `ProfileStatsData` interfaces mirroring what the server actually returns, including space-keyed fields like `'profile picture'`)
- `imports/ui/backup/Backup.jsx` → `Backup.tsx` (authors 4 sub-component prop interfaces from scratch — original had no PropTypes; mirrors server types `BackupData`, `BackupMeta`, `RestoreResult` exactly; `ValidationResult` is a proper discriminated union so downstream access needs no optional chaining)

All PropTypes removed from the migrated files. No `any`, no `@ts-ignore`, no behavioral changes. `strictNullChecks` is on; full strict mode lands in M8 as planned.

Consistency fix included: `Backup.tsx` now uses `App.useApp()` for `message` (matches the pattern in `Orbat.tsx` and `Dashboard.tsx` and follows the CLAUDE.md guidance about drawer/modal context).

## Commits

1. `refactor(ui): migrate orbat folder to TypeScript`
2. `refactor(ui): tighten OrbatPopoverItem to wire format` (review fix)
3. `refactor(ui): migrate dashboard folder to TypeScript`
4. `refactor(ui): migrate backup folder to TypeScript`
5. `refactor(ui): tighten ValidationResult and onFileUpload types per review` (review fix)
6. `refactor(ui): use App.useApp() for message in Backup (consistency)`

## Verification

- [x] `npm run typecheck` exits 0
- [x] `npm test` — 168 passing (matches pre-M7 baseline exactly)
- [x] `git status` clean on the branch
- [ ] Manual smoke test: `npm start`, log in as admin, open ORBAT page, open Dashboard, open Backup page, create a backup .zip, upload it back to trigger the validate/restore modal
- [ ] E2E specs for `dashboard.spec.ts` and `backup.spec.ts` exist but were not run during development (no dev server in the worktree); reviewer should run `npm run e2e` before merging if desired
- [ ] No orbat-specific E2E spec exists (confirmed during Task 1)

## Known follow-ups (separate PRs)

- **`useTourRef` generic** — all three files (and `Header.tsx` from M6) cast `as React.RefObject<HTMLDivElement>` at the `<div ref={...}>` site because `useTourRef` returns `MutableRefObject<HTMLElement | null>`. Making `useTourRef<T extends HTMLElement = HTMLElement>(key)` in `imports/ui/tour/TourContext.tsx` lets all call sites drop their casts. Deferred because it touches files outside this batch's scope.
- **`descritpion` typo in `Orbat.tsx`'s `OrbatNode`** — carried forward from the original JSX. Internal-only field, no wire-format exposure, but should be cleaned up in M8's tightening pass.

## Next batches

Per the plan in `docs/superpowers/plans/2026-04-18-typescript-migration.md`, the remaining M7 folders — `settings`, `logs`, `specializations`, `squads`, `questionnaires`, `tasks`, `registration`, `events`, `members` — will land in follow-up PRs sized to match reviewer capacity. The `members/` folder (24 files) is the largest and will likely be its own PR.