### PR TITLE
feat(i18n): cut runtime over to typed t<K>() backed by translations.ts

### DIFF
--- a/imports/i18n/LanguageContext.tsx
+++ b/imports/i18n/LanguageContext.tsx
@@ -44,6 +44,8 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     }
   }, [language]);
 
+  // useMemo (not useCallback) preserves the generic <K extends LocaleKey> signature —
+  // useCallback's type inference erases function generics into their constraint.
   const t = useMemo<LanguageContextValue['t']>(
     () =>
       function t<K extends LocaleKey>(key: K, ...args: ParamArgs<K>): string {

--- a/imports/i18n/LanguageContext.tsx
+++ b/imports/i18n/LanguageContext.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
-import { locales, defaultLocale, getTranslation, type Locale, type LocaleInfo, type TranslationParams } from './index';
+import { locales, defaultLocale, getTranslation, translateDynamic, type Locale, type LocaleInfo, type LocaleKey, type ParamArgs } from './index';
 
 const STORAGE_KEY = 'community-manager-language';
 
 export interface LanguageContextValue {
   language: Locale;
   setLanguage: (lang: Locale) => void;
-  t: (key: string, params?: TranslationParams) => string;
+  t: <K extends LocaleKey>(key: K, ...args: ParamArgs<K>) => string;
+  tDynamic: (key: string, params?: Record<string, string | number>) => string;
   locales: Record<Locale, LocaleInfo>;
 }
 
@@ -43,13 +44,17 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     }
   }, [language]);
 
-  const translations = useMemo(() => locales[language]?.translations || locales[defaultLocale].translations, [language]);
+  const t = useMemo<LanguageContextValue['t']>(
+    () =>
+      function t<K extends LocaleKey>(key: K, ...args: ParamArgs<K>): string {
+        return getTranslation(key, language, ...args);
+      },
+    [language],
+  );
 
-  const t = useCallback(
-    (key: string, params: TranslationParams = {}) => {
-      return getTranslation(translations, key, params);
-    },
-    [translations],
+  const tDynamic = useCallback<LanguageContextValue['tDynamic']>(
+    (key, params) => translateDynamic(key, language, params),
+    [language],
   );
 
   const value: LanguageContextValue = useMemo(
@@ -57,9 +62,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
       language,
       setLanguage,
       t,
+      tDynamic,
       locales,
     }),
-    [language, setLanguage, t],
+    [language, setLanguage, t, tDynamic],
   );
 
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
@@ -73,9 +79,9 @@ export function useLanguage(): LanguageContextValue {
   return context;
 }
 
