### PR TITLE
feat(server): introduce mutation-pipeline wrapper + refactor crud.lib internally (#98)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,19 @@
+# Project Context
+
+Project-wide domain language and load-bearing decisions. ADRs go in `docs/adr/`. Per-area docs live in `docs/agents/`.
+
+## Domain terms
+
+### MutationWithAudit
+
+The single deep module (`server/mutation-pipeline.ts`) that owns the standard server-mutation lifecycle. Lifecycle stages, in order:
+
+1. **Authentication** — reject anonymous calls with `Meteor.Error(401, …)` unless the descriptor opts in via `allowAnonymous`.
+2. **Permission check** — `checkPermission(userId, module, op)` against the descriptor's `permissionModule`. An optional unconditional `fallbackFlag` (e.g. `canCreateEvents`) re-admits a denied call when set on the user's role.
+3. **Input shape validation** — the descriptor's `validate(args)` callback, where each method declares its own `validateString` / `validateObject` / `validateArrayOfStrings` shape checks.
+4. **Body invocation** — the unique mutation step the caller supplies as `(args) => Promise<TResult>`.
+5. **Audit log emission** — on success only. Standard shapes per op (`insert → { id, ...payload }`, `update → { id, changes }`, `remove → { id }`) are baked in; the descriptor can pass `audit: (args, result) => ({...})` to opt into a custom shape.
+
+On any pre-body failure (auth, permission, validation), the wrapper emits a `<collection>.<op>.denied` audit entry capturing `userId` (and the target `id` for `update`/`remove`) before throwing — closing the previous gap where permission denials produced no audit trail. Body errors propagate untouched: the wrapper does **not** normalize, wrap, or translate them. A body throwing `Meteor.Error('SomeCode', '...')` reaches the caller with `error.error === 'SomeCode'` intact.
+
+The wrapper is exposed as `runMutation(ctx, descriptor, args, body)` with an explicit `ctx` parameter (carrying `userId`), which lets unit tests invoke the lifecycle directly without `Meteor.callAsync`. Both call paths — `createCollectionMethods` (the CRUD factory in `server/crud.lib.ts`) and direct `runMutation` calls from custom methods that opt in — route through the same internal pipeline, so the lifecycle has exactly one implementation regardless of entry door.

--- a/server/crud.lib.ts
+++ b/server/crud.lib.ts
@@ -4,18 +4,19 @@ import {
   validateObject,
   validateString,
   validateArrayOfStrings,
-  checkPermission,
-  checkSpecialPermission,
   getPermissionModule,
   clearRoleCache,
 } from './main';
 import { createLog } from './apis/logs.server';
+import { runMutation } from './mutation-pipeline';
 import type { CrudCollectionMap, CrudCollectionName } from '/imports/api/types';
 
 const SPECIAL_PERMISSION_FALLBACK: Record<string, { create?: string; update?: string }> = {
   events: { create: 'canCreateEvents' },
   tasks: { create: 'canManageTasks', update: 'canManageTasks' },
 };
+
+const UNSAFE_COLLECTIONS: readonly string[] = ['registrations'];
 
 import AttendancesCollection from '../imports/api/collections/attendances.collection';
 import DiscoveryTypesCollection from '../imports/api/collections/discoveryTypes.collection';
@@ -109,153 +110,172 @@ function createCollectionMethods(collection: CrudCollectionName): void {
   try {
     if (Meteor.isServer) {
       const Collection = getCollection(collection);
-      const unsafeCollections: readonly string[] = ['registrations'];
       const permissionModule = getPermissionModule(collection);
+      const fallback = SPECIAL_PERMISSION_FALLBACK[collection];
+      const auditAllowed = collection !== 'logs';
 
       Meteor.methods({
         [`${collection}.read`]: async function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateObject(filter, false);
-          validateObject(options, false);
-
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'read');
-            if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-          }
-
-          return await Collection.find(filter, options).fetchAsync();
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'read',
+              permissionModule,
+              validate: ([f, o]) => {
+                validateObject(f, false);
+                validateObject(o, false);
+              },
+            },
+            [filter, options] as const,
+            async ([f, o]) => Collection.find(f, o).fetchAsync(),
+          );
         },
         [`${collection}.insert`]: async function (payload: Record<string, unknown> = {}) {
-          if (!this.userId && !unsafeCollections.includes(collection)) throw new Meteor.Error(401, 'Unauthorized');
-          validateObject(payload, false);
-
-          if (permissionModule && this.userId) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'create');
-            if (!hasPermission) {
-              const fallbackFlag = SPECIAL_PERMISSION_FALLBACK[collection]?.create;
-              const hasSpecial = fallbackFlag ? await checkSpecialPermission(this.userId, fallbackFlag) : false;
-              if (!hasSpecial) throw new Meteor.Error(403, 'Permission denied');
-            }
-          }
-
-          if (collection === 'tasks') {
-            payload.createdAt = new Date();
-          }
-          const id = await Collection.insertAsync(payload as unknown as CrudCollectionMap[typeof collection]);
-          if (collection !== 'logs') {
-            await createLog(`${collection}.created`, { id, ...payload });
-          }
-          return id;
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'create',
+              action: auditAllowed ? `${collection}.created` : undefined,
+              auditShape: 'insert',
+              permissionModule,
+              fallbackFlag: fallback?.create,
+              allowAnonymous: UNSAFE_COLLECTIONS.includes(collection),
+              validate: ([p]) => validateObject(p, false),
+            },
+            [payload] as const,
+            async ([p]) => {
+              if (collection === 'tasks') {
+                p.createdAt = new Date();
+              }
+              return Collection.insertAsync(p as unknown as CrudCollectionMap[typeof collection]);
+            },
+          );
         },
         [`${collection}.update`]: async function (id: string = '', data: Record<string, unknown> = {}) {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateString(id, false);
-          validateObject(data, false);
-
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'update');
-            if (!hasPermission) {
-              const fallbackFlag = SPECIAL_PERMISSION_FALLBACK[collection]?.update;
-              const hasSpecial = fallbackFlag ? await checkSpecialPermission(this.userId, fallbackFlag) : false;
-              if (!hasSpecial) throw new Meteor.Error(403, 'Permission denied');
-            }
-          }
-
-          const result = await Collection.updateAsync({ _id: id } as never, { $set: data } as never);
-          if (collection !== 'logs') {
-            await createLog(`${collection}.updated`, { id, changes: data });
-          }
-
-          if (collection === 'roles') {
-            clearRoleCache(id);
-          }
-
-          return result;
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'update',
+              action: auditAllowed ? `${collection}.updated` : undefined,
+              auditShape: 'update',
+              permissionModule,
+              fallbackFlag: fallback?.update,
+              validate: ([targetId, changes]) => {
+                validateString(targetId, false);
+                validateObject(changes, false);
+              },
+            },
+            [id, data] as const,
+            async ([targetId, changes]) => {
+              const result = await Collection.updateAsync({ _id: targetId } as never, { $set: changes } as never);
+              if (collection === 'roles') {
+                clearRoleCache(targetId);
+              }
+              return result;
+            },
+          );
         },
         [`${collection}.remove`]: async function (id: string = '') {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateString(id, false);
-
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'delete');
-            if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-          }
-
-          const doc = await Collection.findOneAsync(id);
-          if (!doc) throw new Meteor.Error(404, 'Document not found');
-          const result = await Collection.removeAsync({ _id: id } as never);
-          if (collection !== 'logs') {
-            await createLog(`${collection}.deleted`, { id });
-          }
-
-          if (collection === 'roles') {
-            clearRoleCache(id);
-          }
-
-          return result;
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'delete',
+              action: auditAllowed ? `${collection}.deleted` : undefined,
+              auditShape: 'remove',
+              permissionModule,
+              validate: ([targetId]) => validateString(targetId, false),
+            },
+            [id] as const,
+            async ([targetId]) => {
+              const doc = await Collection.findOneAsync(targetId);
+              if (!doc) throw new Meteor.Error(404, 'Document not found');
+              const result = await Collection.removeAsync({ _id: targetId } as never);
+              if (collection === 'roles') {
+                clearRoleCache(targetId);
+              }
+              return result;
+            },
+          );
         },
         [`${collection}.bulkRemove`]: async function (ids: string[] = []) {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateArrayOfStrings(ids, false);
-          if (ids.length === 0) throw new Meteor.Error(400, 'No ids provided');
-          if (ids.length > 100) throw new Meteor.Error(400, 'Maximum 100 items per bulk delete');
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'delete',
+              permissionModule,
+              validate: ([targetIds]) => {
+                validateArrayOfStrings(targetIds, false);
+                if (targetIds.length === 0) throw new Meteor.Error(400, 'No ids provided');
+                if (targetIds.length > 100) throw new Meteor.Error(400, 'Maximum 100 items per bulk delete');
+              },
+            },
+            [ids] as const,
+            async ([targetIds]) => {
+              let removed = 0;
+              const errors: string[] = [];
 
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'delete');
-            if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-          }
-
-          let removed = 0;
-          const errors: string[] = [];
-
-          for (const id of ids) {
-            try {
-              const doc = await Collection.findOneAsync(id);
-              if (!doc) {
-                errors.push(`Document ${id} not found`);
-                continue;
+              for (const id of targetIds) {
+                try {
+                  const doc = await Collection.findOneAsync(id);
+                  if (!doc) {
+                    errors.push(`Document ${id} not found`);
+                    continue;
+                  }
+                  await Collection.removeAsync({ _id: id } as never);
+                  if (auditAllowed) {
+                    await createLog(`${collection}.deleted`, { id });
+                  }
+                  if (collection === 'roles') {
+                    clearRoleCache(id);
+                  }
+                  removed++;
+                } catch (error) {
+                  errors.push(`Failed to delete ${id}: ${(error as Error).message}`);
+                }
               }
-              await Collection.removeAsync({ _id: id } as never);
-              if (collection !== 'logs') {
-                await createLog(`${collection}.deleted`, { id });
-              }
-              if (collection === 'roles') {
-                clearRoleCache(id);
-              }
-              removed++;
-            } catch (error) {
-              errors.push(`Failed to delete ${id}: ${(error as Error).message}`);
-            }
-          }
 
-          return { removed, errors };
+              return { removed, errors };
+            },
+          );
         },
         [`${collection}.count`]: async function (filter: Record<string, unknown> = {}) {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateObject(filter, false);
-
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'read');
-            if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-          }
-
-          return await Collection.countDocuments(filter);
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'read',
+              permissionModule,
+              validate: ([f]) => validateObject(f, false),
+            },
+            [filter] as const,
+            async ([f]) => Collection.countDocuments(f),
+          );
         },
         [`${collection}.options`]: async function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
