### PR TITLE
fix(e2e): kill registrations.spec.ts flake on `should search and filter`

### DIFF
--- a/e2e/pages/section.page.ts
+++ b/e2e/pages/section.page.ts
@@ -17,8 +17,10 @@ export class SectionPage extends BasePage {
    * Navigate to the section page and wait for table or empty state
    */
   async goto(): Promise<void> {
-    await this.page.goto(this.route);
-    await this.page.waitForLoadState('domcontentloaded');
+    // Default `waitUntil` is `'load'`, which waits for all subresources — including
+    // SockJS long-polling XHRs that legitimately stay open in a Meteor app. The
+    // explicit `waitForSelector` below is the actual readiness gate.
+    await this.page.goto(this.route, { waitUntil: 'domcontentloaded' });
     await this.page.waitForSelector('.ant-table, .ant-empty', { timeout: 15000 });
   }
 

--- a/imports/ui/registration/RegistrationExtra.tsx
+++ b/imports/ui/registration/RegistrationExtra.tsx
@@ -92,11 +92,11 @@ export default function RegistrationExtra({ record }: RegistrationExtraProps) {
         if (cancelled) return;
         setCreatedAlready(Boolean(res));
       })
-      .catch(() => {
-        // Swallow transient call failures (unmount during nav, connection blip).
-        // Without this, a rejected promise becomes an unhandled rejection that
-        // surfaces via the dev-server overlay and intercepts pointer events —
-        // see #122 / PR #129 for the original instance and #130 for this one.
+      .catch(error => {
+        // Swallow rather than let the rejection bubble — the dev-server overlay
+        // turns unhandled rejections into a full-page "Unexpected error" that
+        // intercepts pointer events on every row in the table.
+        if (Meteor.isDevelopment) console.warn('RegistrationExtra members.findOne failed', error);
       });
     return () => {
       cancelled = true;

--- a/imports/ui/registration/RegistrationExtra.tsx
+++ b/imports/ui/registration/RegistrationExtra.tsx
@@ -86,10 +86,21 @@ export default function RegistrationExtra({ record }: RegistrationExtraProps) {
   const [createdAlready, setCreatedAlready] = useState(true);
 
   useEffect(() => {
-    Meteor.callAsync('members.findOne', { 'profile.registrationId': record._id }, { fields: { service: 0 } }).then((res: Member | undefined) => {
-      if (res) setCreatedAlready(true);
-      else setCreatedAlready(false);
-    });
+    let cancelled = false;
+    Meteor.callAsync('members.findOne', { 'profile.registrationId': record._id }, { fields: { services: 0 } })
+      .then((res: Member | undefined) => {
+        if (cancelled) return;
+        setCreatedAlready(Boolean(res));
+      })
+      .catch(() => {
+        // Swallow transient call failures (unmount during nav, connection blip).
+        // Without this, a rejected promise becomes an unhandled rejection that
+        // surfaces via the dev-server overlay and intercepts pointer events —
+        // see #122 / PR #129 for the original instance and #130 for this one.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [record]);
 
   return (

--- a/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
+++ b/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
@@ -21,9 +21,11 @@ export default function DiscoveryTypeTag({ discoveryTypeId }: DiscoveryTypeTagPr
         if (cancelled) return;
         setMatch(res[0]);
       })
-      .catch(() => {
-        // Avoid unhandled rejection on unmount-during-call or transient blips —
-        // see #130 for context. The Tag falls back to the "Not found" state.
+      .catch(error => {
+        // Swallow rather than let the rejection bubble — unhandled rejections
+        // surface via the dev-server overlay. The Tag falls back to the
+        // "Not found" state, which is benign for a row-level decoration.
+        if (Meteor.isDevelopment) console.warn('DiscoveryTypeTag discoveryTypes.read failed', error);
       });
     return () => {
       cancelled = true;

--- a/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
+++ b/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
@@ -11,11 +11,23 @@ export default function DiscoveryTypeTag({ discoveryTypeId }: DiscoveryTypeTagPr
   const [match, setMatch] = useState<DiscoveryType | null>(null);
 
   useEffect(() => {
-    if (!discoveryTypeId) setMatch(null);
-    else
-      Meteor.callAsync('discoveryTypes.read', { _id: discoveryTypeId }, { limit: 1 }).then((res: DiscoveryType[]) =>
-        setMatch(res[0])
-      );
+    if (!discoveryTypeId) {
+      setMatch(null);
+      return;
+    }
+    let cancelled = false;
+    Meteor.callAsync('discoveryTypes.read', { _id: discoveryTypeId }, { limit: 1 })
+      .then((res: DiscoveryType[]) => {
+        if (cancelled) return;
+        setMatch(res[0]);
+      })
+      .catch(() => {
+        // Avoid unhandled rejection on unmount-during-call or transient blips —
+        // see #130 for context. The Tag falls back to the "Not found" state.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [discoveryTypeId]);
 
   if (!discoveryTypeId) return <Tag>-</Tag>;


### PR DESCRIPTION
Closes #130. Diagnosed two co-incident root causes for the intermittent flake first flagged in PR #129's residual concern, plus a credential-exposure typo found in the same area.

## Shape A — "Unexpected error" page snapshot

PR #129 fixed *one* dev-server-overlay-blocking unhandled-rejection source on `/registrations` (`members.findOne` throw-on-miss). Two more remained on the same page, both firing **once per row** of the table — so with 3 seeded test rows, 6 fragile async sites every page load:

| Site | Fix |
|---|---|
| `imports/ui/registration/RegistrationExtra.tsx:88-93` | Wrap `members.findOne` `.then(...)` with `.catch(...)` and a `cancelled` flag for unmount safety. |
| `imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx:13-19` | Same pattern for `discoveryTypes.read`. |

The `.catch` handlers swallow rather than throw — letting the rejection bubble would re-surface the dev-overlay regression. To prevent silent bug-hiding during development, both handlers also log the error in dev mode (`if (Meteor.isDevelopment) console.warn(...)`), matching the existing convention in `Settings.tsx` and `App.tsx`.

The `Unexpected error.` string in the failure snapshot appears nowhere in the codebase or i18n catalogs — it's the **webpack-dev-server overlay's own copy**, which fingerprints the failure as overlay-from-unhandled-rejection rather than an in-app error.

## Shape B — `page.goto` never reaches `load`

`SectionPage.goto()` called `page.goto(this.route)` with no `waitUntil`. Playwright's default is `'load'`, which waits for **all** subresources — including SockJS long-polling XHRs that legitimately stay open in a Meteor app. Under `workers: 5` parallel contention against a single dev server, this race becomes plausible.

The line *immediately after* (`page.waitForLoadState('domcontentloaded')`) plus the existing `waitForSelector('.ant-table, .ant-empty')` is the actual readiness gate. Switched `goto` to `waitUntil: 'domcontentloaded'` and dropped the redundant `waitForLoadState` call.

**Blast radius:** the `SectionPage.goto()` change affects all 11 specs that derive from `SectionPage` (`squads`, `medals`, `registrations`, `taskStatus`, `positions`, `questionnaires`, `eventTypes`, `ranks`, `specializations`, `discoveryTypes`, `roles`). Risk is low: each spec follows its `goto` with assertion-based waits (`expect(...).toBeVisible()`, etc.) that are the actual correctness gate.

## Bonus — credential-exposure fix (was: "quiet typo")

`RegistrationExtra.tsx:89` had `fields: { service: 0 }` (singular). The Meteor user document keys auth credentials under **`services` (plural)** — `services.password.bcrypt` for password hashes, `services.resume.loginTokens` for active session tokens, etc. The projection was *meant* to scrub these from the response payload of `members.findOne`, but the typo defeated the projection — the call was returning the full `services` payload (including the bcrypt hash) to every browser that rendered the registrations table.

This is a **credential-exposure fix**, not a typo cleanup. Severity is bounded by:
- The endpoint requires authentication and the `members` permission (so attackers need a valid session with privileges)
- `bcrypt` hashes are not directly reversible, but exposing them bypasses the rate-limited login surface

But the projection clearly *intended* to scrub the field, so this PR honours the original intent.

## Verification

```
npx playwright test e2e/tests/registrations.spec.ts --repeat-each=10 --workers=5 --retries=0
50 passed (1.2m)
```

50/50 deterministic at `retries=0` (re-verified after the dev-mode logging tweak), exercising both Shape A's row-effect rejections and Shape B's `load`-event wait. Acceptance criterion "runs 10 consecutive times without flaking on `should search and filter`" met.

Also:
- [x] `npm run typecheck` — clean
- [x] `npm test` — 206 passing (no unit-test impact, as expected for UI-side changes)

## Notes for review

- Shape A and Shape B are independent root causes — fixing only one would still leave a smaller flake surface. PR addresses both.
- Items intentionally out of scope: full e2e run on the other 10 specs that use `SectionPage` (the change only relaxes `waitUntil`, never tightens it, so regression risk is low). A typed-projection helper for Mongo `fields` (would have caught the `service`/`services` typo at compile time) is a worthwhile follow-up but a different scope.

## Blocked by

None.
