### PR TITLE
fix(settings): drop legacy try/catch from upsert and remove

### DIFF
--- a/server/apis/settings.server.ts
+++ b/server/apis/settings.server.ts
@@ -24,7 +24,7 @@ if (Meteor.isServer) {
       if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
       validateString(key, false);
       if (value === null || value === undefined) {
-        throw new Meteor.Error('invalid-value', 'Invalid value', value as never);
+        throw new Meteor.Error('invalid-value', 'Invalid value');
       }
       const result = await SettingsCollection.upsertAsync(key, { $set: { key, value } });
       await createLog('settings.updated', { key });

--- a/server/apis/settings.server.ts
+++ b/server/apis/settings.server.ts
@@ -18,33 +18,26 @@ if (Meteor.isServer) {
   });
 
   Meteor.methods({
-    'settings.upsert': async function (key, value) {
+    'settings.upsert': async function (key: string = '', value: unknown) {
       validateUserId(this.userId);
       const hasPermission = await checkPermission(this.userId, 'settings');
       if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
       validateString(key, false);
-      if (!value) {
-        throw new Meteor.Error('invalid-value', 'Invalid value', value);
+      if (value === null || value === undefined) {
+        throw new Meteor.Error('invalid-value', 'Invalid value', value as never);
       }
-      try {
-        const result = await SettingsCollection.upsertAsync(key, { $set: { key, value } });
-        await createLog('settings.updated', { key });
-        return result;
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      const result = await SettingsCollection.upsertAsync(key, { $set: { key, value } });
+      await createLog('settings.updated', { key });
+      return result;
     },
-    'settings.remove': async function (key = null) {
+    'settings.remove': async function (key: string = '') {
       validateUserId(this.userId);
       const hasPermission = await checkPermission(this.userId, 'settings');
       if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
-      try {
-        const result = await SettingsCollection.removeAsync(key);
-        await createLog('settings.deleted', { key });
-        return result;
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      validateString(key, false);
+      const result = await SettingsCollection.removeAsync({ key });
+      await createLog('settings.deleted', { key });
+      return result;
     },
     'settings.findOne': async function (key: string = '') {
       validateUserId(this.userId);

--- a/tests/server/settingsMethods.test.ts
+++ b/tests/server/settingsMethods.test.ts
@@ -69,9 +69,8 @@ describe('settings.upsert — drops legacy try/catch + nullish-only value check 
     assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-upsert'), 'second');
   });
 
-  it('accepts legitimate falsy values that the previous "no falsy" check rejected', async () => {
-    // The previous `if (!value)` rejected 0, false, and ''. The new contract
-    // only rejects null/undefined, so these should round-trip cleanly.
+  it('accepts 0, false, and empty string as legitimate setting values', async () => {
+    // Settings values can legitimately be 0, false, or '' — only nullish is invalid.
     for (const value of [0, false, '']) {
       await callAs(adminUserId, 'settings.upsert', 'community-probe-falsy', value);
       assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-falsy'), value);

--- a/tests/server/settingsMethods.test.ts
+++ b/tests/server/settingsMethods.test.ts
@@ -49,3 +49,96 @@ describe('settings.findOne — returns undefined on miss (#131)', () => {
     }
   });
 });
+
+describe('settings.upsert — drops legacy try/catch + nullish-only value check (#133)', () => {
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ settings: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures([SettingsCollection]);
+  });
+
+  it('inserts a new setting on first call and updates it on subsequent calls (round-trip via findOne)', async () => {
+    await callAs(adminUserId, 'settings.upsert', 'community-probe-upsert', 'first');
+    assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-upsert'), 'first');
+    await callAs(adminUserId, 'settings.upsert', 'community-probe-upsert', 'second');
+    assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-upsert'), 'second');
+  });
+
+  it('accepts legitimate falsy values that the previous "no falsy" check rejected', async () => {
+    // The previous `if (!value)` rejected 0, false, and ''. The new contract
+    // only rejects null/undefined, so these should round-trip cleanly.
+    for (const value of [0, false, '']) {
+      await callAs(adminUserId, 'settings.upsert', 'community-probe-falsy', value);
+      assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-falsy'), value);
+    }
+  });
+
+  it('rejects null and undefined with the invalid-value error code', async () => {
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'settings.upsert', 'community-probe-null', null),
+      'invalid-value',
+    );
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'settings.upsert', 'community-probe-undef', undefined),
+      'invalid-value',
+    );
+  });
+
+  it('body error from SettingsCollection.upsertAsync propagates with original Meteor.Error code intact', async () => {
+    const originalUpsert = SettingsCollection.upsertAsync.bind(SettingsCollection);
+    (SettingsCollection as unknown as { upsertAsync: unknown }).upsertAsync = async () => {
+      throw new Meteor.Error('test-upsert-code', 'test-upsert-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'settings.upsert', 'community-probe-throws', 'any'),
+        'test-upsert-code',
+      );
+    } finally {
+      (SettingsCollection as unknown as { upsertAsync: typeof originalUpsert }).upsertAsync = originalUpsert;
+    }
+  });
+});
+
+describe('settings.remove — drops legacy try/catch + uses { key } selector (#133)', () => {
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ settings: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures([SettingsCollection]);
+  });
+
+  it('removes a setting matched by key field (not _id), so subsequent findOne returns undefined', async () => {
+    // Pre-PR the method called removeAsync(key) which only matched by _id.
+    // Insert a doc whose _id and key differ to prove the new { key } selector
+    // is doing the work — the old _id-based form would not have found this.
+    await createTestDoc(SettingsCollection, { key: 'community-probe-remove', value: 'doomed' });
+    assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-remove'), 'doomed');
+    await callAs(adminUserId, 'settings.remove', 'community-probe-remove');
+    assert.strictEqual(await callAs(adminUserId, 'settings.findOne', 'community-probe-remove'), undefined);
+  });
+
+  it('body error from SettingsCollection.removeAsync propagates with original Meteor.Error code intact', async () => {
+    const originalRemove = SettingsCollection.removeAsync.bind(SettingsCollection);
+    (SettingsCollection as unknown as { removeAsync: unknown }).removeAsync = async () => {
+      throw new Meteor.Error('test-remove-code', 'test-remove-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'settings.remove', 'any-key'),
+        'test-remove-code',
+      );
+    } finally {
+      (SettingsCollection as unknown as { removeAsync: typeof originalRemove }).removeAsync = originalRemove;
+    }
+  });
+});


### PR DESCRIPTION
Closes #133. Removes the file's last two instances of the `try { ... } catch (e) { throw new Meteor.Error(e.message) }` antipattern that PRD #97 user story 7 documents — completing the cleanup begun in PR #132 for `settings.findOne`.

## Why this matters (live caller)

`imports/ui/settings/Settings.tsx:70` is the live consumer of `settings.upsert`:
```ts
Meteor.callAsync('settings.upsert', key, value).catch(error => {
  alert(JSON.stringify({ error: error.error, message: error.message }, null, 2));
});
```

**Before this PR:** when `upsertAsync` threw a coded `Meteor.Error('some-mongo-code', 'Validation failed for X')`, the wrapper collapsed it into `new Meteor.Error('Validation failed for X')` — putting the message in the *code* position. The alert showed `{ error: "Validation failed for X", message: undefined }`. Useless for diagnostics.

**After this PR:** the original error propagates untouched. The alert renders `{ error: "some-mongo-code", message: "Validation failed for X" }`. Now diagnostically meaningful.

## Decisions on the open questions from #133

| # | Question | Decision | Why |
|---|---|---|---|
| 1 | `settings.remove` lookup field — `_id` or `{ key }`? | `{ key }` | Matches `findOne` (consistency wins). Settings collection is tiny (~5 docs in prod), so the unindexed-lookup cost is negligible. Works for any doc with a `key` field, not just those where `_id === key` (the upsert invariant). |
| 2 | `settings.remove` parameter default | `key: string = ''` | Mirrors the `findOne` shape. `validateString(key, false)` rejects `''` at runtime, making the parameter effectively required. |
| 3 | `settings.upsert` value validation — falsy or nullish? | Nullish only (`value === null || value === undefined`) | The previous `if (!value)` rejected `0`, `false`, `''` — all legitimate setting values. The codebase already uses the explicit nullish pair in `questionnaireResponses.server.ts:109,124`; this matches. |

`upsertAsync(key, ...)` keeps its `_id`-based selector form deliberately — switching it to `{ key }` would auto-generate new `_id`s for new keys, breaking the existing `_id === key` invariant. Out of scope per the issue's acceptance criteria.

## Diff shape

`server/apis/settings.server.ts`:
- `settings.upsert`: drops try/catch wrapper, switches falsy check (`!value`) to nullish check (`value === null || value === undefined`), types `key: string = ''` for parameter consistency
- `settings.remove`: drops try/catch wrapper, types `key: string = ''`, switches `removeAsync(key)` to `removeAsync({ key })`, adds `validateString(key, false)`

## Test coverage

`tests/server/settingsMethods.test.ts` gains **6 new tests** (215 passing, was 209):

**`settings.upsert`:**
- Round-trip via `findOne` (insert → update → read)
- **Legitimate-falsy values** (`0`, `false`, `''`) round-trip — directly asserts the new nullish-only contract on the values the old check would have wrongly rejected
- `null` and `undefined` rejected with `invalid-value` code
- Body-error-propagation regression (mock `upsertAsync` to throw a coded `Meteor.Error`, assert the code reaches the caller)

**`settings.remove`:**
- Removes via the `{ key }` selector (round-trip: insert → assert findable → remove → assert gone)
- Body-error-propagation regression (mock `removeAsync` to throw a coded `Meteor.Error`, assert the code reaches the caller)

## Acceptance criteria

- [x] `settings.upsert` and `settings.remove` no longer wrap body errors with `new Meteor.Error(error.message)`
- [x] Original `Meteor.Error` codes propagate through both methods (regression tests assert this directly)
- [x] `settings.remove` lookup field reconciled (now `{ key }`)
- [x] `settings.upsert` value-validation contract decided (nullish-only)
- [x] `Settings.tsx:70` continues to render meaningful `error.error` + `error.message` after the change (verified by the upsert-error-propagation test — the error code reaches the caller intact, which is exactly what `Settings.tsx` reads)
- [x] `npm run typecheck` passes
- [x] All existing tests stay green (209 → 215; net +6 from new tests)

## Blocked by

None. PR #132 (the `findOne` cleanup) has already landed on `main`.
