### PR TITLE
test(i18n): assert {{params}} match across locales per key

### DIFF
--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,7 @@ import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
 import './server/crudMethods.test';
 import './server/getCollection.test';
+import './server/i18n.crossLocale.test';
 import './server/i18n.extractParams.test';
 import './server/membersMethods.test';
 import './server/mutationPipeline.test';

--- a/tests/server/i18n.crossLocale.test.ts
+++ b/tests/server/i18n.crossLocale.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert';
 import { extractParams } from '../../imports/i18n/extract-params';
-import { translations, type Locale, type LocaleKey } from '../../imports/i18n';
+import { translations, locales, defaultLocale, type Locale, type LocaleKey } from '../../imports/i18n';
+
+// Derived from the runtime `locales` object so adding a fourth language to
+// imports/i18n/index.ts automatically grows this test rather than silently
+// leaving the new locale unchecked.
+const NON_CANONICAL_LOCALES: readonly Locale[] = (Object.keys(locales) as Locale[]).filter(l => l !== defaultLocale);
 
 function setsEqual(a: Set<string>, b: Set<string>): boolean {
   if (a.size !== b.size) return false;
@@ -8,28 +13,25 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
   return true;
 }
 
-function findParamDrift(target: Locale): string[] {
+function collectDriftMessages(target: Locale): string[] {
   const failures: string[] = [];
   for (const key of Object.keys(translations) as LocaleKey[]) {
-    const enParams = extractParams(translations[key].en);
+    const enParams = extractParams(translations[key][defaultLocale]);
     const targetParams = extractParams(translations[key][target]);
     if (!setsEqual(enParams, targetParams)) {
       const enList = [...enParams].sort().join(', ') || '(none)';
       const targetList = [...targetParams].sort().join(', ') || '(none)';
-      failures.push(`  ${key}: en=[${enList}] ${target}=[${targetList}]`);
+      failures.push(`  ${key}: ${defaultLocale}=[${enList}] ${target}=[${targetList}]`);
     }
   }
   return failures;
 }
 
 describe('LocaleSet cross-locale param invariants', () => {
-  it('every key has the same {{params}} in de as in en', () => {
-    const drift = findParamDrift('de');
-    assert.strictEqual(drift.length, 0, `${drift.length} key(s) have placeholder drift between en and de:\n${drift.join('\n')}`);
-  });
-
-  it('every key has the same {{params}} in fr as in en', () => {
-    const drift = findParamDrift('fr');
-    assert.strictEqual(drift.length, 0, `${drift.length} key(s) have placeholder drift between en and fr:\n${drift.join('\n')}`);
-  });
+  for (const target of NON_CANONICAL_LOCALES) {
+    it(`every key has the same {{params}} in ${target} as in ${defaultLocale}`, () => {
+      const drift = collectDriftMessages(target);
+      assert.strictEqual(drift.length, 0, `${drift.length} key(s) have placeholder drift between ${defaultLocale} and ${target}:\n${drift.join('\n')}`);
+    });
+  }
 });

--- a/tests/server/i18n.crossLocale.test.ts
+++ b/tests/server/i18n.crossLocale.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { extractParams } from '../../imports/i18n/extract-params';
+import { translations, type Locale, type LocaleKey } from '../../imports/i18n';
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) if (!b.has(item)) return false;
+  return true;
+}
+
+function findParamDrift(target: Locale): string[] {
+  const failures: string[] = [];
+  for (const key of Object.keys(translations) as LocaleKey[]) {
+    const enParams = extractParams(translations[key].en);
+    const targetParams = extractParams(translations[key][target]);
+    if (!setsEqual(enParams, targetParams)) {
+      const enList = [...enParams].sort().join(', ') || '(none)';
+      const targetList = [...targetParams].sort().join(', ') || '(none)';
+      failures.push(`  ${key}: en=[${enList}] ${target}=[${targetList}]`);
+    }
+  }
+  return failures;
+}
+
+describe('LocaleSet cross-locale param invariants', () => {
+  it('every key has the same {{params}} in de as in en', () => {
+    const drift = findParamDrift('de');
+    assert.strictEqual(drift.length, 0, `${drift.length} key(s) have placeholder drift between en and de:\n${drift.join('\n')}`);
+  });
+
+  it('every key has the same {{params}} in fr as in en', () => {
+    const drift = findParamDrift('fr');
+    assert.strictEqual(drift.length, 0, `${drift.length} key(s) have placeholder drift between en and fr:\n${drift.join('\n')}`);
+  });
+});


### PR DESCRIPTION
Closes #112. The cross-locale invariant for the LocaleSet deepening (CONTEXT.md → "LocaleSet").

## Summary

The typed `t<K>()` (#111) extracts call-site param shapes from the `en` value of each translation, so call sites like `t('common.greeting', { name })` are checked against English. But the type system only sees `en` — if a translator writes `de: 'Hallo'` for a key whose `en` is `'Hello {{name}}'`, the German rendering silently drops the name at runtime.

This PR adds the runtime invariant test that catches that drift. For every key in `translations`, it parses `{{...}}` placeholders from all three locale strings (using `extractParams` from #109) and asserts the sets are equal. Failure messages name the offending key and which locale diverges.

Two tests, one per non-canonical locale (de, fr), so a single drift in French doesn't mask drift in German and vice versa. Failures are collected across all keys and reported in one assert message — a developer sees the full list of broken keys, not just the first.

## Result on first run

Zero drift. The manual sync discipline that's kept the locale files aligned has held. Going forward, any new key that introduces placeholder drift will fail in CI before merge.

## Test plan

- [x] `tests/server/i18n.crossLocale.test.ts` exists and is imported in `tests/main.ts` (alphabetical order)
- [x] Both `en/de` and `en/fr` invariant tests pass
- [x] `npm test` — 192 passing (was 190 + 2 new)
- [x] No production runtime change

## What's still possible

This test catches **placeholder drift** (different `{{...}}` set per locale per key). It does NOT catch:

- A translator using a placeholder name not in the runtime regex (`\w+`) — that's tracked in #117 (placeholder-syntax fence)
- The escape hatch `tDynamic` returning the literal key on miss — that's tracked in #124 (eliminate tDynamic)

Both are follow-ups in flight.

## Blocked by

None. #117 (which folds into this test infrastructure) and #113 (cleanup) are now both unblocked.