### PR TITLE
fix(settings): findOne returns undefined on miss instead of throwing

### DIFF
--- a/server/apis/settings.server.ts
+++ b/server/apis/settings.server.ts
@@ -46,19 +46,13 @@ if (Meteor.isServer) {
         throw new Meteor.Error((error as Error).message);
       }
     },
-    'settings.findOne': async function (filter = {}) {
+    'settings.findOne': async function (key: string = '') {
       validateUserId(this.userId);
       const hasPermission = await checkPermission(this.userId, 'settings');
       if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-      validateString(filter, false);
-      try {
-        const setting = await SettingsCollection.findOneAsync(filter);
-        if (!setting) throw new Meteor.Error(404, 'Setting not found');
-        return setting.value;
-      } catch (error) {
-        if ((error as Meteor.Error).error === 404) throw error;
-        throw new Meteor.Error((error as Error).message);
-      }
+      validateString(key, false);
+      const setting = await SettingsCollection.findOneAsync({ key });
+      return setting?.value;
     },
   });
 }

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -10,4 +10,5 @@ import './server/membersMethods.test';
 import './server/mutationPipeline.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
+import './server/settingsMethods.test';
 import './server/validation.test';

--- a/tests/server/settingsMethods.test.ts
+++ b/tests/server/settingsMethods.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
 import SettingsCollection from '../../imports/api/collections/settings.collection';
-import { callAs, cleanupFixtures, createTestDoc, createTestRole, createTestUser } from './fixtures';
+import { assertRejectsWithCode, callAs, cleanupFixtures, createTestDoc, createTestRole, createTestUser } from './fixtures';
 
 describe('settings.findOne — returns undefined on miss (#131)', () => {
   let adminUserId: string;
@@ -28,5 +29,23 @@ describe('settings.findOne — returns undefined on miss (#131)', () => {
     await createTestDoc(SettingsCollection, { key: 'community-probe', value: stored });
     const result = await callAs(adminUserId, 'settings.findOne', 'community-probe');
     assert.deepStrictEqual(result, stored);
+  });
+
+  it('body error from SettingsCollection.findOneAsync propagates with original Meteor.Error code intact', async () => {
+    // Targets the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper that this PR removed — the antipattern collapsed the original error
+    // code into the message position. Mirrors the pattern in membersMethods.test.ts.
+    const originalFindOne = SettingsCollection.findOneAsync.bind(SettingsCollection);
+    (SettingsCollection as unknown as { findOneAsync: unknown }).findOneAsync = async () => {
+      throw new Meteor.Error('test-findone-code', 'test-findone-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'settings.findOne', 'any-key'),
+        'test-findone-code',
+      );
+    } finally {
+      (SettingsCollection as unknown as { findOneAsync: typeof originalFindOne }).findOneAsync = originalFindOne;
+    }
   });
 });

--- a/tests/server/settingsMethods.test.ts
+++ b/tests/server/settingsMethods.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import SettingsCollection from '../../imports/api/collections/settings.collection';
+import { callAs, cleanupFixtures, createTestDoc, createTestRole, createTestUser } from './fixtures';
+
+describe('settings.findOne — returns undefined on miss (#131)', () => {
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ settings: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures([SettingsCollection]);
+  });
+
+  it('returns undefined when no setting matches the key (no throw)', async () => {
+    // Regression: previously threw Meteor.Error(404, 'Setting not found') on miss.
+    // The `settings.findOne` method had no live caller, but the throw-on-miss +
+    // try/catch wrapper that collapsed body errors into messages was the same
+    // antipattern PR #129 fixed for `members.findOne` (see PRD #97 user story 7).
+    const result = await callAs(adminUserId, 'settings.findOne', 'nonexistent-key');
+    assert.strictEqual(result, undefined);
+  });
+
+  it('returns the stored value when a setting matches the key', async () => {
+    const stored = { foo: 'bar' };
+    await createTestDoc(SettingsCollection, { key: 'community-probe', value: stored });
+    const result = await callAs(adminUserId, 'settings.findOne', 'community-probe');
+    assert.deepStrictEqual(result, stored);
+  });
+});


### PR DESCRIPTION
Closes #131. Cleanup mirroring PR #129's fix to `members.findOne`.

## What changed

`server/apis/settings.server.ts:49-62` had two layered antipatterns:

1. **Throw-on-miss for a `findOne`-named method.** The conventional contract for `findOne` is `value | undefined` (matches Mongo, MongoDB, most ORMs). Throwing forces every caller to either `.catch()` or risk an unhandled rejection — exactly the pattern that produced the `RegistrationExtra` overlay regression #122.
2. **Legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`** wrapper that collapsed the original error code into the message position. The same antipattern documented in PRD #97 user story 7 and removed by #129 for `members.findOne`.

After:
```ts
'settings.findOne': async function (key: string = '') {
  validateUserId(this.userId);
  const hasPermission = await checkPermission(this.userId, 'settings');
  if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
  validateString(key, false);
  const setting = await SettingsCollection.findOneAsync({ key });
  return setting?.value;
},
```

## Parameter reconciliation (and small security improvement)

The original signature was internally inconsistent: default `filter = {}` (object) paired with `validateString(filter, false)` (rejects non-strings) — the default always failed validation. The implied contract is "lookup by key string."

**Security note:** narrowing the wire contract from `filter: Mongo.Selector` to `key: string` is also a small NoSQL-injection surface reduction. The previous form *typed* itself as accepting an arbitrary Mongo selector (e.g., `{ $where: ... }`); `validateString` would have rejected it at runtime, but Parse-Don't-Validate-style narrowing at the type/parameter level is strictly better than runtime-only rejection. With `key: string`, the only thing that can ever be passed is a string — no operator-injection foothold exists.

A small twist relative to the issue's drafted recommendation: the recommendation passed the string straight to `findOneAsync(filter)`, which would do an `_id` lookup. The live read path (`imports/ui/settings/settings.hook.tsx:23-27`) queries by the `key` field, so this PR uses `findOneAsync({ key })`.

## Why a cleanup, not a bug fix

`grep -rn "settings\.findOne"` across `imports/`, `client/`, `server/`, and `tests/` returns only the definition. The method has no live caller today; the only client-side `settings.*` call site is `imports/ui/settings/Settings.tsx:70` which calls `settings.upsert`. Settings are read on the client via publications + `SettingsCollection.findOne` directly, bypassing the Meteor method. So this fix removes latent risk, not an active regression.

## Test plan

- [x] `npm test` — 209 passing (was 206; +3 new regression tests in `tests/server/settingsMethods.test.ts`)
- [x] Tests cover: returns `undefined` on miss (the bug condition), returns the stored `value` on hit (happy path), original `Meteor.Error` code propagates through the body untouched (legacy-wrapper-removal regression — mirrors `membersMethods.test.ts:88-104`)
- [x] `npm run typecheck` — clean

## Out of scope (filed as follow-up)

Two sibling methods in the same file — `settings.upsert` (lines 29-35) and `settings.remove` (lines 41-47) — still wrap their bodies in the same `try { ... } catch (e) { throw new Meteor.Error(e.message) }` antipattern. `settings.upsert` has a live caller (`Settings.tsx:70`), so it carries real risk. Filed as #133.

## Wire-contract change (for downstream awareness)

The method signature changes from `(filter: object) => unknown` to `(key: string) => unknown | undefined`. With zero in-tree callers this is safe; any out-of-tree consumer expecting selector-form would need to update.

## Blocked by

None.
