### PR TITLE
refactor(server): migrate members.remove to mutation-pipeline (#102)

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -124,19 +124,24 @@ if (Meteor.isServer) {
       );
     },
     'members.remove': async function (memberId: string = '') {
-      validateUserId(this.userId);
-      await getMemberById(memberId);
-
-      const hasPermission = await checkPermission(this.userId, 'members', 'delete');
-      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-
-      try {
-        const result = await MembersCollection.removeAsync({ _id: memberId } as never);
-        await createLog('members.deleted', { id: memberId });
-        return result;
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      return runMutation(
+        { userId: this.userId },
+        {
+          collection: 'members',
+          operation: 'delete',
+          action: 'members.deleted',
+          auditShape: 'remove',
+          permissionModule: 'members',
+          validate: ([id]) => validateString(id, false),
+        },
+        [memberId] as const,
+        async ([targetId]) => {
+          // Existence check stays as code in the body (1-site variation;
+          // not promoted to a registry field per the rule of three).
+          await getMemberById(targetId);
+          return MembersCollection.removeAsync({ _id: targetId } as never);
+        },
+      );
     },
     'members.saveTaskFilter': async function (filter: Record<string, unknown> = {}) {
       if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');

--- a/tests/server/membersMethods.test.ts
+++ b/tests/server/membersMethods.test.ts
@@ -103,3 +103,33 @@ describe('members.update — migrated to mutation-pipeline (#101)', () => {
     }
   });
 });
+
+describe('members.remove — migrated to mutation-pipeline (#102)', () => {
+  let adminUserId: string;
+  let targetUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ roles: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+    targetUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('body error from MembersCollection.removeAsync propagates with original Meteor.Error code intact', async () => {
+    const originalRemove = MembersCollection.removeAsync.bind(MembersCollection);
+    (MembersCollection as unknown as { removeAsync: unknown }).removeAsync = async () => {
+      throw new Meteor.Error('test-remove-code', 'test-remove-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'members.remove', targetUserId),
+        'test-remove-code',
+      );
+    } finally {
+      (MembersCollection as unknown as { removeAsync: typeof originalRemove }).removeAsync = originalRemove;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #102 — the **final link** in the [#97](https://github.com/sentinel-web/community-manager/issues/97) PRD rollout.

- Migrates \`members.remove\` to call \`runMutation\`. Body retains existence check (via \`getMemberById\`) and \`Collection.removeAsync\`.
- **Deletes the legacy \`try/catch\` antipattern**. Body errors propagate with \`error.error\` intact.
- No registry vocabulary additions, no wrapper vocabulary additions — the simplest of the three custom-method migrations.

After this slice, **every mutation in the codebase routes through the same auth → permission → validate → body → audit lifecycle.**

## Test plan

- [x] \`npm test\` — **182 passing**
- [x] **Error-code propagation test**: monkey-patches \`MembersCollection.removeAsync\` to throw \`new Meteor.Error('test-remove-code', '...')\`; asserts caller sees \`error.error === 'test-remove-code'\`

## #97 chain status

| Issue | PR | Status |
|---|---|---|
| #98 wrapper | [#103](https://github.com/sentinel-web/community-manager/pull/103) | Merged |
| #99 registry | [#105](https://github.com/sentinel-web/community-manager/pull/105) | Merged |
| #100 members.insert | [#106](https://github.com/sentinel-web/community-manager/pull/106) | Merged |
| #101 members.update | [#107](https://github.com/sentinel-web/community-manager/pull/107) | Merged |
| #102 members.remove | this PR | ⬅ closes the chain |