### PR TITLE
feat(i18n): add extractParams template-literal helper for LocaleSet

### DIFF
--- a/imports/i18n/extract-params.ts
+++ b/imports/i18n/extract-params.ts
@@ -1,0 +1,15 @@
+export type ExtractParams<S extends string> = {
+  [K in ExtractParamNames<S>]: string | number;
+};
+
+type ExtractParamNames<S extends string> = S extends `${string}{{${infer P}}}${infer Rest}` ? P | ExtractParamNames<Rest> : never;
+
+const PLACEHOLDER_PATTERN = /\{\{(\w+)\}\}/g;
+
+export function extractParams(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of source.matchAll(PLACEHOLDER_PATTERN)) {
+    names.add(match[1]);
+  }
+  return names;
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,7 @@ import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
 import './server/crudMethods.test';
 import './server/getCollection.test';
+import './server/i18n.extractParams.test';
 import './server/membersMethods.test';
 import './server/mutationPipeline.test';
 import './server/permissions.test';

--- a/tests/server/i18n.extractParams.test.ts
+++ b/tests/server/i18n.extractParams.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import { extractParams, type ExtractParams } from '../../imports/i18n/extract-params';
+
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type _NoPlaceholders = Expect<Equal<ExtractParams<'plain text'>, {}>>;
+type _Empty = Expect<Equal<ExtractParams<''>, {}>>;
+type _Single = Expect<Equal<ExtractParams<'Hello {{name}}'>, { name: string | number }>>;
+type _Multiple = Expect<Equal<ExtractParams<'{{a}} and {{b}}'>, { a: string | number; b: string | number }>>;
+type _Duplicates = Expect<Equal<ExtractParams<'{{a}} {{a}}'>, { a: string | number }>>;
+type _LeadingTrailing = Expect<Equal<ExtractParams<'{{first}} middle {{last}}'>, { first: string | number; last: string | number }>>;
+
+describe('extractParams', () => {
+  it('returns an empty set for an empty string', () => {
+    assert.deepEqual([...extractParams('')], []);
+  });
+
+  it('returns an empty set when there are no placeholders', () => {
+    assert.deepEqual([...extractParams('Hello world')], []);
+  });
+
+  it('extracts a single placeholder', () => {
+    assert.deepEqual([...extractParams('Hello {{name}}')], ['name']);
+  });
+
+  it('extracts multiple placeholders preserving order of first occurrence', () => {
+    assert.deepEqual([...extractParams('{{a}} and {{b}}')], ['a', 'b']);
+  });
+
+  it('collapses duplicate placeholders into a single entry', () => {
+    assert.deepEqual([...extractParams('{{a}} {{a}} {{a}}')], ['a']);
+  });
+
+  it('handles placeholders at the start and end of the string', () => {
+    assert.deepEqual([...extractParams('{{first}} middle {{last}}')], ['first', 'last']);
+  });
+
+  it('ignores malformed placeholders', () => {
+    assert.deepEqual([...extractParams('{name} and {{ }} and {{!@#}}')], []);
+  });
+
+  it('returns a Set (not an array) so callers can compare via deepEqual', () => {
+    const result = extractParams('{{a}}');
+    assert.ok(result instanceof Set);
+  });
+});

--- a/tests/server/i18n.extractParams.test.ts
+++ b/tests/server/i18n.extractParams.test.ts
@@ -37,7 +37,7 @@ describe('extractParams', () => {
   });
 
   it('ignores malformed placeholders', () => {
-    assert.deepEqual([...extractParams('{name} and {{ }} and {{!@#}}')], []);
+    assert.deepEqual([...extractParams('{name} and {{ }} and {{!@#}} and {{}}')], []);
   });
 
   it('returns a Set (not an array) so callers can compare via deepEqual', () => {


### PR DESCRIPTION
Closes #109. First slice of the LocaleSet deepening (CONTEXT.md → "LocaleSet").

## Summary

Adds the foundational primitive that the future typed `t<K>()` will use to derive per-call param shapes from English locale strings:

- `imports/i18n/extract-params.ts` exports `ExtractParams<S>` (recursive template-literal type) and `extractParams(s: string): Set<string>` (runtime counterpart)
- Type-level tests via the standard `Expect<Equal<X, Y>>` pattern verify the template-literal extraction across empty/single/multiple/duplicate placeholder cases
- Runtime tests cover empty input, no placeholders, single, multiple, duplicates, leading/trailing, malformed input, and the `Set` return type

Nothing in the codebase imports the helper yet — pure addition. Behavior unchanged across all 138 `useTranslation()` call sites. The cutover happens in #111 once the codemod (#110) lands.

## Test plan

- [x] `npm test` — 190 passing (was 182; +8 extractParams tests)
- [x] Type-level assertions compile clean (any failed `Expect<Equal<>>` would break tsc)
- [x] No existing imports change; no behavior change

## Blocked by

None.

## Blocks

- #111 (cutover)