### PR TITLE
test(fixtures): widen createTestRole to accept synthetic test flags

### DIFF
--- a/tests/server/fixtures.ts
+++ b/tests/server/fixtures.ts
@@ -17,7 +17,7 @@ function prefixedId(): string {
   return `${TEST_PREFIX}${Random.id()}`;
 }
 
-export async function createTestRole(permissions: Partial<Role> = {}): Promise<string> {
+export async function createTestRole(permissions: Partial<Role> & Record<string, unknown> = {}): Promise<string> {
   const _id = prefixedId();
   await RolesCollection.insertAsync({ _id, name: `Test Role ${_id}`, ...permissions });
   return _id;


### PR DESCRIPTION
Closes #119.

## Summary

The pipeline test "unconditional fallback flag permits an op when the main permission is denied" deliberately uses a synthetic flag name (\`__testFallbackFlag\`) so the test isolates from the real \`Role\` schema's fallback flags (e.g. \`canCreateEvents\`). This is the right design intent — the test exercises pipeline mechanics, not real-world flags. But \`createTestRole\`'s parameter type \`Partial<Role>\` rejected the synthetic key with TS2353.

Fix: widen the parameter to \`Partial<Role> & Record<string, unknown>\`. The intersection:

- Preserves typed-key autocomplete on real \`Role\` fields (current call sites in \`crudMethods.test.ts\`, \`membersMethods.test.ts\`, \`mutationPipeline.test.ts\` continue to get IntelliSense on \`roles\`, \`medals\`, etc.)
- Permits string-keyed extensions like \`__testFallbackFlag\` for synthetic test flags
- Mirrors the existing fixture pattern (\`createTestDoc\` already uses \`Record<string, unknown>\` for the same fixture-flexibility reason)

The test does not need a code change — only the fixture's signature.

Considered alternatives:
- Add a typed escape hatch (\`& { __testFallbackFlag?: boolean }\`) — would require updating the helper every time a new synthetic flag appears
- Promote \`__test*\` to the real \`Role\` schema — pollutes production types with test-only fields

The intersection approach has the lowest churn and zero production-schema cost.

## Test plan

- [x] \`npm run typecheck\` — only the members.server.ts error from #118 remains (fixed on PR #120)
- [x] \`npm test\` — 182 passing (baseline)
- [x] All 11 existing \`createTestRole\` call sites still typecheck (verified by tsc)

## Blocked by

None. Independent of #118/#120 (different file, different fix). Both must land for \`npm run typecheck\` to be clean on \`main\`.