### PR TITLE
refactor(ui): migrate tasks and registration folders to TypeScript (M7 Batch 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ e2e/.auth/
 e2e/test-results/
 e2e/playwright-report/
 e2e/blob-report/
+
+# Git worktrees
+.worktrees/

--- a/imports/api/types/misc.ts
+++ b/imports/api/types/misc.ts
@@ -3,7 +3,9 @@ import type { ColoredEntity } from './shared';
 export type Medal = ColoredEntity;
 export type EventType = ColoredEntity;
 export type TaskStatus = ColoredEntity;
-export type DiscoveryType = ColoredEntity;
+export interface DiscoveryType extends ColoredEntity {
+  hasTextInput?: boolean;
+}
 export type Position = ColoredEntity;
 
 export interface Specialization extends ColoredEntity {
@@ -18,9 +20,12 @@ export interface Registration {
   name: string;
   id: number;
   age: number;
-  discoveryType?: string;
+  discoveryType?: string | null;
+  discoveryTypeDetails?: string | null;
+  steamProfileLink?: string | null;
+  discordTag?: string | null;
   rulesReadAndAccepted: boolean;
-  description?: string;
+  description?: string | null;
 }
 
 export interface ProfilePicture {

--- a/imports/api/types/task.ts
+++ b/imports/api/types/task.ts
@@ -17,6 +17,7 @@ export interface Task {
   link?: string;
   description?: string;
   parent?: string;
+  completedBy?: MemberId[];
   createdAt?: Date;
   comments?: TaskComment[];
 }

--- a/imports/ui/registration/Registration.tsx
+++ b/imports/ui/registration/Registration.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import RegistrationsCollection from '../../api/collections/registrations.collection';
 import type { Registration as RegistrationDoc } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
-import type { TourElementRef } from '../tour/TourContext';
 import { useTourRef } from '../tour/TourContext';
 import Section from '../section/Section';
 import getRegistrationColumns from './registration.columns';
@@ -14,7 +13,7 @@ export default function Registration() {
   const filterFactory = useCallback((string: string) => ({ name: { $regex: string, $options: 'i' } }), []);
 
   return (
-    <div ref={sectionRef as unknown as React.RefObject<HTMLDivElement>}>
+    <div ref={sectionRef as React.RefObject<HTMLDivElement>}>
       <Section<RegistrationDoc>
         title={t('registrations.title')}
         collectionName="registrations"

--- a/imports/ui/registration/Registration.tsx
+++ b/imports/ui/registration/Registration.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react';
 import RegistrationsCollection from '../../api/collections/registrations.collection';
+import type { Registration as RegistrationDoc } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
+import type { TourElementRef } from '../tour/TourContext';
 import { useTourRef } from '../tour/TourContext';
 import Section from '../section/Section';
 import getRegistrationColumns from './registration.columns';
@@ -9,11 +11,11 @@ import RegistrationForm from './RegistrationForm';
 export default function Registration() {
   const { t } = useTranslation();
   const sectionRef = useTourRef('registrations-section');
-  const filterFactory = useCallback(string => ({ name: { $regex: string, $options: 'i' } }), []);
+  const filterFactory = useCallback((string: string) => ({ name: { $regex: string, $options: 'i' } }), []);
 
   return (
-    <div ref={sectionRef}>
-      <Section
+    <div ref={sectionRef as unknown as React.RefObject<HTMLDivElement>}>
+      <Section<RegistrationDoc>
         title={t('registrations.title')}
         collectionName="registrations"
         Collection={RegistrationsCollection}

--- a/imports/ui/registration/RegistrationExtra.tsx
+++ b/imports/ui/registration/RegistrationExtra.tsx
@@ -2,6 +2,7 @@ import { App, Button, Form, Input, Modal, Space } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useEffect, useState } from 'react';
 import type { Registration } from '../../api/types';
+import type { Member } from '../../api/types/member';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
 interface ConfirmModalProps {
@@ -85,7 +86,7 @@ export default function RegistrationExtra({ record }: RegistrationExtraProps) {
   const [createdAlready, setCreatedAlready] = useState(true);
 
   useEffect(() => {
-    Meteor.callAsync('members.findOne', { 'profile.registrationId': record._id }, { fields: { service: 0 } }).then(res => {
+    Meteor.callAsync('members.findOne', { 'profile.registrationId': record._id }, { fields: { service: 0 } }).then((res: Member | undefined) => {
       if (res) setCreatedAlready(true);
       else setCreatedAlready(false);
     });

--- a/imports/ui/registration/RegistrationExtra.tsx
+++ b/imports/ui/registration/RegistrationExtra.tsx
@@ -1,10 +1,16 @@
 import { App, Button, Form, Input, Modal, Space } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
+import type { Registration } from '../../api/types';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
-const ConfirmModal = ({ open, setOpen, record }) => {
+interface ConfirmModalProps {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  record: Registration;
+}
+
+const ConfirmModal = ({ open, setOpen, record }: ConfirmModalProps) => {
   const { t } = useTranslation();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
@@ -34,9 +40,10 @@ const ConfirmModal = ({ open, setOpen, record }) => {
       message.success(t('registrations.memberCreated'));
       setOpen(false);
     } catch (error) {
+      const err = error as Meteor.Error;
       notification.error({
-        message: error.error,
-        description: error.message,
+        message: err.error as string,
+        description: err.message,
       });
     } finally {
       setLoading(false);
@@ -66,13 +73,12 @@ const ConfirmModal = ({ open, setOpen, record }) => {
     </Modal>
   );
 };
-ConfirmModal.propTypes = {
-  open: PropTypes.bool,
-  setOpen: PropTypes.func,
-  record: PropTypes.object,
-};
 
-export default function RegistrationExtra({ record }) {
+interface RegistrationExtraProps {
+  record: Registration;
+}
+
+export default function RegistrationExtra({ record }: RegistrationExtraProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -94,6 +100,3 @@ export default function RegistrationExtra({ record }) {
     </Space>
   );
 }
-RegistrationExtra.propTypes = {
-  record: PropTypes.object,
-};

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -1,32 +1,54 @@
 import { Alert, App, Button, Col, Form, Input, InputNumber, Row, Switch, Tooltip } from 'antd';
+import type { FormInstance } from 'antd';
+import type { ValidateStatus } from 'antd/es/form/FormItem';
 import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
 import { useFind, useSubscribe } from 'meteor/react-meteor-data';
-import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import DiscoveryTypesCollection from '../../api/collections/discoveryTypes.collection';
+import type { Registration } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
+import type { DrawerContextValue } from '../app/types';
 import CollectionSelect from '../components/CollectionSelect';
 import DiscoveryTypeForm from './discovery-types/DiscoveryTypesForm';
 
-export default function RegistrationForm({ setOpen }) {
-  const [form] = Form.useForm();
-  const drawer = useContext(DrawerContext);
+interface RegistrationFormValues {
+  name: string;
+  id: number | null;
+  age: number | null;
+  discoveryType: string | null;
+  discoveryTypeDetails?: string;
+  steamProfileLink?: string;
+  discordTag?: string;
+  rulesReadAndAccepted: boolean;
+  description?: string;
+}
+
+interface RegistrationFormProps {
+  setOpen: (open: boolean) => void;
+  form?: FormInstance;
+}
+
+export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [form] = Form.useForm<any>();
+  const drawer = useContext(DrawerContext) as DrawerContextValue;
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [disableSubmit, setDisableSubmit] = useState(false);
-  const [nameError, setNameError] = useState(undefined);
-  const [idError, setIdError] = useState(undefined);
+  const [nameError, setNameError] = useState<ValidateStatus | undefined>(undefined);
+  const [idError, setIdError] = useState<ValidateStatus | undefined>(undefined);
 
-  const model = useMemo(() => {
+  const model = useMemo((): Registration | Record<string, never> => {
     if (!Meteor.user()) return {};
-    return drawer.drawerModel || {};
+    return (drawer.drawerModel as unknown as Registration) || {};
   }, [drawer.drawerModel]);
 
   useEffect(() => {
     if (Object.keys(model).length > 0) {
-      form.setFieldsValue(model);
+      form.setFieldsValue(model as unknown as RegistrationFormValues);
     } else {
       form.setFieldsValue({
         name: '',
@@ -44,7 +66,7 @@ export default function RegistrationForm({ setOpen }) {
   const validateName = useCallback(() => {
     const value = form.getFieldValue('name');
     setNameError('validating');
-    Meteor.callAsync('registrations.validateName', value, model?._id)
+    Meteor.callAsync('registrations.validateName', value, (model as Registration)?._id)
       .then(result => {
         setNameError(result ? 'success' : 'error');
         setDisableSubmit(!result);
@@ -52,12 +74,12 @@ export default function RegistrationForm({ setOpen }) {
       .catch(() => {
         setNameError('warning');
       });
-  }, [form.getFieldValue, model?._id]);
+  }, [form.getFieldValue, (model as Registration)?._id]);
 
   const validateId = useCallback(() => {
     const value = form.getFieldValue('id');
     setIdError('validating');
-    Meteor.callAsync('registrations.validateId', value, model?._id)
+    Meteor.callAsync('registrations.validateId', value, (model as Registration)?._id)
       .then(result => {
         setIdError(result ? 'success' : 'error');
         setDisableSubmit(!result);
@@ -65,7 +87,7 @@ export default function RegistrationForm({ setOpen }) {
       .catch(() => {
         setIdError('warning');
       });
-  }, [form.getFieldValue, model?._id]);
+  }, [form.getFieldValue, (model as Registration)?._id]);
 
   useSubscribe('discoveryTypes', {}, {});
   const discoveryTypes = useFind(() => DiscoveryTypesCollection.find({}), []);
@@ -81,32 +103,33 @@ export default function RegistrationForm({ setOpen }) {
   }, [form, discoveryTypes]);
 
   const handleSubmit = useCallback(
-    values => {
+    (values: RegistrationFormValues) => {
       setLoading(true);
       const { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description } = values;
       const args = [
-        ...(model?._id ? [model._id] : []),
+        ...((model as Registration)?._id ? [(model as Registration)._id] : []),
         { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description },
       ];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'registrations.update' : 'registrations.insert', ...args)
+      Meteor.callAsync(Meteor.user() && (model as Registration)?._id ? 'registrations.update' : 'registrations.insert', ...args)
         .then(() => {
           setOpen(false);
           form.resetFields();
           message.success(t('messages.registrationSuccessful'));
         })
         .catch(error => {
+          const err = error as Meteor.Error;
           notification.error({
-            message: error.error,
-            description: error.message,
+            message: err.error as string,
+            description: err.message,
           });
         })
         .finally(() => setLoading(false));
     },
-    [setOpen, form, model, message, notification]
+    [setOpen, form, model, message, notification],
   );
 
   const handleValuesChange = useCallback(
-    (changedValues, values) => {
+    (changedValues: Partial<RegistrationFormValues>, values?: Partial<RegistrationFormValues>) => {
       if ('name' in (values ?? {})) {
         validateName();
       }
@@ -114,17 +137,17 @@ export default function RegistrationForm({ setOpen }) {
         validateId();
       }
       if ('rulesReadAndAccepted' in (changedValues ?? {}) && 'rulesReadAndAccepted' in (values ?? {})) {
-        setDisableSubmit(!values.rulesReadAndAccepted);
+        setDisableSubmit(!values?.rulesReadAndAccepted);
       }
       if ('discoveryType' in (changedValues ?? {})) {
         handleDiscoveryTypeChange();
       }
     },
-    [validateId, validateName, handleDiscoveryTypeChange]
+    [validateId, validateName, handleDiscoveryTypeChange],
   );
 
   useEffect(() => {
-    handleValuesChange(model ?? {});
+    handleValuesChange(model as unknown as Partial<RegistrationFormValues>);
   }, [model, handleValuesChange]);
 
   return (
@@ -168,13 +191,13 @@ export default function RegistrationForm({ setOpen }) {
         <InputNumber min={16} step={1} placeholder={t('forms.placeholders.enterAge')} />
       </Form.Item>
       <CollectionSelect
-        defaultValue={model?.discoveryType}
+        defaultValue={(model as Registration)?.discoveryType ?? undefined}
         name="discoveryType"
         subscription="discoveryTypes"
         label={t('forms.labels.discoveryType')}
         rules={[{ required: false, type: 'string' }]}
         placeholder={t('forms.placeholders.selectDiscoveryType')}
-        collection={DiscoveryTypesCollection}
+        collection={DiscoveryTypesCollection as unknown as Mongo.Collection<{ _id?: string; name?: string; color?: string; [key: string]: unknown }>}
         FormComponent={DiscoveryTypeForm}
         onChange={handleDiscoveryTypeChange}
       />
@@ -214,6 +237,3 @@ export default function RegistrationForm({ setOpen }) {
     </Form>
   );
 }
-RegistrationForm.propTypes = {
-  setOpen: PropTypes.func,
-};

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -144,7 +144,7 @@ export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
   );
 
   useEffect(() => {
-    handleValuesChange(model as unknown as Partial<RegistrationFormValues>, model as unknown as RegistrationFormValues);
+    handleValuesChange(model as unknown as Partial<RegistrationFormValues>, {} as RegistrationFormValues);
   }, [model, handleValuesChange]);
 
   return (

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -1,5 +1,4 @@
 import { Alert, App, Button, Col, Form, Input, InputNumber, Row, Switch, Tooltip } from 'antd';
-import type { FormInstance } from 'antd';
 import type { ValidateStatus } from 'antd/es/form/FormItem';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
@@ -27,12 +26,10 @@ interface RegistrationFormValues {
 
 interface RegistrationFormProps {
   setOpen: (open: boolean) => void;
-  form?: FormInstance;
 }
 
 export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [form] = Form.useForm<any>();
+  const [form] = Form.useForm<RegistrationFormValues>();
   const drawer = useContext(DrawerContext) as DrawerContextValue;
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
@@ -67,7 +64,7 @@ export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
     const value = form.getFieldValue('name');
     setNameError('validating');
     Meteor.callAsync('registrations.validateName', value, (model as Registration)?._id)
-      .then(result => {
+      .then((result: boolean) => {
         setNameError(result ? 'success' : 'error');
         setDisableSubmit(!result);
       })
@@ -80,7 +77,7 @@ export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
     const value = form.getFieldValue('id');
     setIdError('validating');
     Meteor.callAsync('registrations.validateId', value, (model as Registration)?._id)
-      .then(result => {
+      .then((result: boolean) => {
         setIdError(result ? 'success' : 'error');
         setDisableSubmit(!result);
       })
@@ -125,21 +122,21 @@ export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
         })
         .finally(() => setLoading(false));
     },
-    [setOpen, form, model, message, notification],
+    [setOpen, form, model, message, notification, t],
   );
 
   const handleValuesChange = useCallback(
-    (changedValues: Partial<RegistrationFormValues>, values?: Partial<RegistrationFormValues>) => {
-      if ('name' in (values ?? {})) {
+    (changedValues: Partial<RegistrationFormValues>, values: RegistrationFormValues) => {
+      if ('name' in values) {
         validateName();
       }
-      if ('id' in (values ?? {})) {
+      if ('id' in values) {
         validateId();
       }
-      if ('rulesReadAndAccepted' in (changedValues ?? {}) && 'rulesReadAndAccepted' in (values ?? {})) {
-        setDisableSubmit(!values?.rulesReadAndAccepted);
+      if ('rulesReadAndAccepted' in changedValues && 'rulesReadAndAccepted' in values) {
+        setDisableSubmit(!values.rulesReadAndAccepted);
       }
-      if ('discoveryType' in (changedValues ?? {})) {
+      if ('discoveryType' in changedValues) {
         handleDiscoveryTypeChange();
       }
     },
@@ -147,7 +144,7 @@ export default function RegistrationForm({ setOpen }: RegistrationFormProps) {
   );
 
   useEffect(() => {
-    handleValuesChange(model as unknown as Partial<RegistrationFormValues>);
+    handleValuesChange(model as unknown as Partial<RegistrationFormValues>, model as unknown as RegistrationFormValues);
   }, [model, handleValuesChange]);
 
   return (

--- a/imports/ui/registration/RegistrationModal.tsx
+++ b/imports/ui/registration/RegistrationModal.tsx
@@ -1,10 +1,14 @@
 import { Form, Modal } from 'antd';
-import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
-import RegistrationForm from './RegistrationForm';
 import { useTranslation } from '/imports/i18n/LanguageContext';
+import RegistrationForm from './RegistrationForm';
 
-export default function RegistrationModal({ open, setOpen }) {
+interface RegistrationModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export default function RegistrationModal({ open, setOpen }: RegistrationModalProps) {
   const [form] = Form.useForm();
   const { t } = useTranslation();
 
@@ -19,7 +23,3 @@ export default function RegistrationModal({ open, setOpen }) {
     </Modal>
   );
 }
-RegistrationModal.propTypes = {
-  open: PropTypes.bool,
-  setOpen: PropTypes.func,
-};

--- a/imports/ui/registration/RegistrationModal.tsx
+++ b/imports/ui/registration/RegistrationModal.tsx
@@ -1,4 +1,4 @@
-import { Form, Modal } from 'antd';
+import { Modal } from 'antd';
 import React, { useCallback } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import RegistrationForm from './RegistrationForm';
@@ -9,17 +9,15 @@ interface RegistrationModalProps {
 }
 
 export default function RegistrationModal({ open, setOpen }: RegistrationModalProps) {
-  const [form] = Form.useForm();
   const { t } = useTranslation();
 
   const handleClose = useCallback(() => {
     setOpen(false);
-    form.resetFields();
-  }, [setOpen, form.resetFields]);
+  }, [setOpen]);
 
   return (
     <Modal title={t('modals.registration')} open={open} onCancel={handleClose} footer={null} centered destroyOnHidden>
-      <RegistrationForm form={form} setOpen={setOpen} />
+      <RegistrationForm setOpen={setOpen} />
     </Modal>
   );
 }

--- a/imports/ui/registration/registration.columns.tsx
+++ b/imports/ui/registration/registration.columns.tsx
@@ -1,12 +1,23 @@
+import type { ColumnsType } from 'antd/es/table';
 import React from 'react';
+import type { Registration } from '../../api/types';
+import type { LanguageContextValue } from '../../i18n/LanguageContext';
+import type { SectionPermissions } from '../section/types';
 import TableActions from '../table/body/actions/TableActions';
 import DiscoveryTypeTag from './discovery-types/DiscoveryTypeTag';
 import RegistrationExtra from './RegistrationExtra';
 
-export default function getRegistrationColumns(handleEdit, handleDelete, permissions = {}, t = k => k) {
+type TFn = LanguageContextValue['t'];
+
+export default function getRegistrationColumns(
+  handleEdit: (e: React.MouseEvent<HTMLElement>, record: Registration) => void,
+  handleDelete: (e: React.MouseEvent<HTMLElement>, record: Registration) => void,
+  permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
+  t: TFn = k => k,
+): ColumnsType<Registration> {
   const { canUpdate = true, canDelete = true } = permissions;
 
-  const columns = [
+  const columns: ColumnsType<Registration> = [
     {
       title: t('common.name'),
       dataIndex: 'name',
@@ -29,15 +40,22 @@ export default function getRegistrationColumns(handleEdit, handleDelete, permiss
       title: t('columns.discoveryType'),
       dataIndex: 'discoveryType',
       key: 'discoveryType',
-      sorter: (a, b) => a.discoveryType.localeCompare(b.discoveryType),
-      render: discoveryType => <DiscoveryTypeTag discoveryTypeId={discoveryType} />,
+      sorter: (a, b) => (a.discoveryType ?? '').localeCompare(b.discoveryType ?? ''),
+      render: (discoveryType: string) => <DiscoveryTypeTag discoveryTypeId={discoveryType} />,
     },
     {
       title: t('columns.steamProfileLink'),
       dataIndex: 'steamProfileLink',
       key: 'steamProfileLink',
       ellipsis: true,
-      render: link => (link ? <a href={link} target="_blank" rel="noopener noreferrer">{link}</a> : '-'),
+      render: (link: string | null | undefined) =>
+        link ? (
+          <a href={link} target="_blank" rel="noopener noreferrer">
+            {link}
+          </a>
+        ) : (
+          '-'
+        ),
     },
     {
       title: t('columns.discordTag'),
@@ -50,7 +68,7 @@ export default function getRegistrationColumns(handleEdit, handleDelete, permiss
       dataIndex: 'description',
       key: 'description',
       ellipsis: true,
-      sorter: (a, b) => a.description.localeCompare(b.description),
+      sorter: (a, b) => (a.description ?? '').localeCompare(b.description ?? ''),
     },
   ];
 
@@ -59,7 +77,7 @@ export default function getRegistrationColumns(handleEdit, handleDelete, permiss
       title: t('common.actions'),
       dataIndex: '_id',
       key: '_id',
-      render: (id, record) => (
+      render: (_id: string, record: Registration) => (
         <TableActions
           record={record}
           handleEdit={handleEdit}

--- a/imports/ui/tasks/KanbanBoard.tsx
+++ b/imports/ui/tasks/KanbanBoard.tsx
@@ -3,16 +3,29 @@ import { Badge, Button, Card, Col, Empty, Grid, Row, Typography } from 'antd';
 import dayjs from 'dayjs';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import type { Task } from '../../api/types/task';
 import { useTranslation } from '../../i18n/LanguageContext';
+import type { RowClickEvent } from '../section/types';
 import TaskStatusTag from './task-status/TaskStatusTag';
 import { Participants } from './task.columns';
 
-const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
+interface DropResult {
+  destination?: { droppableId: string; index: number } | null;
+  source: { droppableId: string; index: number };
+  draggableId: string;
+}
+
+interface KanbanBoardProps {
+  datasource?: Task[];
+  handleEdit: (e: RowClickEvent, record: Task) => void;
+  handleDelete: (e: RowClickEvent, record: Task) => void;
+}
+
+export default function KanbanBoard({ datasource, handleEdit, handleDelete }: KanbanBoardProps) {
   const { t } = useTranslation();
-  const onDragEnd = result => {
+  const onDragEnd = (result: DropResult) => {
     const { destination, source, draggableId } = result;
     if (!destination) return;
     if (destination.droppableId === source.droppableId && destination.index === source.index) return;
@@ -20,16 +33,15 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
     Meteor.callAsync('tasks.update', draggableId, { status: destination.droppableId });
   };
 
-  const options = useTracker(() => Meteor.user()?.profile?.taskFilter?.status || [], []);
+  const options = useTracker(() => (Meteor.user()?.profile?.taskFilter?.status as string[] | undefined) || [], []);
 
   const columns = useMemo(() => {
-    return (
-      datasource?.reduce((acc, task) => {
-        if (!acc[task.status]) acc[task.status] = [];
-        acc[task.status].push(task);
-        return acc;
-      }, {}) || {}
-    );
+    const result: Record<string, Task[]> = datasource?.reduce<Record<string, Task[]>>((acc, task) => {
+      if (!acc[task.status ?? '']) acc[task.status ?? ''] = [];
+      acc[task.status ?? ''].push(task);
+      return acc;
+    }, {}) ?? {};
+    return result;
   }, [datasource]);
 
   const breakpoints = Grid.useBreakpoint();
@@ -42,7 +54,7 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Row gutter={[16, 16]}>
-        {options.map(status => (
+        {options.map((status: string) => (
           <Col key={status} span={colSpan}>
             <Droppable droppableId={status}>
               {provided => (
@@ -50,7 +62,7 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
                   <Card title={<TaskStatusTag taskStatusId={status} />}>
                     {!columns[status]?.length && <Empty />}
                     {columns[status]?.map((task, index) => (
-                      <Draggable key={`${status}-${task._id}`} draggableId={task._id} index={index}>
+                      <Draggable key={`${status}-${task._id}`} draggableId={task._id ?? ''} index={index}>
                         {provided => (
                           <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
                             <Card
@@ -75,9 +87,11 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
                                 </pre>
                               )}
                               <Participants participants={task.participants} />
-                              {task.completedBy?.length > 0 && (
+                              {task.completedBy && task.completedBy.length > 0 && (
                                 <div style={{ marginTop: 4 }}>
-                                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>{t('tasks.completedBy')}{' '}</Typography.Text>
+                                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                    {t('tasks.completedBy')}{' '}
+                                  </Typography.Text>
                                   <Participants participants={task.completedBy} />
                                 </div>
                               )}
@@ -89,7 +103,7 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
                                     </Typography.Text>
                                   </Col>
                                 )}
-                                {task.comments?.length > 0 && (
+                                {task.comments && task.comments.length > 0 && (
                                   <Col>
                                     <Badge count={task.comments.length} size="small">
                                       <CommentOutlined style={{ fontSize: 16 }} />
@@ -112,11 +126,4 @@ const KanbanBoard = ({ datasource, handleEdit, handleDelete }) => {
       </Row>
     </DragDropContext>
   );
-};
-KanbanBoard.propTypes = {
-  datasource: PropTypes.array,
-  handleEdit: PropTypes.func,
-  handleDelete: PropTypes.func,
-};
-
-export default KanbanBoard;
+}

--- a/imports/ui/tasks/KanbanBoard.tsx
+++ b/imports/ui/tasks/KanbanBoard.tsx
@@ -37,10 +37,11 @@ export default function KanbanBoard({ datasource, handleEdit, handleDelete }: Ka
 
   const columns = useMemo(() => {
     const result: Record<string, Task[]> = datasource?.reduce<Record<string, Task[]>>((acc, task) => {
-      if (!acc[task.status ?? '']) acc[task.status ?? ''] = [];
-      acc[task.status ?? ''].push(task);
+      const key = task.status as string;
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(task);
       return acc;
-    }, {}) ?? {};
+    }, {}) || {};
     return result;
   }, [datasource]);
 

--- a/imports/ui/tasks/TaskFilter.tsx
+++ b/imports/ui/tasks/TaskFilter.tsx
@@ -1,23 +1,38 @@
 import { App, Form, Select } from 'antd';
+import { Mongo } from 'meteor/mongo';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useMemo } from 'react';
 import TaskStatusCollection from '../../api/collections/taskStatus.collection';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
+import type { DrawerContextValue } from '../app/types';
 import CollectionSelect from '../components/CollectionSelect';
 import FormFooter from '../components/FormFooter';
-import MembersSelect from '../members/MembersSelect';
+import MembersSelectJs from '../members/MembersSelect';
 import TaskStatusForm from './task-status/TaskStatusForm';
 
-const TaskFilter = ({ setOpen }) => {
+// MembersSelect is a JS component — cast to allow flexible prop passing from TSX
+const MembersSelect = MembersSelectJs as unknown as React.ComponentType<Record<string, unknown>>;
+
+interface TaskFilterModel {
+  type?: string;
+  status?: string[];
+  participants?: string[];
+}
+
+interface TaskFilterProps {
+  setOpen: (open: boolean) => void;
+}
+
+export default function TaskFilter({ setOpen }: TaskFilterProps) {
   const { t } = useTranslation();
-  const { drawerModel: model } = useContext(DrawerContext);
+  const { drawerModel } = useContext(DrawerContext) as DrawerContextValue;
+  const model = drawerModel as unknown as TaskFilterModel;
   const { notification } = App.useApp();
   const [form] = Form.useForm();
 
   const handleFinish = useCallback(
-    async values => {
+    async (values: TaskFilterModel) => {
       Meteor.callAsync('members.saveTaskFilter', values)
         .then(() => {
           setOpen(false);
@@ -52,7 +67,7 @@ const TaskFilter = ({ setOpen }) => {
         rules={[{ required: false, type: 'array' }]}
         placeholder={t('common.status')}
         FormComponent={TaskStatusForm}
-        collection={TaskStatusCollection}
+        collection={TaskStatusCollection as unknown as Mongo.Collection<{ _id?: string; name?: string; color?: string; [key: string]: unknown }>}
         mode="multiple"
         subscription="taskStatus"
       />
@@ -60,16 +75,10 @@ const TaskFilter = ({ setOpen }) => {
         name="participants"
         label={t('tasks.participants')}
         rules={[{ required: false, type: 'array' }]}
-        placeholder={t('forms.placeholders.selectParticipants')}
         defaultValue={model?.participants}
         multiple
       />
       <FormFooter setOpen={setOpen} />
     </Form>
   );
-};
-TaskFilter.propTypes = {
-  setOpen: PropTypes.func,
-};
-
-export default TaskFilter;
+}

--- a/imports/ui/tasks/TaskFilter.tsx
+++ b/imports/ui/tasks/TaskFilter.tsx
@@ -10,15 +10,10 @@ import CollectionSelect from '../components/CollectionSelect';
 import FormFooter from '../components/FormFooter';
 import MembersSelectJs from '../members/MembersSelect';
 import TaskStatusForm from './task-status/TaskStatusForm';
+import type { TaskFilterModel } from './types';
 
 // MembersSelect is a JS component — cast to allow flexible prop passing from TSX
 const MembersSelect = MembersSelectJs as unknown as React.ComponentType<Record<string, unknown>>;
-
-interface TaskFilterModel {
-  type?: string;
-  status?: string[];
-  participants?: string[];
-}
 
 interface TaskFilterProps {
   setOpen: (open: boolean) => void;

--- a/imports/ui/tasks/TaskForm.tsx
+++ b/imports/ui/tasks/TaskForm.tsx
@@ -2,19 +2,34 @@ import { CommentOutlined, SendOutlined } from '@ant-design/icons';
 import { App, Button, Divider, Form, Input, List, Select, Typography } from 'antd';
 import dayjs from 'dayjs';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
+import { Mongo } from 'meteor/mongo';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import TasksCollection from '../../api/collections/tasks.collection';
 import TaskStatusCollection from '../../api/collections/taskStatus.collection';
+import type { Task, TaskComment } from '../../api/types/task';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
+import type { DrawerContextValue } from '../app/types';
 import CollectionSelect from '../components/CollectionSelect';
 import FormFooter from '../components/FormFooter';
-import MembersSelect from '../members/MembersSelect';
+import MembersSelectJs from '../members/MembersSelect';
 import TaskStatusForm from './task-status/TaskStatusForm';
 
-const TaskForm = ({ setOpen }) => {
-  const { drawerModel: model } = useContext(DrawerContext);
+// MembersSelect is a JS component — cast to allow flexible prop passing from TSX
+const MembersSelect = MembersSelectJs as unknown as React.ComponentType<Record<string, unknown>>;
+
+interface MemberOption {
+  value: string;
+  label: string;
+}
+
+interface TaskFormProps {
+  setOpen: (open: boolean) => void;
+}
+
+export default function TaskForm({ setOpen }: TaskFormProps) {
+  const { drawerModel } = useContext(DrawerContext) as DrawerContextValue;
+  const model = drawerModel as unknown as Task;
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const { isUpdate, endpoint } = useMemo(
@@ -23,26 +38,27 @@ const TaskForm = ({ setOpen }) => {
   );
 
   const handleFinish = useCallback(
-    async values => {
+    async (values: Partial<Task>) => {
       try {
         const args = isUpdate ? [model._id, values] : [values];
         await Meteor.callAsync(endpoint, ...args);
         setOpen(false);
         message.success(isUpdate ? t('messages.taskUpdated') : t('messages.taskCreated'));
       } catch (error) {
+        const err = error as Meteor.Error;
         notification.error({
-          message: error.error,
-          description: error.message,
+          message: err.error as string,
+          description: err.message,
         });
       }
     },
     [setOpen, endpoint, model?._id, isUpdate, message, notification, t]
   );
 
-  const [participantOptions, setParticipantOptions] = useState([]);
+  const [participantOptions, setParticipantOptions] = useState<MemberOption[]>([]);
   useEffect(() => {
     Meteor.callAsync('members.options')
-      .then(res => setParticipantOptions(res))
+      .then((res: MemberOption[]) => setParticipantOptions(res))
       .catch(() => {});
   }, []);
 
@@ -50,12 +66,14 @@ const TaskForm = ({ setOpen }) => {
 
   // Comments state
   const [commentText, setCommentText] = useState('');
-  const [comments, setComments] = useState(model?.comments || []);
+  const [comments, setComments] = useState<TaskComment[]>(model?.comments || []);
   const [commentLoading, setCommentLoading] = useState(false);
 
   const memberNames = useMemo(() => {
-    const map = {};
-    participantOptions.forEach(o => { map[o.value] = o.label; });
+    const map: Record<string, string> = {};
+    participantOptions.forEach(o => {
+      map[o.value] = o.label;
+    });
     return map;
   }, [participantOptions]);
 
@@ -64,11 +82,12 @@ const TaskForm = ({ setOpen }) => {
     setCommentLoading(true);
     try {
       await Meteor.callAsync('tasks.addComment', model._id, commentText.trim());
-      setComments(prev => [...prev, { userId: Meteor.userId(), text: commentText.trim(), createdAt: new Date() }]);
+      setComments(prev => [...prev, { userId: Meteor.userId() as string, text: commentText.trim(), createdAt: new Date() }]);
       setCommentText('');
       message.success(t('tasks.commentAdded'));
     } catch (error) {
-      notification.error({ message: error.error, description: error.message });
+      const err = error as Meteor.Error;
+      notification.error({ message: err.error as string, description: err.message });
     }
     setCommentLoading(false);
   }, [commentText, model?._id, message, notification, t]);
@@ -84,7 +103,7 @@ const TaskForm = ({ setOpen }) => {
         label={t('forms.labels.taskStatus')}
         placeholder={t('common.selectTaskStatus')}
         rules={[{ required: true, type: 'string' }]}
-        collection={TaskStatusCollection}
+        collection={TaskStatusCollection as unknown as Mongo.Collection<{ _id?: string; name?: string; color?: string; [key: string]: unknown }>}
         subscription="taskStatus"
         FormComponent={TaskStatusForm}
       />
@@ -115,7 +134,7 @@ const TaskForm = ({ setOpen }) => {
         label={t('forms.labels.parentTask')}
         placeholder={t('common.selectTask')}
         rules={[{ required: false, type: 'string' }]}
-        collection={TasksCollection}
+        collection={TasksCollection as unknown as Mongo.Collection<{ _id?: string; name?: string; color?: string; [key: string]: unknown }>}
         subscription="tasks"
         FormComponent={TaskForm}
       />
@@ -166,9 +185,4 @@ const TaskForm = ({ setOpen }) => {
       )}
     </Form>
   );
-};
-TaskForm.propTypes = {
-  setOpen: PropTypes.func,
-};
-
-export default TaskForm;
+}

--- a/imports/ui/tasks/Tasks.tsx
+++ b/imports/ui/tasks/Tasks.tsx
@@ -15,18 +15,13 @@ import KanbanBoard from './KanbanBoard';
 import { getTaskColumns } from './task.columns';
 import TaskFilter from './TaskFilter';
 import TaskForm from './TaskForm';
+import type { TaskFilterModel } from './types';
 
 const empty = <></>;
 
-interface TaskFilter {
-  type?: string;
-  status?: string[];
-  participants?: string[];
-}
-
 export default function Tasks() {
   const tasksRef = useTourRef('tasks-section');
-  const filter = useTracker(() => Meteor.user()?.profile?.taskFilter as TaskFilter | undefined, []);
+  const filter = useTracker(() => Meteor.user()?.profile?.taskFilter as TaskFilterModel | undefined, []);
   const drawer = useContext(DrawerContext) as DrawerContextValue;
   const { t } = useTranslation();
 

--- a/imports/ui/tasks/Tasks.tsx
+++ b/imports/ui/tasks/Tasks.tsx
@@ -1,11 +1,15 @@
 import { Button } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
+import { Mongo } from 'meteor/mongo';
 import React, { useCallback, useContext } from 'react';
 import TasksCollection from '../../api/collections/tasks.collection';
+import type { Task } from '../../api/types/task';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
+import type { DrawerContextValue } from '../app/types';
 import Section from '../section/Section';
+import type { TourElementRef } from '../tour/TourContext';
 import { useTourRef } from '../tour/TourContext';
 import KanbanBoard from './KanbanBoard';
 import { getTaskColumns } from './task.columns';
@@ -14,17 +18,23 @@ import TaskForm from './TaskForm';
 
 const empty = <></>;
 
+interface TaskFilter {
+  type?: string;
+  status?: string[];
+  participants?: string[];
+}
+
 export default function Tasks() {
   const tasksRef = useTourRef('tasks-section');
-  const filter = useTracker(() => Meteor.user()?.profile?.taskFilter, []);
-  const drawer = useContext(DrawerContext);
+  const filter = useTracker(() => Meteor.user()?.profile?.taskFilter as TaskFilter | undefined, []);
+  const drawer = useContext(DrawerContext) as DrawerContextValue;
   const { t } = useTranslation();
 
   const openFilterDrawer = useCallback(
-    e => {
+    (e: React.MouseEvent) => {
       e.preventDefault();
       drawer.setDrawerTitle(t('tasks.filterTasks'));
-      drawer.setDrawerModel(filter);
+      drawer.setDrawerModel(filter as unknown as Record<string, unknown>);
       drawer.setDrawerComponent(<TaskFilter setOpen={drawer.setDrawerOpen} />);
       drawer.setDrawerExtra(empty);
       drawer.setDrawerOpen(true);
@@ -33,20 +43,20 @@ export default function Tasks() {
   );
 
   const filterFactory = useCallback(
-    string => {
-      const newFilter = {
+    (string: string): Mongo.Selector<Task> => {
+      const newFilter: Mongo.Selector<Task> = {
         status: { $in: filter?.status || [] },
       };
-      if (string) newFilter.name = { $regex: string, $options: 'i' };
-      if (filter?.participants?.length) newFilter.participants = { $in: filter.participants };
+      if (string) (newFilter as Record<string, unknown>).name = { $regex: string, $options: 'i' };
+      if (filter?.participants?.length) (newFilter as Record<string, unknown>).participants = { $in: filter.participants };
       return newFilter;
     },
     [filter]
   );
 
   return (
-    <div ref={tasksRef}>
-      <Section
+    <div ref={tasksRef as React.RefObject<HTMLDivElement>}>
+      <Section<Task>
         title={t('tasks.title')}
         collectionName="tasks"
         Collection={TasksCollection}

--- a/imports/ui/tasks/Tasks.tsx
+++ b/imports/ui/tasks/Tasks.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
 import type { DrawerContextValue } from '../app/types';
 import Section from '../section/Section';
-import type { TourElementRef } from '../tour/TourContext';
 import { useTourRef } from '../tour/TourContext';
 import KanbanBoard from './KanbanBoard';
 import { getTaskColumns } from './task.columns';

--- a/imports/ui/tasks/task.columns.tsx
+++ b/imports/ui/tasks/task.columns.tsx
@@ -19,10 +19,7 @@ export function Participants({ participants }: ParticipantsProps) {
   const [value, setValue] = useState<string | string[]>('loading...');
 
   useEffect(() => {
-    if (!participants?.length) {
-      setValue('-');
-      return;
-    }
+    if (!participants?.length) setValue('-');
     const filter = { _id: { $in: participants } };
     const options = { fields: { 'profile.name': 1, 'profile.id': 1, 'profile.rankId': 1 } };
     Meteor.callAsync('members.participantNames', filter, options)

--- a/imports/ui/tasks/task.columns.tsx
+++ b/imports/ui/tasks/task.columns.tsx
@@ -16,14 +16,14 @@ interface ParticipantsProps {
 }
 
 export function Participants({ participants }: ParticipantsProps) {
-  const [value, setValue] = useState<string | string[]>('loading...');
+  const [value, setValue] = useState<string>('loading...');
 
   useEffect(() => {
     if (!participants?.length) setValue('-');
     const filter = { _id: { $in: participants } };
     const options = { fields: { 'profile.name': 1, 'profile.id': 1, 'profile.rankId': 1 } };
     Meteor.callAsync('members.participantNames', filter, options)
-      .then((res: string[]) => {
+      .then((res: string) => {
         if (!res?.length) setValue('-');
         else setValue(res);
       })

--- a/imports/ui/tasks/task.columns.tsx
+++ b/imports/ui/tasks/task.columns.tsx
@@ -1,20 +1,32 @@
 import dayjs from 'dayjs';
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import type { ColumnsType } from 'antd/es/table';
 import TaskStatusCollection from '../../api/collections/taskStatus.collection';
+import type { Task } from '../../api/types/task';
+import type { LanguageContextValue } from '../../i18n/LanguageContext';
+import type { SectionPermissions } from '../section/types';
 import TableActions from '../table/body/actions/TableActions';
 import TaskStatusTag from './task-status/TaskStatusTag';
 
-export const Participants = ({ participants }) => {
-  const [value, setValue] = useState('loading...');
+type TFn = LanguageContextValue['t'];
+
+interface ParticipantsProps {
+  participants?: string[];
+}
+
+export function Participants({ participants }: ParticipantsProps) {
+  const [value, setValue] = useState<string | string[]>('loading...');
 
   useEffect(() => {
-    if (!participants?.length) setValue('-');
+    if (!participants?.length) {
+      setValue('-');
+      return;
+    }
     const filter = { _id: { $in: participants } };
     const options = { fields: { 'profile.name': 1, 'profile.id': 1, 'profile.rankId': 1 } };
     Meteor.callAsync('members.participantNames', filter, options)
-      .then(res => {
+      .then((res: string[]) => {
         if (!res?.length) setValue('-');
         else setValue(res);
       })
@@ -22,15 +34,17 @@ export const Participants = ({ participants }) => {
   }, [participants]);
 
   return <>{value}</>;
-};
-Participants.propTypes = {
-  participants: PropTypes.array,
-};
+}
 
-const getTaskColumns = (handleTaskEdit, handleTaskDelete, permissions = {}, t = k => k) => {
+export function getTaskColumns(
+  handleTaskEdit: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
+  handleTaskDelete: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
+  permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
+  t: TFn = k => k,
+): ColumnsType<Task> {
   const { canUpdate = true, canDelete = true } = permissions;
 
-  const columns = [
+  const columns: ColumnsType<Task> = [
     {
       title: t('common.name'),
       dataIndex: 'name',
@@ -57,7 +71,7 @@ const getTaskColumns = (handleTaskEdit, handleTaskDelete, permissions = {}, t = 
       sorter: (a, b) => {
         const aStatus = a.status ? TaskStatusCollection.findOne({ _id: a.status })?.name : a.status;
         const bStatus = b.status ? TaskStatusCollection.findOne({ _id: b.status })?.name : b.status;
-        return aStatus.localeCompare(bStatus);
+        return (aStatus ?? '').localeCompare(bStatus ?? '');
       },
       ellipsis: true,
       render: status => (status ? <TaskStatusTag taskStatusId={status} /> : '-'),
@@ -65,7 +79,7 @@ const getTaskColumns = (handleTaskEdit, handleTaskDelete, permissions = {}, t = 
     {
       title: t('tasks.createdAt'),
       dataIndex: 'createdAt',
-      sorter: (a, b) => new Date(a.createdAt || 0) - new Date(b.createdAt || 0),
+      sorter: (a, b) => new Date(a.createdAt || 0).valueOf() - new Date(b.createdAt || 0).valueOf(),
       render: createdAt => (createdAt ? dayjs(createdAt).format('YYYY-MM-DD') : '-'),
       ellipsis: true,
     },
@@ -82,7 +96,6 @@ const getTaskColumns = (handleTaskEdit, handleTaskDelete, permissions = {}, t = 
   }
 
   return columns;
-};
+}
 
-export { getTaskColumns };
 export default getTaskColumns;

--- a/imports/ui/tasks/types.ts
+++ b/imports/ui/tasks/types.ts
@@ -1,0 +1,7 @@
+import type { Task } from '/imports/api/types/task';
+
+export interface TaskFilterModel {
+  type?: string;
+  status?: string[];
+  participants?: Task['participants'];
+}


### PR DESCRIPTION
## Summary

Batch 4 of the M7 TypeScript migration converts the `tasks/` and `registration/` feature folders (10 components + 1 shared types file + small extensions to `imports/api/types/`).

**Migrated:**
- `imports/ui/tasks/`: KanbanBoard, TaskFilter, TaskForm, Tasks, task.columns
- `imports/ui/registration/`: Registration, RegistrationExtra, RegistrationForm, RegistrationModal, registration.columns

**Type extensions** (matching real UI/server usage that was previously undocumented):
- `Task.completedBy?: MemberId[]` — used by `TaskForm` and `task.columns`/`KanbanBoard`
- `DiscoveryType.hasTextInput?: boolean` — used by `RegistrationForm` and `DiscoveryTypesForm`
- `Registration` gained `discoveryTypeDetails`, `steamProfileLink`, `discordTag`, all `string | null`; `description` widened to nullable

**New shared types file:**
- `imports/ui/tasks/types.ts` — exports `TaskFilterModel`, replacing the same interface that was previously inlined in three places (Batch 3 `questionnaires/types.ts` pattern)

## Patterns established / preserved

- `Form.useForm<RegistrationFormValues>()` — typed form, dropped `<any>` workaround
- All `Meteor.callAsync` `.then` callbacks have explicit return-type annotations (wire-format accuracy)
- Drawer model double-cast: `drawer.drawerModel as unknown as ConcreteType` ↔ `setDrawerModel(x as unknown as Record<string, unknown>)`
- `App.useApp()` for `message`/`notification`, never the static antd singleton
- Runtime parity preserved: `Participants` useEffect, `KanbanBoard` columns reduce coercion, `RegistrationForm` initial-mount validator semantics — all match original JSX byte-for-byte

## Deferred to later batches (tracked)

- Export `CollectionDoc` from `CollectionSelect.tsx` to eliminate 4× inline `Mongo.Collection<{...}>` casts (will be needed in Batch 5 events/)
- Consolidate `MembersSelect` typed wrapper (currently cast via `as unknown as React.ComponentType<Record<string, unknown>>` in two files; will recur in events/ and members/ batches)
- Make `useTourRef` generic to drop the `as React.RefObject<HTMLDivElement>` casts (deferred follow-up tracked since Batch 1)
- Normalize `TFn` vs `TranslateFn` and absolute vs relative `i18n` imports (M8 consolidation)

## Test plan

- [ ] `npm test` — 168 tests pass
- [ ] `npx tsc --noEmit` — zero errors
- [ ] Tasks page: table view loads, kanban view loads with drag-and-drop reordering, task filter drawer opens/saves
- [ ] Task form: create + edit (name, status, participants, completedBy, priority, link, description, parent); add a comment in edit mode
- [ ] Registration page: table loads with all columns; sort by `name`/`id`/`age`/`discoveryType`/`description` does not crash on null values
- [ ] Registration form (anonymous): submit a new registration with rules acceptance, name/id blacklist enforcement working
- [ ] Registration form (authenticated edit): edit existing registration, all fields populate correctly
- [ ] Registration extra: "Create Member" button opens modal, creates member, button transitions to disabled state