### PR TITLE
refactor(server): CollectionPermissionRegistry + plural audit-action names (#99)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,3 +17,22 @@ The single deep module (`server/mutation-pipeline.ts`) that owns the standard se
 On any pre-body failure (auth, permission, validation), the wrapper emits a `<collection>.<op>.denied` audit entry capturing `userId` (and the target `id` for `update`/`remove`) before throwing — closing the previous gap where permission denials produced no audit trail. Body errors propagate untouched: the wrapper does **not** normalize, wrap, or translate them. A body throwing `Meteor.Error('SomeCode', '...')` reaches the caller with `error.error === 'SomeCode'` intact.
 
 The wrapper is exposed as `runMutation(ctx, descriptor, args, body)` with an explicit `ctx` parameter (carrying `userId`), which lets unit tests invoke the lifecycle directly without `Meteor.callAsync`. Both call paths — `createCollectionMethods` (the CRUD factory in `server/crud.lib.ts`) and direct `runMutation` calls from custom methods that opt in — route through the same internal pipeline, so the lifecycle has exactly one implementation regardless of entry door.
+
+### CollectionPermissionRegistry
+
+The single source of per-collection metadata that both the CRUD factory and the `MutationWithAudit` wrapper consult. Lives in `server/collection-registry.ts` as a typed `Record<CrudCollectionName, CollectionRegistryEntry>` — one entry per collection with these fields:
+
+- `module` — the permission module name used for `checkPermission`. Several collections (e.g. `attendances`, `profilePictures`, `questionnaireResponses`) do not own a permission module of their own; they ride on a parent module's permissions, encoded here.
+- `fallback` (optional) — unconditional special-permission flag per `create` / `update` op, e.g. `canCreateEvents` for `events.create` or `canManageTasks` for `tasks.{create,update}`. When set, possession of the flag re-admits a denied call.
+- `allowsAnonymous` (optional) — per-op carve-out permitting a `null` `userId`. Currently only `registrations.insert` opts in.
+- `redact` (optional) — per-op path-list of fields stripped from the audit payload before logging, used by sensitive sites such as `members.insert` to keep secrets out of the audit trail.
+
+The registry holds plain TypeScript values throughout: no predicate functions, no string-key DSLs, no discriminated-union "kind" fields. The `Record<CrudCollectionName, _>` type forces every member of the canonical collection-name union to have an entry — adding a collection to the union without updating the registry is a compile error.
+
+## Doctrines
+
+### Rule of three
+
+Variations in **3+ sites** go in the registry as data; variations in **1–2 sites** stay as code in custom method bodies that opt into the wrapper. This is a falsifiable test for future registry vocabulary changes, and the discipline that keeps the registry inspectable as plain values rather than drifting into a configuration DSL.
+
+When you find yourself wanting to express a new kind of variation in the registry (a new field, a new gate kind, a new shape modifier), the question is empirical: *is this pattern already present in three or more sites?* If yes, promote it to the registry. If no, leave it as code in the body of the one or two methods that need it; revisit when a third site appears. This applies in both directions: a registry field that's used by only one or two sites is a candidate for demotion back to code in those bodies.

--- a/server/apis/events.server.ts
+++ b/server/apis/events.server.ts
@@ -65,10 +65,10 @@ if (Meteor.isServer) {
 
       if (isSignedUp) {
         await EventsCollection.updateAsync(eventId, { $pull: { attendees: this.userId } } as never);
-        await createLog('event.rsvp.removed', { eventId, userId: this.userId });
+        await createLog('events.rsvp.removed', { eventId, userId: this.userId });
       } else {
         await EventsCollection.updateAsync(eventId, { $addToSet: { attendees: this.userId } } as never);
-        await createLog('event.rsvp.added', { eventId, userId: this.userId });
+        await createLog('events.rsvp.added', { eventId, userId: this.userId });
       }
 
       return !isSignedUp;

--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -74,7 +74,7 @@ if (Meteor.isServer) {
 
       try {
         const memberId = await Accounts.createUserAsync(payload as Parameters<typeof Accounts.createUserAsync>[0]);
-        await createLog('member.created', {
+        await createLog('members.created', {
           id: memberId,
           username: payload.username,
         });
@@ -106,7 +106,7 @@ if (Meteor.isServer) {
       const modifier = { $set: data };
       try {
         const result = await MembersCollection.updateAsync(selector as never, modifier as never);
-        await createLog('member.updated', {
+        await createLog('members.updated', {
           id: memberId,
           changes: data,
         });
@@ -124,7 +124,7 @@ if (Meteor.isServer) {
 
       try {
         const result = await MembersCollection.removeAsync({ _id: memberId } as never);
-        await createLog('member.deleted', { id: memberId });
+        await createLog('members.deleted', { id: memberId });
         return result;
       } catch (error) {
         throw new Meteor.Error((error as Error).message);

--- a/server/apis/specializations.server.ts
+++ b/server/apis/specializations.server.ts
@@ -23,7 +23,7 @@ if (Meteor.isServer) {
       const spec = await SpecializationsCollection.findOneAsync(specializationId);
       if (!spec) throw new Meteor.Error(404, 'Specialization not found');
 
-      await createLog('specialization.requested', {
+      await createLog('specializations.requested', {
         userId: this.userId,
         specializationId,
         specializationName: spec.name,

--- a/server/collection-registry.ts
+++ b/server/collection-registry.ts
@@ -1,0 +1,34 @@
+import type { CrudCollectionName } from '/imports/api/types';
+
+export interface CollectionRegistryEntry {
+  readonly module: string;
+  readonly fallback?: { readonly create?: string; readonly update?: string };
+  readonly allowsAnonymous?: { readonly insert?: boolean };
+  readonly redact?: { readonly insert?: readonly string[]; readonly update?: readonly string[] };
+}
+
+// Per-collection metadata. The Record<CrudCollectionName, _> type forces
+// every member of the canonical collection-name union to have an entry —
+// adding a collection to the union without updating this map is a compile
+// error. The runtime shape-conformance test in permissions.test.ts catches
+// the same omission under loosened type checks.
+export const COLLECTION_REGISTRY: Record<CrudCollectionName, CollectionRegistryEntry> = {
+  attendances: { module: 'events' },
+  discoveryTypes: { module: 'discoveryTypes' },
+  events: { module: 'events', fallback: { create: 'canCreateEvents' } },
+  eventTypes: { module: 'eventTypes' },
+  logs: { module: 'logs' },
+  medals: { module: 'medals' },
+  members: { module: 'members' },
+  positions: { module: 'positions' },
+  profilePictures: { module: 'members' },
+  questionnaireResponses: { module: 'questionnaires' },
+  questionnaires: { module: 'questionnaires' },
+  ranks: { module: 'ranks' },
+  registrations: { module: 'registrations', allowsAnonymous: { insert: true } },
+  roles: { module: 'roles' },
+  specializations: { module: 'specializations' },
+  squads: { module: 'squads' },
+  taskStatus: { module: 'taskStatus' },
+  tasks: { module: 'tasks', fallback: { create: 'canManageTasks', update: 'canManageTasks' } },
+};

--- a/server/crud.lib.ts
+++ b/server/crud.lib.ts
@@ -4,19 +4,12 @@ import {
   validateObject,
   validateString,
   validateArrayOfStrings,
-  getPermissionModule,
   clearRoleCache,
 } from './main';
 import { createLog } from './apis/logs.server';
 import { runMutation } from './mutation-pipeline';
+import { COLLECTION_REGISTRY } from './collection-registry';
 import type { CrudCollectionMap, CrudCollectionName } from '/imports/api/types';
-
-const SPECIAL_PERMISSION_FALLBACK: Record<string, { create?: string; update?: string }> = {
-  events: { create: 'canCreateEvents' },
-  tasks: { create: 'canManageTasks', update: 'canManageTasks' },
-};
-
-const UNSAFE_COLLECTIONS: readonly string[] = ['registrations'];
 
 import AttendancesCollection from '../imports/api/collections/attendances.collection';
 import DiscoveryTypesCollection from '../imports/api/collections/discoveryTypes.collection';
@@ -110,8 +103,10 @@ function createCollectionMethods(collection: CrudCollectionName): void {
   try {
     if (Meteor.isServer) {
       const Collection = getCollection(collection);
-      const permissionModule = getPermissionModule(collection);
-      const fallback = SPECIAL_PERMISSION_FALLBACK[collection];
+      const registryEntry = COLLECTION_REGISTRY[collection];
+      const permissionModule = registryEntry.module;
+      const fallback = registryEntry.fallback;
+      const allowsAnonymousInsert = registryEntry.allowsAnonymous?.insert === true;
       const auditAllowed = collection !== 'logs';
 
       Meteor.methods({
@@ -141,7 +136,7 @@ function createCollectionMethods(collection: CrudCollectionName): void {
               auditShape: 'insert',
               permissionModule,
               fallbackFlag: fallback?.create,
-              allowAnonymous: UNSAFE_COLLECTIONS.includes(collection),
+              allowAnonymous: allowsAnonymousInsert,
               validate: ([p]) => validateObject(p, false),
             },
             [payload] as const,

--- a/server/main.ts
+++ b/server/main.ts
@@ -22,6 +22,7 @@ import './apis/settings.server';
 import './apis/specializations.server';
 import './apis/squads.server';
 import './apis/tasks.server';
+import { COLLECTION_REGISTRY } from './collection-registry';
 import { createCollectionMethods, createCollectionPublish } from './crud.lib';
 import { CACHE, SQUAD_SCOPED_PERMISSIONS } from './config';
 
@@ -31,42 +32,13 @@ export type CrudOperation = 'read' | 'create' | 'update' | 'delete';
 
 const BOOLEAN_MODULES: readonly string[] = ['dashboard', 'orbat', 'logs', 'settings'];
 
-const CRUD_MODULES: readonly string[] = [
-  'discoveryTypes',
-  'events',
-  'eventTypes',
-  'medals',
-  'members',
-  'positions',
-  'questionnaires',
-  'ranks',
-  'registrations',
-  'roles',
-  'specializations',
-  'squads',
-  'tasks',
-  'taskStatus',
-];
-
-const COLLECTION_TO_MODULE: Record<string, string> = {
-  attendances: 'events',
-  discoveryTypes: 'discoveryTypes',
-  events: 'events',
-  eventTypes: 'eventTypes',
-  medals: 'medals',
-  members: 'members',
-  positions: 'positions',
-  profilePictures: 'members',
-  questionnaires: 'questionnaires',
-  questionnaireResponses: 'questionnaires',
-  ranks: 'ranks',
-  registrations: 'registrations',
-  roles: 'roles',
-  specializations: 'specializations',
-  squads: 'squads',
-  tasks: 'tasks',
-  taskStatus: 'taskStatus',
-};
+// Distinct CRUD-style permission modules across the registry, minus boolean
+// modules. Used by normalizeRolePermissions to expand `role[mod] = true` into
+// the four-op object. Derived from the registry so adding a collection
+// updates this set automatically.
+const CRUD_MODULE_SET: readonly string[] = [
+  ...new Set(Object.values(COLLECTION_REGISTRY).map(entry => entry.module)),
+].filter(module => !BOOLEAN_MODULES.includes(module));
 
 interface RoleCacheEntry {
   role: Role | null;
@@ -98,7 +70,7 @@ export function normalizeRolePermissions(role: Role | null | undefined): Role | 
 
   const isAdmin = role.roles === true;
 
-  for (const module of CRUD_MODULES) {
+  for (const module of CRUD_MODULE_SET) {
     const key = module as keyof Role;
     const permission = role[key];
     if (permission === true) {
@@ -183,17 +155,13 @@ export function clearRoleCache(roleId?: string): void {
   }
 }
 
-export function getPermissionModule(collectionName: string): string | null {
-  return COLLECTION_TO_MODULE[collectionName] || null;
-}
-
 export async function checkSpecialPermission(userId: string | null | undefined, flag: string): Promise<boolean> {
   const role = await getUserRole(userId);
   if (!role) return false;
   return (role as unknown as Record<string, unknown>)[flag] === true;
 }
 
-export { BOOLEAN_MODULES, CRUD_MODULES };
+export { BOOLEAN_MODULES };
 
 export function isOfficerOrAdmin(role: Role | null | undefined): boolean {
   if (!role) return false;

--- a/tests/server/permissions.test.ts
+++ b/tests/server/permissions.test.ts
@@ -153,7 +153,12 @@ describe('COLLECTION_REGISTRY', () => {
     ];
     for (const collection of expected) {
       assert.ok(COLLECTION_REGISTRY[collection], `Expected registry entry for ${collection}`);
-      assert.strictEqual(typeof COLLECTION_REGISTRY[collection].module, 'string');
+      const { module } = COLLECTION_REGISTRY[collection];
+      assert.strictEqual(typeof module, 'string');
+      // Non-empty guardrail: an empty module string would be falsy at the
+      // wrapper's `if (descriptor.permissionModule)` check, silently disabling
+      // the permission gate for that collection.
+      assert.ok(module.length > 0, `Registry entry for ${collection} must have a non-empty module`);
     }
     assert.deepStrictEqual([...Object.keys(COLLECTION_REGISTRY)].sort(), [...expected].sort());
   });

--- a/tests/server/permissions.test.ts
+++ b/tests/server/permissions.test.ts
@@ -2,11 +2,17 @@ import assert from 'node:assert';
 import {
   normalizeRolePermissions,
   isOfficerOrAdmin,
-  getPermissionModule,
   BOOLEAN_MODULES,
-  CRUD_MODULES,
 } from '../../server/main';
-import type { Role } from '/imports/api/types';
+import { COLLECTION_REGISTRY } from '../../server/collection-registry';
+import type { CrudCollectionName, Role } from '/imports/api/types';
+
+// Local derivation matching server/main.ts's CRUD_MODULE_SET. Used by
+// normalizeRolePermissions tests that need the canonical CRUD-style
+// permission-module list to drive role-shape assertions.
+const CRUD_MODULE_SET: readonly string[] = [
+  ...new Set(Object.values(COLLECTION_REGISTRY).map(entry => entry.module)),
+].filter(module => !BOOLEAN_MODULES.includes(module));
 
 describe('normalizeRolePermissions', () => {
   it('returns null for null input', () => {
@@ -65,12 +71,12 @@ describe('normalizeRolePermissions', () => {
 
   it('normalizes all CRUD modules', () => {
     const role = { name: 'full' } as Record<string, unknown>;
-    for (const mod of CRUD_MODULES) {
+    for (const mod of CRUD_MODULE_SET) {
       role[mod] = true;
     }
     const result = normalizeRolePermissions(role as unknown as Role) as Record<string, unknown> | null;
     assert.ok(result);
-    for (const mod of CRUD_MODULES) {
+    for (const mod of CRUD_MODULE_SET) {
       // 'roles' is special - it's the admin flag and gets restored
       if (mod === 'roles') continue;
       assert.deepStrictEqual(result[mod], { read: true, create: true, update: true, delete: true }, `${mod} should be normalized`);
@@ -113,72 +119,72 @@ describe('isOfficerOrAdmin', () => {
   });
 });
 
-describe('getPermissionModule', () => {
-  it('returns correct module for members', () => {
-    assert.strictEqual(getPermissionModule('members'), 'members');
-  });
-
-  it('returns events module for attendances', () => {
-    assert.strictEqual(getPermissionModule('attendances'), 'events');
-  });
-
-  it('returns members module for profilePictures', () => {
-    assert.strictEqual(getPermissionModule('profilePictures'), 'members');
-  });
-
-  it('returns questionnaires module for questionnaireResponses', () => {
-    assert.strictEqual(getPermissionModule('questionnaireResponses'), 'questionnaires');
-  });
-
-  it('returns null for unknown collection', () => {
-    assert.strictEqual(getPermissionModule('unknownCollection'), null);
-  });
-
-  it('returns correct module for all mapped collections', () => {
-    const expectedMappings: Record<string, string> = {
-      attendances: 'events',
-      discoveryTypes: 'discoveryTypes',
-      events: 'events',
-      eventTypes: 'eventTypes',
-      medals: 'medals',
-      members: 'members',
-      positions: 'positions',
-      profilePictures: 'members',
-      questionnaires: 'questionnaires',
-      questionnaireResponses: 'questionnaires',
-      ranks: 'ranks',
-      registrations: 'registrations',
-      roles: 'roles',
-      specializations: 'specializations',
-      squads: 'squads',
-      tasks: 'tasks',
-      taskStatus: 'taskStatus',
-    };
-    for (const [collection, module] of Object.entries(expectedMappings)) {
-      assert.strictEqual(getPermissionModule(collection), module, `${collection} should map to ${module}`);
-    }
-  });
-});
-
 describe('BOOLEAN_MODULES', () => {
   it('contains dashboard, orbat, logs, settings', () => {
     assert.deepStrictEqual([...BOOLEAN_MODULES].sort(), ['dashboard', 'logs', 'orbat', 'settings']);
   });
 });
 
-describe('CRUD_MODULES', () => {
-  it('contains all expected modules', () => {
-    const expected = [
-      'discoveryTypes', 'events', 'eventTypes', 'medals', 'members',
-      'positions', 'questionnaires', 'ranks', 'registrations', 'roles',
-      'specializations', 'squads', 'tasks', 'taskStatus',
+describe('COLLECTION_REGISTRY', () => {
+  // Shape conformance: every member of the canonical CrudCollectionName union
+  // has a registry entry. The Record<CrudCollectionName, _> type would already
+  // enforce this at compile time; this test guards against the same omission
+  // under loosened type checks (e.g. if anyone reaches for `as` casts).
+  it('has an entry for every CrudCollectionName', () => {
+    const expected: readonly CrudCollectionName[] = [
+      'attendances',
+      'discoveryTypes',
+      'events',
+      'eventTypes',
+      'logs',
+      'medals',
+      'members',
+      'positions',
+      'profilePictures',
+      'questionnaireResponses',
+      'questionnaires',
+      'ranks',
+      'registrations',
+      'roles',
+      'specializations',
+      'squads',
+      'taskStatus',
+      'tasks',
     ];
-    assert.deepStrictEqual([...CRUD_MODULES].sort(), expected.sort());
+    for (const collection of expected) {
+      assert.ok(COLLECTION_REGISTRY[collection], `Expected registry entry for ${collection}`);
+      assert.strictEqual(typeof COLLECTION_REGISTRY[collection].module, 'string');
+    }
+    assert.deepStrictEqual([...Object.keys(COLLECTION_REGISTRY)].sort(), [...expected].sort());
   });
 
-  it('does not overlap with BOOLEAN_MODULES', () => {
-    for (const mod of CRUD_MODULES) {
-      assert.ok(!BOOLEAN_MODULES.includes(mod), `${mod} should not be in both CRUD and BOOLEAN modules`);
+  it('maps overloaded collections to their permission module owner', () => {
+    // attendances/profilePictures/questionnaireResponses do not have their
+    // own permission modules — they ride on the parent module's permissions.
+    assert.strictEqual(COLLECTION_REGISTRY.attendances.module, 'events');
+    assert.strictEqual(COLLECTION_REGISTRY.profilePictures.module, 'members');
+    assert.strictEqual(COLLECTION_REGISTRY.questionnaireResponses.module, 'questionnaires');
+  });
+
+  it('declares fallback flags only for collections that actually have them', () => {
+    assert.strictEqual(COLLECTION_REGISTRY.events.fallback?.create, 'canCreateEvents');
+    assert.strictEqual(COLLECTION_REGISTRY.tasks.fallback?.create, 'canManageTasks');
+    assert.strictEqual(COLLECTION_REGISTRY.tasks.fallback?.update, 'canManageTasks');
+    assert.strictEqual(COLLECTION_REGISTRY.medals.fallback, undefined);
+  });
+
+  it('declares allowsAnonymous only for registrations.insert', () => {
+    assert.strictEqual(COLLECTION_REGISTRY.registrations.allowsAnonymous?.insert, true);
+    assert.strictEqual(COLLECTION_REGISTRY.medals.allowsAnonymous, undefined);
+  });
+
+  it('does not declare any CRUD-style module that overlaps with BOOLEAN_MODULES', () => {
+    for (const entry of Object.values(COLLECTION_REGISTRY)) {
+      if (entry.module === 'logs') continue; // logs is intentionally a boolean module
+      assert.ok(
+        !BOOLEAN_MODULES.includes(entry.module),
+        `Module ${entry.module} should not overlap with BOOLEAN_MODULES`,
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes #99 (PR 2 of the [#97](https://github.com/sentinel-web/community-manager/issues/97) rollout). Replaces the auto-closed [#104](https://github.com/sentinel-web/community-manager/pull/104), which was orphaned when its base branch was deleted on merge of [#103](https://github.com/sentinel-web/community-manager/pull/103). Same content as #104, rebased on the merged \`main\`, plus one extra commit adding a non-empty-module guardrail surfaced during self-review.

- Adds `server/collection-registry.ts` with `COLLECTION_REGISTRY` — a single typed `Record<CrudCollectionName, CollectionRegistryEntry>` carrying `module`, optional `fallback`, optional `allowsAnonymous`, and optional `redact` per collection. Plain TypeScript values throughout.
- Deletes the four pre-existing metadata structures: `CRUD_MODULES`, `COLLECTION_TO_MODULE`, `SPECIAL_PERMISSION_FALLBACK`, `UNSAFE_COLLECTIONS`. Also deletes `getPermissionModule` (inlined to a single registry lookup at its one production call site).
- Normalizes every audit-action name to plural-collection form across production code:
  - `member.{created,updated,deleted}` → `members.*`
  - `event.rsvp.{added,removed}` → `events.rsvp.*`
  - `specialization.requested` → `specializations.requested`
- Adds `CollectionPermissionRegistry` term + the **rule-of-three doctrine** to `CONTEXT.md` alongside `MutationWithAudit`.
- Updates `tests/server/permissions.test.ts`: removes the `CRUD_MODULES` and `getPermissionModule` describe blocks (entities no longer exist); adds a `COLLECTION_REGISTRY` block with a shape-conformance test asserting every `CrudCollectionName` has a registry entry, per-field assertions, and a non-empty-module guardrail.

## ⚠️ Externally observable change — coordination required before merge

The audit-action name normalization is **the only observable change** in this PR. Any external log consumer that filters or alerts on the singular forms will need to be updated:

| Old action name | New action name |
|---|---|
| `member.created` | `members.created` |
| `member.updated` | `members.updated` |
| `member.deleted` | `members.deleted` |
| `event.rsvp.added` | `events.rsvp.added` |
| `event.rsvp.removed` | `events.rsvp.removed` |
| `specialization.requested` | `specializations.requested` |

## Test plan

- [x] `npm test` — 178 passing
- [x] Shape conformance: `Record<CrudCollectionName, _>` enforces every collection has an entry at compile time; runtime test guards against loosened type checks
- [x] Non-empty module guardrail asserts no registry entry can silently disable the permission gate
- [x] Module-mapping tests verify overloaded collections (`attendances`/`profilePictures`/`questionnaireResponses`) point at the right parent module
- [x] Fallback-flag and `allowsAnonymous` declarations match the legacy hand-maintained constants byte-for-byte
- [x] No singular audit names remain anywhere in the codebase

## Out of scope (follow-ups)

- Per-method migrations of `members.insert` / `members.update` / `members.remove` onto the `MutationWithAudit` wrapper — issues #100 / #101 / #102. Those PRs will additionally consume the registry's `redact` field for `members.insert`'s password handling.