### PR TITLE
refactor(server): migrate members.update to mutation-pipeline (#101)

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -11,7 +11,7 @@ import RanksCollection from '../../imports/api/collections/ranks.collection';
 import RolesCollection from '../../imports/api/collections/roles.collection';
 import SpecializationsCollection from '../../imports/api/collections/specializations.collection';
 import SquadsCollection from '../../imports/api/collections/squads.collection';
-import { validateObject, validatePublish, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
+import { validateObject, validatePublish, validateString, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
 import { createLog } from './logs.server';
 import { runMutation } from '../mutation-pipeline';
 import { COLLECTION_REGISTRY } from '../collection-registry';
@@ -84,36 +84,44 @@ if (Meteor.isServer) {
       );
     },
     'members.update': async function (memberId: string = '', data: Record<string, unknown> = {}) {
-      validateUserId(this.userId);
-      const targetMember = await getMemberById(memberId);
-
-      const hasPermission = await checkPermission(this.userId, 'members', 'update');
-      if (!hasPermission) {
-        const isSpecOnly = data['profile.specializationIds'] && Object.keys(data).length === 1;
-        const canManageSpecs = isSpecOnly && (await checkSpecialPermission(this.userId, 'canManageSpecializations'));
-        if (!canManageSpecs) throw new Meteor.Error(403, 'Permission denied');
-      }
-
-      const role = await getUserRole(this.userId);
-      if (!isOfficerOrAdmin(role)) {
-        const viewer = await MembersCollection.findOneAsync(this.userId);
-        if (viewer?.profile?.squadId && targetMember?.profile?.squadId !== viewer.profile.squadId) {
-          throw new Meteor.Error(403, 'Cannot update members outside your squad');
-        }
-      }
-
-      const selector = { _id: memberId };
-      const modifier = { $set: data };
-      try {
-        const result = await MembersCollection.updateAsync(selector as never, modifier as never);
-        await createLog('members.updated', {
-          id: memberId,
-          changes: data,
-        });
-        return result;
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      const callerUserId = this.userId;
+      return runMutation(
+        { userId: callerUserId },
+        {
+          collection: 'members',
+          operation: 'update',
+          action: 'members.updated',
+          auditShape: 'update',
+          permissionModule: 'members',
+          validate: ([id, d]) => {
+            validateString(id, false);
+            validateObject(d, false);
+          },
+          permissionOverride: async (ctx, [, d]) => {
+            // specOnly + canManageSpecializations: a non-update-permitted caller
+            // may still mutate `profile.specializationIds` alone. 1-site rule —
+            // stays as a callback per the rule of three.
+            const changes = d as Record<string, unknown>;
+            const isSpecOnly = changes['profile.specializationIds'] && Object.keys(changes).length === 1;
+            if (!isSpecOnly) return false;
+            return checkSpecialPermission(ctx.userId, 'canManageSpecializations');
+          },
+        },
+        [memberId, data] as const,
+        async ([targetId, changes]) => {
+          // Existence check + squad-scope reject stay as code in the body — both
+          // are 1-site variations and out of scope for the registry.
+          const targetMember = await getMemberById(targetId);
+          const role = await getUserRole(callerUserId);
+          if (!isOfficerOrAdmin(role)) {
+            const viewer = await MembersCollection.findOneAsync(callerUserId);
+            if (viewer?.profile?.squadId && targetMember?.profile?.squadId !== viewer.profile.squadId) {
+              throw new Meteor.Error(403, 'Cannot update members outside your squad');
+            }
+          }
+          return MembersCollection.updateAsync({ _id: targetId } as never, { $set: changes } as never);
+        },
+      );
     },
     'members.remove': async function (memberId: string = '') {
       validateUserId(this.userId);

--- a/server/mutation-pipeline.ts
+++ b/server/mutation-pipeline.ts
@@ -23,6 +23,12 @@ export interface MutationDescriptor<TArgs extends readonly unknown[], TResult> {
   readonly allowAnonymous?: boolean;
   readonly permissionModule?: string | null;
   readonly fallbackFlag?: string | null;
+  // Conditional re-admit when the main permission check (and any unconditional
+  // fallbackFlag) has denied the call. Receives the same ctx + args the body
+  // will see, returns true to allow. The escape hatch for variations that
+  // depend on the data being mutated (rule of three: stays as a callback
+  // until 3+ collections need it).
+  readonly permissionOverride?: (ctx: MutationContext, args: TArgs) => Promise<boolean>;
   readonly validate?: (args: TArgs) => void;
 }
 
@@ -107,8 +113,13 @@ export async function runMutation<TArgs extends readonly unknown[], TResult>(
       const flag = descriptor.fallbackFlag;
       const hasSpecial = flag ? await checkSpecialPermission(ctx.userId, flag) : false;
       if (!hasSpecial) {
-        await emitDenial(ctx, descriptor, args);
-        throw new Meteor.Error(403, 'Permission denied');
+        const overrideAllowed = descriptor.permissionOverride
+          ? await descriptor.permissionOverride(ctx, args)
+          : false;
+        if (!overrideAllowed) {
+          await emitDenial(ctx, descriptor, args);
+          throw new Meteor.Error(403, 'Permission denied');
+        }
       }
     }
   }

--- a/tests/server/membersMethods.test.ts
+++ b/tests/server/membersMethods.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import LogsCollection from '../../imports/api/collections/logs.collection';
+import MembersCollection from '../../imports/api/collections/members.collection';
 import {
   assertRejectsWithCode,
   callAs,
@@ -67,5 +68,38 @@ describe('members.insert — migrated to mutation-pipeline (#100)', () => {
     // Cleanup the user we just created (cleanupFixtures only catches test-prefixed _ids,
     // but Accounts.createUserAsync generates its own id — remove explicitly).
     await Meteor.users.removeAsync({ _id: insertedId });
+  });
+});
+
+describe('members.update — migrated to mutation-pipeline (#101)', () => {
+  let adminUserId: string;
+  let targetUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ roles: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+    targetUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('body error from MembersCollection.updateAsync propagates with original Meteor.Error code intact', async () => {
+    // Targets the legacy `try { ... updateAsync ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper specifically — the antipattern only obscured errors thrown inside that block.
+    const originalUpdate = MembersCollection.updateAsync.bind(MembersCollection);
+    (MembersCollection as unknown as { updateAsync: unknown }).updateAsync = async () => {
+      throw new Meteor.Error('test-update-code', 'test-update-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () =>
+          callAs(adminUserId, 'members.update', targetUserId, { 'profile.description': 'probe' }),
+        'test-update-code',
+      );
+    } finally {
+      (MembersCollection as unknown as { updateAsync: typeof originalUpdate }).updateAsync = originalUpdate;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #101 (PR 4 of the [#97](https://github.com/sentinel-web/community-manager/issues/97) rollout).

- Migrates \`members.update\` to call \`runMutation\`. Standard preamble (auth, validation, baseline permission) moves to the wrapper.
- **Adds \`permissionOverride\` to the descriptor** — an async \`(ctx, args) => boolean\` callback that re-admits a denied permission check. Used here to preserve the conditional rule: *a non-update-permitted caller may still mutate \`profile.specializationIds\` alone if they hold \`canManageSpecializations\`*. Per the rule of three, this stays as a callback (1 site) rather than a registry field.
- **Squad-scope check stays as code in the body** — officer-or-admin bypass; otherwise reject cross-squad targets. Body also retains the existence check via \`getMemberById\`. Both are 1-site variations explicitly out of scope for the registry per #101.
- **Deletes the legacy \`try/catch\` antipattern** wrapping \`updateAsync\`. After this, body errors propagate with \`error.error\` intact.

## Test plan

- [x] \`npm test\` — **181 passing** (180 baseline + 1 new regression test)
- [x] **Error-code propagation test**: monkey-patches \`MembersCollection.updateAsync\` to throw \`new Meteor.Error('test-update-code', '...')\`; asserts caller sees \`error.error === 'test-update-code'\` (would fail before — legacy antipattern collapsed message into code)

## Out of scope

- Promoting \`specOnly\` or squad-scope to registry fields — both still 1-site
- The next link is #102 (\`members.remove\`), which is the simplest of the three migrations and adds no wrapper vocabulary