### PR TITLE
fix(members): assert non-null callerUserId in squad-scope check

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -114,7 +114,7 @@ if (Meteor.isServer) {
           const targetMember = await getMemberById(targetId);
           const role = await getUserRole(callerUserId);
           if (!isOfficerOrAdmin(role)) {
-            const viewer = await MembersCollection.findOneAsync(callerUserId);
+            const viewer = await MembersCollection.findOneAsync(callerUserId!);
             if (viewer?.profile?.squadId && targetMember?.profile?.squadId !== viewer.profile.squadId) {
               throw new Meteor.Error(403, 'Cannot update members outside your squad');
             }


### PR DESCRIPTION
Closes #118.

## Summary

`MembersCollection.findOneAsync(callerUserId)` at `server/apis/members.server.ts:117` was a TS2769: `callerUserId` is typed `string | null`, but the runtime is provably safe — by the time the body executes, `runMutation`'s auth gate has rejected null `userId` (members does not opt into `allowsAnonymous`). The type system can't see the guarantee because it crosses the runMutation seam.

Fix: a non-null assertion at the call site (`callerUserId!`), matching the project's documented pattern from CLAUDE.md ("use `!` non-null assertion to preserve original behavior").

Considered alternatives:
- Local narrow at body entry (`const userId = callerUserId!;` followed by replacing all uses) — wider diff, no behavioral benefit since the `!` assertion is the same fence
- Plumb the validated `userId` through `runMutation`'s ctx callback — touches the wrapper signature, deserves its own design conversation against #97/CONTEXT.md, out of scope here

The single-character fix is the minimum surface area that resolves the typecheck error without changing observable behavior.

## Test plan

- [x] `npm run typecheck` — only the createTestRole error from #119 remains
- [x] `npm test` — 182 passing (baseline)
- [x] Squad-scope reject path is structurally unchanged (same `if (!isOfficerOrAdmin) → findOneAsync → squadId compare → throw 403`)

## Blocked by

None.