### PR TITLE
refactor(server): migrate members.insert to mutation-pipeline (#100)

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -13,6 +13,8 @@ import SpecializationsCollection from '../../imports/api/collections/specializat
 import SquadsCollection from '../../imports/api/collections/squads.collection';
 import { validateObject, validatePublish, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
 import { createLog } from './logs.server';
+import { runMutation } from '../mutation-pipeline';
+import { COLLECTION_REGISTRY } from '../collection-registry';
 import type { Role } from '/imports/api/types';
 
 async function getMemberById(memberId: string): Promise<Meteor.User> {
@@ -66,22 +68,20 @@ if (Meteor.isServer) {
       return member;
     },
     'members.insert': async function (payload: Record<string, unknown> = {}): Promise<string> {
-      validateUserId(this.userId);
-      validateObject(payload, false);
-
-      const hasPermission = await checkPermission(this.userId, 'members', 'create');
-      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-
-      try {
-        const memberId = await Accounts.createUserAsync(payload as Parameters<typeof Accounts.createUserAsync>[0]);
-        await createLog('members.created', {
-          id: memberId,
-          username: payload.username,
-        });
-        return memberId;
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      return runMutation(
+        { userId: this.userId },
+        {
+          collection: 'members',
+          operation: 'create',
+          action: 'members.created',
+          auditShape: 'insert',
+          permissionModule: 'members',
+          redact: COLLECTION_REGISTRY.members.redact?.insert,
+          validate: ([p]) => validateObject(p, false),
+        },
+        [payload] as const,
+        async ([p]) => Accounts.createUserAsync(p as Parameters<typeof Accounts.createUserAsync>[0]),
+      );
     },
     'members.update': async function (memberId: string = '', data: Record<string, unknown> = {}) {
       validateUserId(this.userId);

--- a/server/collection-registry.ts
+++ b/server/collection-registry.ts
@@ -19,7 +19,7 @@ export const COLLECTION_REGISTRY: Record<CrudCollectionName, CollectionRegistryE
   eventTypes: { module: 'eventTypes' },
   logs: { module: 'logs' },
   medals: { module: 'medals' },
-  members: { module: 'members' },
+  members: { module: 'members', redact: { insert: ['password'] } },
   positions: { module: 'positions' },
   profilePictures: { module: 'members' },
   questionnaireResponses: { module: 'questionnaires' },

--- a/server/mutation-pipeline.ts
+++ b/server/mutation-pipeline.ts
@@ -15,6 +15,10 @@ export interface MutationDescriptor<TArgs extends readonly unknown[], TResult> {
   readonly action?: string;
   readonly auditShape?: AuditShape;
   readonly audit?: (args: TArgs, result: TResult) => Record<string, unknown>;
+  // Top-level keys to strip from the standard audit payload before logging.
+  // Applied only to standard auditShape paths; descriptor.audit functions own
+  // their own redaction.
+  readonly redact?: readonly string[];
   readonly requireAuth?: boolean;
   readonly allowAnonymous?: boolean;
   readonly permissionModule?: string | null;
@@ -124,7 +128,15 @@ export async function runMutation<TArgs extends readonly unknown[], TResult>(
     if (descriptor.audit) {
       await createLog(descriptor.action, descriptor.audit(args, result));
     } else if (descriptor.auditShape) {
-      await createLog(descriptor.action, buildStandardPayload(descriptor.auditShape, args, result));
+      let payload = buildStandardPayload(descriptor.auditShape, args, result);
+      if (descriptor.redact?.length) {
+        const redacted: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(payload)) {
+          if (!descriptor.redact.includes(key)) redacted[key] = value;
+        }
+        payload = redacted;
+      }
+      await createLog(descriptor.action, payload);
     }
   }
 

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,7 @@ import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
 import './server/crudMethods.test';
 import './server/getCollection.test';
+import './server/membersMethods.test';
 import './server/mutationPipeline.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';

--- a/tests/server/membersMethods.test.ts
+++ b/tests/server/membersMethods.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert';
+import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
+import LogsCollection from '../../imports/api/collections/logs.collection';
+import {
+  assertRejectsWithCode,
+  callAs,
+  cleanupFixtures,
+  createTestRole,
+  createTestUser,
+  TEST_PREFIX,
+} from './fixtures';
+
+// Targets the bespoke methods in server/apis/members.server.ts that are being
+// migrated onto the mutation-pipeline wrapper one slice at a time. Each test
+// here asserts an invariant that the legacy try/catch antipattern violated —
+// see PRD #97 user story 7.
+
+describe('members.insert — migrated to mutation-pipeline (#100)', () => {
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ roles: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('body error from Accounts.createUserAsync propagates with original Meteor.Error code intact', async () => {
+    // Legacy antipattern: catch and rethrow as `new Meteor.Error(error.message)`,
+    // which collapsed the original error code into the message-position-as-code.
+    // After migration, the original error must reach the caller untouched.
+    const original = Accounts.createUserAsync;
+    (Accounts as unknown as { createUserAsync: unknown }).createUserAsync = async () => {
+      throw new Meteor.Error('test-original-code', 'test-original-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'members.insert', { username: `${TEST_PREFIX}propagation_probe` }),
+        'test-original-code',
+      );
+    } finally {
+      (Accounts as unknown as { createUserAsync: typeof original }).createUserAsync = original;
+    }
+  });
+
+  it('successful insert does not log the password (redact list applied)', async () => {
+    const username = `${TEST_PREFIX}redact_probe_${Math.random().toString(36).slice(2, 8)}`;
+    const insertedId = (await callAs(adminUserId, 'members.insert', {
+      username,
+      password: 'this-must-not-appear-in-logs',
+      profile: { name: 'Redact Probe' },
+    })) as string;
+    assert.ok(insertedId, 'Expected insert to return a member id');
+
+    const log = (await LogsCollection.findOneAsync(
+      { action: 'members.created', 'payload.id': insertedId },
+      { sort: { createdAt: -1 } },
+    )) as { payload: Record<string, unknown> } | undefined;
+    assert.ok(log, 'Expected a members.created audit entry');
+    assert.strictEqual(log.payload.password, undefined, 'Audit payload must not contain the password');
+    assert.strictEqual(log.payload.username, username, 'Audit payload should still carry the username');
+    assert.strictEqual(log.payload.id, insertedId);
+
+    // Cleanup the user we just created (cleanupFixtures only catches test-prefixed _ids,
+    // but Accounts.createUserAsync generates its own id — remove explicitly).
+    await Meteor.users.removeAsync({ _id: insertedId });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #100 (PR 3 of the [#97](https://github.com/sentinel-web/community-manager/issues/97) rollout).

- Migrates \`members.insert\` to call \`runMutation\`. Body retains only \`Accounts.createUserAsync\` (not a Collection write — stays bespoke per the rule-of-three doctrine).
- **Deletes the legacy \`try/catch\` antipattern** that was clobbering the original \`Meteor.Error\` code into the message position. After this, \`error.error === 'original-code'\` reaches the caller intact.
- Adds \`redact\` support to the wrapper: when \`auditShape: 'insert'\` and the descriptor passes a \`redact\` list, named top-level keys are stripped from the standard audit payload before logging.
- Adds \`redact: { insert: ['password'] }\` to the \`members\` entry in \`COLLECTION_REGISTRY\` — passwords cannot flow into \`members.created\` audit entries even if the audit shape widens later.

## Test plan

- [x] \`npm test\` — **180 passing** (178 baseline + 2 new regression tests)
- [x] **Error-code propagation test**: monkey-patches \`Accounts.createUserAsync\` to throw \`new Meteor.Error('test-original-code', 'test-original-message')\`; asserts caller sees \`error.error === 'test-original-code'\` (would fail before — legacy antipattern collapsed message into code)
- [x] **Redact test**: invokes \`members.insert\` with \`{ username, password, profile }\`; asserts the resulting \`members.created\` audit log has \`payload.password === undefined\` while \`payload.username\` and \`payload.id\` remain intact

## Out of scope

- Pre-mutation transforms, post-mutation hooks, mutate-step substitution, conditional permission predicates — explicitly deferred per #100 acceptance criteria
- The next link in the chain (\`members.update\` migration) is #101 and adds a \`permissionOverride\` callback to the wrapper for the conditional \`specOnly\` rule