-          if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-          validateObject(filter, false);
-          validateObject(options, false);
-
-          if (permissionModule) {
-            const hasPermission = await checkPermission(this.userId, permissionModule, 'read');
-            if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-          }
-
-          return await Collection.find(filter, options).mapAsync((item: any) => {
-            const profile = item.profile as { name?: string } | undefined;
-            const name = profile?.name || (item.name as string | undefined);
-            return { key: item._id, label: name, title: name, value: item._id, raw: item };
-          });
+          return runMutation(
+            { userId: this.userId },
+            {
+              collection,
+              operation: 'read',
+              permissionModule,
+              validate: ([f, o]) => {
+                validateObject(f, false);
+                validateObject(o, false);
+              },
+            },
+            [filter, options] as const,
+            async ([f, o]) =>
+              Collection.find(f, o).mapAsync((item: any) => {
+                const profile = item.profile as { name?: string } | undefined;
+                const name = profile?.name || (item.name as string | undefined);
+                return { key: item._id, label: name, title: name, value: item._id, raw: item };
+              }),
+          );
         },
       });
     }

--- a/server/mutation-pipeline.ts
+++ b/server/mutation-pipeline.ts
@@ -1,0 +1,132 @@
+import { Meteor } from 'meteor/meteor';
+import { checkPermission, checkSpecialPermission } from './main';
+import { createLog } from './apis/logs.server';
+
+export type MutationOp = 'read' | 'create' | 'update' | 'delete';
+export type AuditShape = 'insert' | 'update' | 'remove';
+
+export interface MutationContext {
+  readonly userId: string | null;
+}
+
+export interface MutationDescriptor<TArgs extends readonly unknown[], TResult> {
+  readonly collection: string;
+  readonly operation: MutationOp;
+  readonly action?: string;
+  readonly auditShape?: AuditShape;
+  readonly audit?: (args: TArgs, result: TResult) => Record<string, unknown>;
+  readonly requireAuth?: boolean;
+  readonly allowAnonymous?: boolean;
+  readonly permissionModule?: string | null;
+  readonly fallbackFlag?: string | null;
+  readonly validate?: (args: TArgs) => void;
+}
+
+const OP_TO_DENIAL_SEGMENT: Record<MutationOp, string> = {
+  create: 'insert',
+  delete: 'remove',
+  read: 'read',
+  update: 'update',
+};
+
+function buildDenialAction<TArgs extends readonly unknown[], TResult>(
+  descriptor: MutationDescriptor<TArgs, TResult>,
+): string {
+  return `${descriptor.collection}.${OP_TO_DENIAL_SEGMENT[descriptor.operation]}.denied`;
+}
+
+function buildStandardPayload<TArgs extends readonly unknown[], TResult>(
+  shape: AuditShape,
+  args: TArgs,
+  result: TResult,
+): Record<string, unknown> {
+  switch (shape) {
+    case 'insert': {
+      const payload = (args[0] ?? {}) as Record<string, unknown>;
+      return { id: result as unknown as string, ...payload };
+    }
+    case 'update': {
+      const id = args[0] as string;
+      const changes = (args[1] ?? {}) as Record<string, unknown>;
+      return { id, changes };
+    }
+    case 'remove': {
+      const id = args[0] as string;
+      return { id };
+    }
+  }
+}
+
+function extractDenialId<TArgs extends readonly unknown[], TResult>(
+  descriptor: MutationDescriptor<TArgs, TResult>,
+  args: TArgs,
+): string | undefined {
+  // For ops where the first arg is the target id, surface it on `payload.id`
+  // so denial entries are queryable by the same lookup pattern as success
+  // entries (`findLatestAuditLog(action, payloadId)`).
+  if (descriptor.operation === 'update' || descriptor.operation === 'delete') {
+    const candidate = args[0];
+    return typeof candidate === 'string' ? candidate : undefined;
+  }
+  return undefined;
+}
+
+async function emitDenial<TArgs extends readonly unknown[], TResult>(
+  ctx: MutationContext,
+  descriptor: MutationDescriptor<TArgs, TResult>,
+  args: TArgs,
+): Promise<void> {
+  const action = buildDenialAction(descriptor);
+  const id = extractDenialId(descriptor, args);
+  const payload: Record<string, unknown> = { userId: ctx.userId };
+  if (id !== undefined) payload.id = id;
+  await createLog(action, payload);
+}
+
+export async function runMutation<TArgs extends readonly unknown[], TResult>(
+  ctx: MutationContext,
+  descriptor: MutationDescriptor<TArgs, TResult>,
+  args: TArgs,
+  body: (args: TArgs) => Promise<TResult>,
+): Promise<TResult> {
+  const requireAuth = descriptor.requireAuth ?? true;
+  const isAnonymous = !ctx.userId;
+
+  if (isAnonymous && requireAuth && !descriptor.allowAnonymous) {
+    await emitDenial(ctx, descriptor, args);
+    throw new Meteor.Error(401, 'Unauthorized');
+  }
+
+  if (!isAnonymous && descriptor.permissionModule) {
+    const hasPermission = await checkPermission(ctx.userId, descriptor.permissionModule, descriptor.operation);
+    if (!hasPermission) {
+      const flag = descriptor.fallbackFlag;
+      const hasSpecial = flag ? await checkSpecialPermission(ctx.userId, flag) : false;
+      if (!hasSpecial) {
+        await emitDenial(ctx, descriptor, args);
+        throw new Meteor.Error(403, 'Permission denied');
+      }
+    }
+  }
+
+  if (descriptor.validate) {
+    try {
+      descriptor.validate(args);
+    } catch (error) {
+      await emitDenial(ctx, descriptor, args);
+      throw error;
+    }
+  }
+
+  const result = await body(args);
+
+  if (descriptor.action) {
+    if (descriptor.audit) {
+      await createLog(descriptor.action, descriptor.audit(args, result));
+    } else if (descriptor.auditShape) {
+      await createLog(descriptor.action, buildStandardPayload(descriptor.auditShape, args, result));
+    }
+  }
+
+  return result;
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,7 @@ import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
 import './server/crudMethods.test';
 import './server/getCollection.test';
+import './server/mutationPipeline.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
 import './server/validation.test';

--- a/tests/server/mutationPipeline.test.ts
+++ b/tests/server/mutationPipeline.test.ts
@@ -1,0 +1,361 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import { runMutation } from '../../server/mutation-pipeline';
+import LogsCollection from '../../imports/api/collections/logs.collection';
+import MedalsCollection from '../../imports/api/collections/medals.collection';
+import {
+  assertRejectsWithCode,
+  callAs,
+  cleanupFixtures,
+  createTestRole,
+  createTestUser,
+  findLatestAuditLog,
+  TEST_PREFIX,
+} from './fixtures';
+
+// The wrapper's seam mechanics are exercised against a fake collection name
+// (`__pipeline_test`) so denial logs and success-via-custom-audit logs can
+// be cleaned up by action prefix without polluting the real Logs ranges.
+const FAKE_COLLECTION = '__pipeline_test';
+
+async function cleanPipelineLogs(): Promise<void> {
+  await LogsCollection.removeAsync({ action: { $regex: `^${FAKE_COLLECTION}\\.` } });
+}
+
+async function findLatestPipelineLog(action: string): Promise<{ action: string; payload: Record<string, unknown> } | undefined> {
+  return (await LogsCollection.findOneAsync(
+    { action },
+    { sort: { createdAt: -1 } },
+  )) as { action: string; payload: Record<string, unknown> } | undefined;
+}
+
+describe('mutation-pipeline — runMutation seam mechanics', () => {
+  let adminUserId: string;
+  let readerUserId: string;
+
+  before(async () => {
+    const [adminRoleId, readerRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      createTestRole({ medals: { read: true, create: false, update: false, delete: false } }),
+    ]);
+    [adminUserId, readerUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: readerRoleId }),
+    ]);
+  });
+
+  afterEach(async () => {
+    await cleanPipelineLogs();
+  });
+
+  after(async () => {
+    await cleanupFixtures([MedalsCollection]);
+  });
+
+  it('permission denied — body never invoked', async () => {
+    let bodyRan = false;
+    await assertRejectsWithCode(
+      () =>
+        runMutation(
+          { userId: readerUserId },
+          {
+            collection: FAKE_COLLECTION,
+            operation: 'create',
+            permissionModule: 'medals',
+          },
+          [],
+          async () => {
+            bodyRan = true;
+            return null;
+          },
+        ),
+      403,
+    );
+    assert.strictEqual(bodyRan, false, 'Body must not run when permission denied');
+  });
+
+  it('permission denied — emits <collection>.<op>.denied audit entry with userId', async () => {
+    await assertRejectsWithCode(
+      () =>
+        runMutation(
+          { userId: readerUserId },
+          {
+            collection: FAKE_COLLECTION,
+            operation: 'create',
+            permissionModule: 'medals',
+          },
+          [],
+          async () => null,
+        ),
+      403,
+    );
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.insert.denied`);
+    assert.ok(log, 'Expected denial audit entry');
+    assert.strictEqual(log.payload.userId, readerUserId);
+  });
+
+  it('missing userId — 401, body skipped, denial audit entry written', async () => {
+    let bodyRan = false;
+    await assertRejectsWithCode(
+      () =>
+        runMutation(
+          { userId: null },
+          {
+            collection: FAKE_COLLECTION,
+            operation: 'update',
+            permissionModule: 'medals',
+          },
+          [],
+          async () => {
+            bodyRan = true;
+            return null;
+          },
+        ),
+      401,
+    );
+    assert.strictEqual(bodyRan, false);
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.update.denied`);
+    assert.ok(log, 'Expected denial audit entry on missing userId');
+    assert.strictEqual(log.payload.userId, null);
+  });
+
+  it('permission allowed — body invoked and return value passed through', async () => {
+    const result = await runMutation(
+      { userId: adminUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'read',
+        permissionModule: 'medals',
+      },
+      [],
+      async () => 'sentinel-value',
+    );
+    assert.strictEqual(result, 'sentinel-value');
+  });
+
+  it('body throws — no audit entry, original error code preserved', async () => {
+    await assertRejectsWithCode(
+      () =>
+        runMutation(
+          { userId: adminUserId },
+          {
+            collection: FAKE_COLLECTION,
+            operation: 'create',
+            action: `${FAKE_COLLECTION}.created`,
+            auditShape: 'insert',
+            permissionModule: 'medals',
+          },
+          [{ name: 'irrelevant' }] as const,
+          async () => {
+            throw new Meteor.Error('original-code', 'body failed');
+          },
+        ),
+      'original-code',
+    );
+    const successLog = await findLatestPipelineLog(`${FAKE_COLLECTION}.created`);
+    assert.strictEqual(successLog, undefined, 'Body throw must not emit a success audit entry');
+  });
+
+  it('body succeeds — standard insert audit shape: { id, ...payload }', async () => {
+    const fakeId = await runMutation(
+      { userId: adminUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'create',
+        action: `${FAKE_COLLECTION}.created`,
+        auditShape: 'insert',
+        permissionModule: 'medals',
+      },
+      [{ name: 'alpha', color: '#fff' }] as const,
+      async () => 'inserted-id',
+    );
+    assert.strictEqual(fakeId, 'inserted-id');
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.created`);
+    assert.ok(log, 'Expected success audit entry');
+    assert.deepStrictEqual(log.payload, { id: 'inserted-id', name: 'alpha', color: '#fff' });
+  });
+
+  it('body succeeds — standard update audit shape: { id, changes }', async () => {
+    await runMutation(
+      { userId: adminUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'update',
+        action: `${FAKE_COLLECTION}.updated`,
+        auditShape: 'update',
+        permissionModule: 'medals',
+      },
+      ['target-id', { color: '#000' }] as const,
+      async () => 1,
+    );
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.updated`);
+    assert.ok(log);
+    assert.deepStrictEqual(log.payload, { id: 'target-id', changes: { color: '#000' } });
+  });
+
+  it('body succeeds — standard remove audit shape: { id }', async () => {
+    await runMutation(
+      { userId: adminUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'delete',
+        action: `${FAKE_COLLECTION}.deleted`,
+        auditShape: 'remove',
+        permissionModule: 'medals',
+      },
+      ['gone-id'] as const,
+      async () => 1,
+    );
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.deleted`);
+    assert.ok(log);
+    assert.deepStrictEqual(log.payload, { id: 'gone-id' });
+  });
+
+  it('descriptor-level audit function overrides the standard shape', async () => {
+    await runMutation(
+      { userId: adminUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'create',
+        action: `${FAKE_COLLECTION}.custom`,
+        auditShape: 'insert',
+        audit: (_args, result) => ({ customKey: 'customValue', result }),
+        permissionModule: 'medals',
+      },
+      [{ name: 'should-be-ignored' }] as const,
+      async () => 'r',
+    );
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.custom`);
+    assert.ok(log);
+    assert.deepStrictEqual(log.payload, { customKey: 'customValue', result: 'r' });
+  });
+
+  it('unconditional fallback flag permits an op when the main permission is denied', async () => {
+    const fallbackRoleId = await createTestRole({
+      medals: { read: false, create: false, update: false, delete: false },
+      __testFallbackFlag: true,
+    });
+    const fallbackUserId = await createTestUser({ roleId: fallbackRoleId });
+
+    let bodyRan = false;
+    await runMutation(
+      { userId: fallbackUserId },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'create',
+        permissionModule: 'medals',
+        fallbackFlag: '__testFallbackFlag',
+      },
+      [],
+      async () => {
+        bodyRan = true;
+        return null;
+      },
+    );
+    assert.strictEqual(bodyRan, true, 'Body must run when fallback flag is set despite denied main permission');
+  });
+
+  it('allowAnonymous permits an op when userId is null', async () => {
+    let bodyRan = false;
+    const result = await runMutation(
+      { userId: null },
+      {
+        collection: FAKE_COLLECTION,
+        operation: 'create',
+        permissionModule: 'medals',
+        allowAnonymous: true,
+      },
+      [],
+      async () => {
+        bodyRan = true;
+        return 'anonymous-result';
+      },
+    );
+    assert.strictEqual(bodyRan, true);
+    assert.strictEqual(result, 'anonymous-result');
+  });
+
+  it('validation failure — emits denial entry and propagates the validator error', async () => {
+    let bodyRan = false;
+    await assertRejectsWithCode(
+      () =>
+        runMutation(
+          { userId: adminUserId },
+          {
+            collection: FAKE_COLLECTION,
+            operation: 'create',
+            permissionModule: 'medals',
+            validate: () => {
+              throw new Meteor.Error('validate-shape', 'bad shape');
+            },
+          },
+          [],
+          async () => {
+            bodyRan = true;
+            return null;
+          },
+        ),
+      'validate-shape',
+    );
+    assert.strictEqual(bodyRan, false);
+    const log = await findLatestPipelineLog(`${FAKE_COLLECTION}.insert.denied`);
+    assert.ok(log, 'Expected denial entry on validation failure');
+  });
+});
+
+describe('mutation-pipeline — factory and direct call paths produce equivalent audit emissions', () => {
+  // Asserts the "exactly one implementation" invariant: a Meteor method
+  // generated by createCollectionMethods and a hand-rolled runMutation call
+  // with the equivalent descriptor must write the same audit shape.
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ roles: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures([MedalsCollection]);
+  });
+
+  it('factory-generated medals.insert and direct runMutation produce equivalent audit shapes', async () => {
+    const factoryId = (await callAs(adminUserId, 'medals.insert', {
+      name: `${TEST_PREFIX}contract_factory`,
+      color: '#abcdef',
+    })) as string;
+
+    const directId = (await runMutation(
+      { userId: adminUserId },
+      {
+        collection: 'medals',
+        operation: 'create',
+        action: 'medals.created',
+        auditShape: 'insert',
+        permissionModule: 'medals',
+      },
+      [{ name: `${TEST_PREFIX}contract_direct`, color: '#abcdef' }] as const,
+      async ([payload]) => MedalsCollection.insertAsync(payload as never),
+    )) as string;
+
+    const factoryLog = await findLatestAuditLog('medals.created', factoryId);
+    const directLog = await findLatestAuditLog('medals.created', directId);
+
+    assert.ok(factoryLog, 'Factory-generated method must write audit log');
+    assert.ok(directLog, 'Direct runMutation call must write audit log');
+    assert.strictEqual(factoryLog.action, directLog.action);
+
+    // Strip the differing ids and compare structural shape.
+    const factoryShape = { ...factoryLog.payload };
+    const directShape = { ...directLog.payload };
+    delete factoryShape.id;
+    delete factoryShape.name;
+    delete directShape.id;
+    delete directShape.name;
+    assert.deepStrictEqual(
+      Object.keys(factoryShape).sort(),
+      Object.keys(directShape).sort(),
+      'Factory and direct payloads must have identical key sets',
+    );
+    assert.strictEqual(factoryShape.color, directShape.color);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #98 (PR 1 of the [#97](https://github.com/sentinel-web/community-manager/issues/97) rollout).

- Adds `server/mutation-pipeline.ts` exporting `runMutation(ctx, descriptor, args, body)` — a single deep module owning auth → permission (with unconditional fallback flag + anonymous-allowed exception) → input shape validation → body invocation → audit log emission.
- Refactors `server/crud.lib.ts` so all seven generated CRUD methods (`read`/`insert`/`update`/`remove`/`bulkRemove`/`count`/`options`) delegate the preamble and audit emission to the wrapper. Side-effects unique to one site (tasks `createdAt` injection, roles cache clear, bulkRemove's per-iteration loop) stay as code in the body.
- Permission denials now emit `<collection>.<op>.denied` audit entries capturing `userId` and the target `id` where applicable — closing the previous gap where denials produced no audit trail.
- Introduces `CONTEXT.md` at the repo root with the `MutationWithAudit` domain term defining the wrapper and its five lifecycle stages.

**No external API changes**: existing audit-action names, error codes, and side effects all behave identically. The four pre-existing per-collection metadata structures (`CRUD_MODULES`, `COLLECTION_TO_MODULE`, `SPECIAL_PERMISSION_FALLBACK`, `unsafeCollections`) are still consulted from inside the wrapper; their consolidation into a registry is deferred to #99.

## Test plan

- [x] 168-test baseline passes unchanged
- [x] 12 new direct-call unit tests for the wrapper (`tests/server/mutationPipeline.test.ts`) covering every acceptance bullet:
  - permission denied → body never invoked
  - permission denied → `<collection>.<op>.denied` audit entry with `userId`
  - missing `userId` → 401, body skipped, denial audit entry written
  - permission allowed → body invoked, return value passed through
  - body throws → no audit entry, original error code preserved
  - body succeeds → standard `insert` / `update` / `remove` audit shapes
  - descriptor-level `audit` function overrides the standard shape
  - unconditional `fallbackFlag` permits an op when main permission denied
  - `allowAnonymous` permits an op when `userId` is null
  - validation failure → emits denial entry, propagates the validator error
- [x] Contract test asserting factory-generated `medals.insert` and a direct `runMutation` call produce equivalent audit-log shapes for the same operation
- [x] Final tally: **181 passing** (168 baseline + 13 new)

## Out of scope (follow-ups)

- Registry consolidation + audit-name normalization (`member.*` → `members.*`) — issue #99
- Per-method migrations of `members.insert` / `members.update` / `members.remove` — issues #100 / #101 / #102