-export function useTranslation(): { t: LanguageContextValue['t'] } {
-  const { t } = useLanguage();
-  return { t };
+export function useTranslation(): { t: LanguageContextValue['t']; tDynamic: LanguageContextValue['tDynamic'] } {
+  const { t, tDynamic } = useLanguage();
+  return { t, tDynamic };
 }
 
 export default LanguageContext;

--- a/imports/i18n/index.ts
+++ b/imports/i18n/index.ts
@@ -1,46 +1,49 @@
-import en from './locales/en.json';
-import de from './locales/de.json';
-import fr from './locales/fr.json';
+import { translations, type Locale } from './translations';
+import type { ExtractParams } from './extract-params';
 
-export type Locale = 'en' | 'de' | 'fr';
+export type { Locale, TranslationSet } from './translations';
+export { translations };
 
-export interface TranslationTree {
-  [key: string]: string | TranslationTree;
-}
+export type LocaleKey = keyof typeof translations;
+
+export type ParamArgs<K extends LocaleKey> = keyof ExtractParams<(typeof translations)[K]['en']> extends never
+  ? []
+  : [params: ExtractParams<(typeof translations)[K]['en']>];
 
 export interface LocaleInfo {
   name: string;
   flag: string;
-  translations: TranslationTree;
 }
 
 export const locales: Record<Locale, LocaleInfo> = {
-  en: { name: 'English', flag: '🇬🇧', translations: en as TranslationTree },
-  de: { name: 'Deutsch', flag: '🇩🇪', translations: de as TranslationTree },
-  fr: { name: 'Français', flag: '🇫🇷', translations: fr as TranslationTree },
+  en: { name: 'English', flag: '🇬🇧' },
+  de: { name: 'Deutsch', flag: '🇩🇪' },
+  fr: { name: 'Français', flag: '🇫🇷' },
 };
 
 export const defaultLocale: Locale = 'en';
 
-export type TranslationParams = Record<string, string | number>;
+const PLACEHOLDER_PATTERN = /\{\{(\w+)\}\}/g;
 
-export function getTranslation(translations: TranslationTree, key: string, params: TranslationParams = {}): string {
-  const keys = key.split('.');
-  let value: string | TranslationTree | undefined = translations;
+function interpolate(template: string, params: Record<string, string | number>): string {
+  return template.replace(PLACEHOLDER_PATTERN, (_, name: string) =>
+    params[name] !== undefined ? String(params[name]) : `{{${name}}}`,
+  );
+}
 
-  for (const k of keys) {
-    if (value && typeof value === 'object' && k in value) {
-      value = (value as TranslationTree)[k];
-    } else {
-      return key;
-    }
-  }
+export function getTranslation<K extends LocaleKey>(key: K, locale: Locale, ...args: ParamArgs<K>): string {
+  const value = translations[key][locale];
+  const params = (args[0] ?? {}) as Record<string, string | number>;
+  return interpolate(value, params);
+}
 
-  if (typeof value !== 'string') {
-    return key;
-  }
-
-  return value.replace(/\{\{(\w+)\}\}/g, (_, param: string) => {
-    return params[param] !== undefined ? String(params[param]) : `{{${param}}}`;
-  });
+// Escape hatch for sites that compute the key dynamically (e.g. `collections.${name}`).
+// Returns the key string verbatim if it isn't in the unified source — preserves the
+// pre-cutover defensive behavior at sites that can't statically prove their key set.
+// Prefer `getTranslation` (or the typed `t` from useTranslation) wherever the key is
+// known statically.
+export function translateDynamic(key: string, locale: Locale, params: Record<string, string | number> = {}): string {
+  const entry = (translations as Record<string, Record<Locale, string> | undefined>)[key];
+  if (!entry) return key;
+  return interpolate(entry[locale], params);
 }

--- a/imports/ui/backup/Backup.tsx
+++ b/imports/ui/backup/Backup.tsx
@@ -52,7 +52,7 @@ export default function Backup() {
   const [restoring, setRestoring] = useState(false);
   const [createSafetyBackup, setCreateSafetyBackup] = useState(true);
   const [safetyBackupData, setSafetyBackupData] = useState<BackupData | null>(null);
-  const { t } = useTranslation();
+  const { t, tDynamic } = useTranslation();
 
   const handleBackup = useCallback(async () => {
     setLoading(true);
@@ -232,6 +232,7 @@ export default function Backup() {
         onConfirm={handleRestore}
         onCancel={handleCancelRestore}
         t={t}
+        tDynamic={tDynamic}
       />
 
       <SafetyBackupModal
@@ -317,9 +318,10 @@ interface RestoreConfirmModalProps {
   onConfirm: () => void;
   onCancel: () => void;
   t: LanguageContextValue['t'];
+  tDynamic: LanguageContextValue['tDynamic'];
 }
 
-function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel, t }: RestoreConfirmModalProps) {
+function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel, t, tDynamic }: RestoreConfirmModalProps) {
   return (
     <Modal
       title={
@@ -367,7 +369,7 @@ function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBa
             <Typography.Title level={5}>{t('backup.collectionCounts')}</Typography.Title>
             <Descriptions bordered size="small" column={2}>
               {Object.entries(validationResult.meta.collectionCounts).map(([name, count]) => (
-                <Descriptions.Item key={name} label={t(`collections.${name}`) || name}>
+                <Descriptions.Item key={name} label={tDynamic(`collections.${name}`)}>
                   {count}
                 </Descriptions.Item>
               ))}

--- a/imports/ui/backup/Backup.tsx
+++ b/imports/ui/backup/Backup.tsx
@@ -6,7 +6,6 @@ import dayjs from 'dayjs';
 import JSZip from 'jszip';
 import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useState } from 'react';
-import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import { useTranslation } from '../../i18n/LanguageContext';
 import SectionCard from '../section/SectionCard';
 import { useTourRef } from '../tour/TourContext';
@@ -52,7 +51,7 @@ export default function Backup() {
   const [restoring, setRestoring] = useState(false);
   const [createSafetyBackup, setCreateSafetyBackup] = useState(true);
   const [safetyBackupData, setSafetyBackupData] = useState<BackupData | null>(null);
-  const { t, tDynamic } = useTranslation();
+  const { t } = useTranslation();
 
   const handleBackup = useCallback(async () => {
     setLoading(true);
@@ -215,10 +214,10 @@ export default function Backup() {
       <SectionCard title={t('backup.title')} ready={true}>
         <Row gutter={[24, 24]}>
           <Col xs={24} lg={12}>
-            <BackupSection loading={loading} onBackup={handleBackup} t={t} />
+            <BackupSection loading={loading} onBackup={handleBackup} />
           </Col>
           <Col xs={24} lg={12}>
-            <RestoreSection onFileUpload={handleFileUpload} t={t} />
+            <RestoreSection onFileUpload={handleFileUpload} />
           </Col>
         </Row>
       </SectionCard>
@@ -231,15 +230,12 @@ export default function Backup() {
         onCreateSafetyBackupChange={setCreateSafetyBackup}
         onConfirm={handleRestore}
         onCancel={handleCancelRestore}
-        t={t}
-        tDynamic={tDynamic}
       />
 
       <SafetyBackupModal
         open={!!safetyBackupData}
         onDownload={handleDownloadSafetyBackup}
         onClose={handleCloseSafetyBackupModal}
-        t={t}
       />
     </div>
   );
@@ -248,10 +244,10 @@ export default function Backup() {
 interface BackupSectionProps {
   loading: boolean;
   onBackup: () => void;
-  t: LanguageContextValue['t'];
 }
 
-function BackupSection({ loading, onBackup, t }: BackupSectionProps) {
+function BackupSection({ loading, onBackup }: BackupSectionProps) {
+  const { t } = useTranslation();
   return (
     <Row gutter={[16, 16]}>
       <Col span={24}>
@@ -273,10 +269,10 @@ function BackupSection({ loading, onBackup, t }: BackupSectionProps) {
 
 interface RestoreSectionProps {
   onFileUpload: (file: RcFile) => Promise<false | undefined>;
-  t: LanguageContextValue['t'];
 }
 
-function RestoreSection({ onFileUpload, t }: RestoreSectionProps) {
+function RestoreSection({ onFileUpload }: RestoreSectionProps) {
+  const { t } = useTranslation();
   return (
     <Row gutter={[16, 16]}>
       <Col span={24}>
@@ -317,11 +313,10 @@ interface RestoreConfirmModalProps {
   onCreateSafetyBackupChange: (checked: boolean) => void;
   onConfirm: () => void;
   onCancel: () => void;
-  t: LanguageContextValue['t'];
-  tDynamic: LanguageContextValue['tDynamic'];
 }
 
-function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel, t, tDynamic }: RestoreConfirmModalProps) {
+function RestoreConfirmModal({ open, validationResult, restoring, createSafetyBackup, onCreateSafetyBackupChange, onConfirm, onCancel }: RestoreConfirmModalProps) {
+  const { t, tDynamic } = useTranslation();
   return (
     <Modal
       title={
@@ -391,10 +386,10 @@ interface SafetyBackupModalProps {
   open: boolean;
   onDownload: () => void;
   onClose: () => void;
-  t: LanguageContextValue['t'];
 }
 
-function SafetyBackupModal({ open, onDownload, onClose, t }: SafetyBackupModalProps) {
+function SafetyBackupModal({ open, onDownload, onClose }: SafetyBackupModalProps) {
+  const { t } = useTranslation();
   return (
     <Modal
       title={

--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { App, Button, Card, Col, Collapse, Descriptions, Row, Statistic, Tag, Typography } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { useTourRef } from '../tour/TourContext';
 

--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ export default function Dashboard() {
   const { message } = App.useApp();
   const [stats, setStats] = useState<DashboardStats>({});
   const [loading, setLoading] = useState(false);
-  const { t } = useTranslation();
+  const { t, tDynamic } = useTranslation();
   const statsRef = useTourRef('dashboard-stats');
   const fetchStats = useCallback(function () {
     setLoading(true);
@@ -79,7 +79,7 @@ export default function Dashboard() {
           {
             key: '1',
             label: t('dashboard.yourProfile'),
-            children: <ProfileStats profileStats={stats.profile} t={t} />,
+            children: <ProfileStats profileStats={stats.profile} />,
           },
           {
             key: '2',
@@ -89,7 +89,7 @@ export default function Dashboard() {
                 {Object.entries(stats)
                   .filter(([key]) => key !== 'profile')
                   .map(([key, value]) => {
-                    const translateStatKey = (k: string) => t(`dashboard.stats.${k}`) || k;
+                    const translateStatKey = (k: string) => tDynamic(`dashboard.stats.${k}`);
                     return typeof value === 'object' ? (
                       Object.keys(value as Record<string, number>).map(childKey => (
                         <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
@@ -118,17 +118,14 @@ export default function Dashboard() {
 
 interface ProfileStatsProps {
   profileStats?: ProfileStatsData;
-  t: LanguageContextValue['t'];
 }
 
-export function ProfileStats({ profileStats, t }: ProfileStatsProps) {
+export function ProfileStats({ profileStats }: ProfileStatsProps) {
+  const { tDynamic } = useTranslation();
   const fullWidthKeys = useMemo(() => ['description', 'specializations', 'medals'], []);
   const oneThirdWidthKeys = useMemo(() => ['rank', 'id', 'name', 'entry date', 'squad', 'role', 'attendance points', 'inactivity points'], []);
 
-  const translateLabel = useCallback(
-    (key: string) => (t ? t(`dashboard.profileLabels.${key}`) : key),
-    [t]
-  );
+  const translateLabel = useCallback((key: string) => tDynamic(`dashboard.profileLabels.${key}`), [tDynamic]);
 
   return (
     <Row gutter={[16, 16]} justify="center" align="middle">

--- a/imports/ui/events/event-types/eventTypes.columns.tsx
+++ b/imports/ui/events/event-types/eventTypes.columns.tsx
@@ -9,7 +9,7 @@ const getEventTypeColumns = (
   handleEdit: (e: RowClickEvent, record: EventType) => void,
   handleDelete: (e: RowClickEvent, record: EventType) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TranslateFn = k => k
+  t: TranslateFn,
 ): ColumnsType<EventType> => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/events/event.columns.tsx
+++ b/imports/ui/events/event.columns.tsx
@@ -8,7 +8,7 @@ const getEventColumns = (
   handleEdit: (e: RowClickEvent, record: EventDoc) => void,
   handleDelete: (e: RowClickEvent, record: EventDoc) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TranslateFn = k => k
+  t: TranslateFn,
 ): ColumnsType<EventDoc> => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/logs/logs.columns.tsx
+++ b/imports/ui/logs/logs.columns.tsx
@@ -18,7 +18,7 @@ type TFn = LanguageContextValue['t'];
 const getLogsColumns = (
   handleView: (e: React.MouseEvent<HTMLElement>, record: LogEntry) => void,
   handleDelete: (e: React.MouseEvent<HTMLElement>, record: LogEntry) => void,
-  t: TFn = k => k
+  t: TFn,
 ): ColumnsType<LogEntry> => {
   return [
     {

--- a/imports/ui/members/ProfileModal.tsx
+++ b/imports/ui/members/ProfileModal.tsx
@@ -19,7 +19,7 @@ export default function ProfileModal({ showProfile = false, toggleProfile = () =
 
   return (
     <Modal title={t('modals.profile')} open={showProfile} onCancel={toggleProfile} width={getModalWidth(window.innerWidth)} footer={null} centered>
-      {profileStats && <ProfileStats profileStats={profileStats} t={t} />}
+      {profileStats && <ProfileStats profileStats={profileStats} />}
     </Modal>
   );
 }

--- a/imports/ui/members/roles/RolesForm.tsx
+++ b/imports/ui/members/roles/RolesForm.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { TranslateFn } from '../../section/types';
+import type { LocaleKey } from '/imports/i18n';
 import type { CrudPermission, Role } from '../../../api/types/role';
 import { DrawerContext } from '../../app/App';
 import type { DrawerContextValue } from '../../app/types';
@@ -25,13 +26,10 @@ interface CrudPermissionInputProps {
   t: TranslateFn;
 }
 
-interface CrudModuleEntry {
-  name: string;
-  labelKey: string;
-}
-
-// Modules that use CRUD permissions - label keys reference navigation translations
-const CRUD_MODULES: CrudModuleEntry[] = [
+// Modules that use CRUD permissions - label keys reference navigation translations.
+// `as const satisfies` preserves the literal union of labelKey values so t(labelKey)
+// resolves to a paramless LocaleKey rather than the full LocaleKey union.
+const CRUD_MODULES = [
   { name: 'members', labelKey: 'navigation.members' },
   { name: 'events', labelKey: 'navigation.events' },
   { name: 'tasks', labelKey: 'navigation.tasks' },
@@ -46,7 +44,7 @@ const CRUD_MODULES: CrudModuleEntry[] = [
   { name: 'roles', labelKey: 'navigation.roles' },
   { name: 'questionnaires', labelKey: 'navigation.questionnaires' },
   { name: 'positions', labelKey: 'navigation.positions' },
-];
+] as const satisfies readonly { name: string; labelKey: LocaleKey }[];
 
 /**
  * Normalizes permission value for form initial values.

--- a/imports/ui/questionnaires/questionnaire.columns.tsx
+++ b/imports/ui/questionnaires/questionnaire.columns.tsx
@@ -2,6 +2,7 @@ import { Button, Col, Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import React from 'react';
 import type { Questionnaire } from '../../api/types/questionnaire';
+import type { LocaleKey } from '/imports/i18n';
 import type { RowClickEvent, SectionPermissions, TranslateFn } from '../section/types';
 import TableActions from '../table/body/actions/TableActions';
 
@@ -10,6 +11,14 @@ const STATUS_COLORS: Record<string, string> = {
   active: 'success',
   closed: 'error',
 };
+
+// `as const satisfies` preserves the literal union so t(STATUS_LABEL_KEYS[status])
+// resolves to a paramless LocaleKey rather than the full LocaleKey union.
+const STATUS_LABEL_KEYS = {
+  draft: 'questionnaires.draft',
+  active: 'questionnaires.active',
+  closed: 'questionnaires.closed',
+} as const satisfies Record<string, LocaleKey>;
 
 interface ViewResponsesExtraProps {
   record: Questionnaire;
@@ -44,7 +53,11 @@ const getQuestionnaireColumns = (
       dataIndex: 'status',
       key: 'status',
       sorter: (a: Questionnaire, b: Questionnaire) => (a.status || '').localeCompare(b.status || ''),
-      render: (status: string) => <Tag color={STATUS_COLORS[status] || 'default'}>{status ? t(`questionnaires.${status}`) : t('questionnaires.draft')}</Tag>,
+      render: (status: string) => (
+        <Tag color={STATUS_COLORS[status] || 'default'}>
+          {t(STATUS_LABEL_KEYS[status as keyof typeof STATUS_LABEL_KEYS] ?? 'questionnaires.draft')}
+        </Tag>
+      ),
     },
     {
       title: t('questionnaires.questions'),

--- a/imports/ui/registration/discovery-types/discoveryTypes.columns.tsx
+++ b/imports/ui/registration/discovery-types/discoveryTypes.columns.tsx
@@ -9,7 +9,7 @@ export default function getDiscoveryTypeColumns(
   handleEdit: (e: RowClickEvent, record: DiscoveryType) => void,
   handleDelete: (e: RowClickEvent, record: DiscoveryType) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TranslateFn = k => k
+  t: TranslateFn,
 ): ColumnsType<DiscoveryType> {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/registration/registration.columns.tsx
+++ b/imports/ui/registration/registration.columns.tsx
@@ -13,7 +13,7 @@ export default function getRegistrationColumns(
   handleEdit: (e: React.MouseEvent<HTMLElement>, record: Registration) => void,
   handleDelete: (e: React.MouseEvent<HTMLElement>, record: Registration) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TFn = k => k,
+  t: TFn,
 ): ColumnsType<Registration> {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/settings/Settings.tsx
+++ b/imports/ui/settings/Settings.tsx
@@ -130,10 +130,10 @@ function SettingTitle({ title }: SettingTitleProps) {
 interface CommunityNameBlackListSettingsProps {
   communityNameBlackList?: string[];
   handleChange?: HandleChangeFn;
-  t?: TFn;
+  t: TFn;
 }
 
-function CommunityNameBlackListSettings({ communityNameBlackList = [], handleChange = () => {}, t = k => k }: CommunityNameBlackListSettingsProps) {
+function CommunityNameBlackListSettings({ communityNameBlackList = [], handleChange = () => {}, t }: CommunityNameBlackListSettingsProps) {
   const [value, setValue] = useState('');
 
   const handleClick = useCallback(() => {
@@ -193,10 +193,10 @@ function CommunityNameBlackListSettings({ communityNameBlackList = [], handleCha
 interface CommunityIdBlackListSettingsProps {
   communityIdBlackList?: string[];
   handleChange?: HandleChangeFn;
-  t?: TFn;
+  t: TFn;
 }
 
-function CommunityIdBlackListSettings({ communityIdBlackList = [], handleChange = () => {}, t = k => k }: CommunityIdBlackListSettingsProps) {
+function CommunityIdBlackListSettings({ communityIdBlackList = [], handleChange = () => {}, t }: CommunityIdBlackListSettingsProps) {
   const [value, setValue] = useState('');
 
   const handleClick = useCallback(() => {
@@ -256,10 +256,10 @@ function CommunityIdBlackListSettings({ communityIdBlackList = [], handleChange 
 interface CommunityTitleSettingsProps {
   communityTitle?: string;
   handleChange?: HandleChangeFn;
-  t?: TFn;
+  t: TFn;
 }
 
-function CommunityTitleSettings({ communityTitle, handleChange = () => {}, t = k => k }: CommunityTitleSettingsProps) {
+function CommunityTitleSettings({ communityTitle, handleChange = () => {}, t }: CommunityTitleSettingsProps) {
   return (
     <Row gutter={[16, 16]}>
       <SettingTitle title={t('settings.communityTitle')} />
@@ -273,10 +273,10 @@ function CommunityTitleSettings({ communityTitle, handleChange = () => {}, t = k
 interface CommunityLogoSettingsProps {
   communityLogo?: string;
   handleChange?: HandleChangeFn;
-  t?: TFn;
+  t: TFn;
 }
 
-function CommunityLogoSettings({ communityLogo, handleChange = () => {}, t = k => k }: CommunityLogoSettingsProps) {
+function CommunityLogoSettings({ communityLogo, handleChange = () => {}, t }: CommunityLogoSettingsProps) {
   return (
     <Row gutter={[16, 16]}>
       <SettingTitle title={t('settings.communityLogo')} />
@@ -298,10 +298,10 @@ function CommunityLogoSettings({ communityLogo, handleChange = () => {}, t = k =
 interface CommunityColorSettingsProps {
   communityColor?: string;
   handleChange?: HandleChangeFn;
-  t?: TFn;
+  t: TFn;
 }
 
-function CommunityColorSettings({ communityColor, handleChange = () => {}, t = k => k }: CommunityColorSettingsProps) {
+function CommunityColorSettings({ communityColor, handleChange = () => {}, t }: CommunityColorSettingsProps) {
   return (
     <Row gutter={[16, 16]}>
       <SettingTitle title={t('settings.communityColor')} />
@@ -313,10 +313,10 @@ function CommunityColorSettings({ communityColor, handleChange = () => {}, t = k
 }
 
 interface DemoDataSettingsProps {
-  t?: TFn;
+  t: TFn;
 }
 
-function DemoDataSettings({ t = k => k }: DemoDataSettingsProps) {
+function DemoDataSettings({ t }: DemoDataSettingsProps) {
   const [loading, setLoading] = useState(false);
 
   const handleGenerate = useCallback(async () => {
@@ -353,10 +353,10 @@ function DemoDataSettings({ t = k => k }: DemoDataSettingsProps) {
 }
 
 interface TourSettingsProps {
-  t?: TFn;
+  t: TFn;
 }
 
-function TourSettings({ t = k => k }: TourSettingsProps) {
+function TourSettings({ t }: TourSettingsProps) {
   const { startTour } = useContext(TourContext);
   const { setNavigationValue } = useNavigation();
 

--- a/imports/ui/specializations/specializations.columns.tsx
+++ b/imports/ui/specializations/specializations.columns.tsx
@@ -53,7 +53,7 @@ const getSpecializationColumns = (
   handleEdit: (e: RowClickEvent, record: Specialization) => void,
   handleDelete: (e: RowClickEvent, record: Specialization) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TFn = k => k
+  t: TFn,
 ): ColumnsType<Specialization> => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/squads/squads.columns.tsx
+++ b/imports/ui/squads/squads.columns.tsx
@@ -41,13 +41,12 @@ export const SquadTags = ({ squadIds }: SquadTagsProps) => {
 };
 
 const defaultPermissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true };
-const defaultT: TranslateFn = k => k;
 
 const getSquadsColumns: ColumnsFactory<Squad> = (
   handleEdit: (e: RowClickEvent, record: Squad) => void,
   handleDelete: (e: RowClickEvent, record: Squad) => void,
   permissions: SectionPermissions = defaultPermissions,
-  t: TranslateFn = defaultT,
+  t: TranslateFn,
 ) => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/tasks/task-status/task-status.columns.tsx
+++ b/imports/ui/tasks/task-status/task-status.columns.tsx
@@ -9,7 +9,7 @@ const getTaskStatusColumns = (
   handleEdit: (e: RowClickEvent, record: TaskStatus) => void,
   handleDelete: (e: RowClickEvent, record: TaskStatus) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TranslateFn = k => k
+  t: TranslateFn,
 ): ColumnsType<TaskStatus> => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/tasks/task.columns.tsx
+++ b/imports/ui/tasks/task.columns.tsx
@@ -37,7 +37,7 @@ export function getTaskColumns(
   handleTaskEdit: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
   handleTaskDelete: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TFn = k => k,
+  t: TFn,
 ): ColumnsType<Task> {
   const { canUpdate = true, canDelete = true } = permissions;
 


### PR DESCRIPTION
Closes #111. The load-bearing LocaleSet migration step.

## Summary

The runtime stops reading `imports/i18n/locales/{en,de,fr}.json` and starts reading the unified `imports/i18n/translations.ts` (committed in #115). The `t()` signature is now typed: `t<K extends LocaleKey>(key: K, ...args: ParamArgs<K>) => string`.

After this lands, three failure modes are structurally eliminated (compile-time):

- **Typo on call site** — `t('comon.create')` is a compile error (LocaleKey union)
- **Missing interpolation params** — `t('common.greeting')` when `en` is `'Hello {{name}}'` is a compile error (ExtractParams<...> requires the param)
- **Missing locale entry per key** — the `{ en, de, fr }` row shape forbids it (already enforced by translations.ts)

## What changed

**Core (2 files)**

- `imports/i18n/index.ts` — drops the three JSON imports, adds `LocaleKey`/`ParamArgs<K>` types, retypes `getTranslation`, exposes `translateDynamic` as an explicit escape hatch for runtime-computed keys.
- `imports/i18n/LanguageContext.tsx` — typed `t<K>()`, added `tDynamic` on the context and via `useTranslation()`.

**Dead-code cleanup (10 files)** — column factories had `t: TranslateFn = k => k` defaults that were dead code (Section always passes `t`). The defaults were broken under the new generic-variadic signature; removing them was simpler than typing them. Files: `events/event*.columns.tsx`, `logs/logs.columns.tsx`, `registration/*.columns.tsx`, `specializations/specializations.columns.tsx`, `squads/squads.columns.tsx`, `tasks/task*.columns.tsx`.

**Settings.tsx subcomponents (1 file, 7 sites)** — same pattern: `t = k => k` defaults removed; props interfaces tightened from `t?: TFn` to `t: TFn` since every actual call site passes it.

**Real call-site bugs surfaced by the typed t (4 files)**

- `Backup.tsx` — `t(\`collections.${name}\`)` → `tDynamic(...)` (legitimate dynamic key)
- `Dashboard.tsx` — two sites: `t(\`dashboard.stats.${k}\`)` and `t(\`dashboard.profileLabels.${key}\`)` both switched to `tDynamic`. ProfileStats refactored to use `useTranslation()` directly instead of taking `t` as a prop.
- `ProfileModal.tsx` — drops the `t={t}` prop on ProfileStats (no longer needed).
- `RolesForm.tsx` — `CRUD_MODULES` typed via `as const satisfies readonly { name: string; labelKey: LocaleKey }[]` so labelKey is the specific paramless union, not the broad LocaleKey.
- `questionnaire.columns.tsx` — `STATUS_LABEL_KEYS` typed via `as const satisfies Record<string, LocaleKey>` for the same narrowing.

## On the runtime fallback

`translateDynamic` returns the key string verbatim if the key isn't in the unified source. This preserves pre-cutover defensive behavior at the 3 sites that compute keys at runtime (`collections.*`, `dashboard.stats.*`, `dashboard.profileLabels.*`). The strict `getTranslation` does not fall back — it indexes into the unified source directly. Issue #113 (delete JSONs + simplify walker) can now proceed; whether the fallback in `translateDynamic` should also be removed (forcing a structural refactor of the 3 dynamic-key sites) is a separate architectural conversation worth its own issue.

## Test plan

- [x] `npm run typecheck` — clean (zero errors)
- [x] `npm test` — 190 passing (was 190; no test changes since this is pure runtime/type plumbing)
- [x] All 138 existing `useTranslation()` call sites compile

Manual browser verification was not performed because the dev server has a known regression on `main` (issue #122 — webpack-overlay during page renders) that affects manual testing reliability. Recommend verifying navigation, common buttons, member form, and task form once #122 is resolved.

## Unblocks

- #112 (cross-locale param invariant test)
- #113 (delete JSON files + simplify getTranslation)
- #117 (placeholder-syntax fence — was waiting on #112)