### PR TITLE
fix(server): drop the last two legacy try/catch antipattern instances

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -172,20 +172,16 @@ if (Meteor.isServer) {
       validateUserId(this.userId);
       validateObject(filter, false);
       validateObject(options, false);
-      try {
-        const members = await MembersCollection.find(filter, options).fetchAsync();
+      const members = await MembersCollection.find(filter, options).fetchAsync();
 
-        const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
-        const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
-        const rankNameById = new Map(ranks.map(r => [r._id, r.name]));
+      const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
+      const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
+      const rankNameById = new Map(ranks.map(r => [r._id, r.name]));
 
-        const names = members.map(member =>
-          getFullName(rankNameById.get(member.profile?.rankId as string), member.profile?.id, member.profile?.name)
-        );
-        return names.join(', ');
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      const names = members.map(member =>
+        getFullName(rankNameById.get(member.profile?.rankId as string), member.profile?.id, member.profile?.name)
+      );
+      return names.join(', ');
     },
     'members.getUsedIds': async function () {
       if (!this.userId) {

--- a/server/apis/specializations.server.ts
+++ b/server/apis/specializations.server.ts
@@ -8,13 +8,8 @@ if (Meteor.isServer) {
     'specializations.names': async function (specializations: string[] = []): Promise<string> {
       validateUserId(this.userId);
       validateArrayOfStrings(specializations, false);
-      try {
-        const foundSpecializations = await SpecializationsCollection.find({ _id: { $in: specializations } }).fetchAsync();
-        const names = foundSpecializations.map(s => s.name);
-        return names.join(', ');
-      } catch (error) {
-        throw new Meteor.Error((error as Error).message);
-      }
+      const foundSpecializations = await SpecializationsCollection.find({ _id: { $in: specializations } }).fetchAsync();
+      return foundSpecializations.map(s => s.name).join(', ');
     },
     'specializations.request': async function (specializationId: string): Promise<boolean> {
       validateUserId(this.userId);

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -11,4 +11,5 @@ import './server/mutationPipeline.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
 import './server/settingsMethods.test';
+import './server/specializationsMethods.test';
 import './server/validation.test';

--- a/tests/server/membersMethods.test.ts
+++ b/tests/server/membersMethods.test.ts
@@ -131,6 +131,37 @@ describe('members.findOne — returns undefined on miss (#122)', () => {
   });
 });
 
+describe('members.participantNames — legacy try/catch removed (#97)', () => {
+  let adminUserId: string;
+
+  before(async () => {
+    const adminRoleId = await createTestRole({ roles: true });
+    adminUserId = await createTestUser({ roleId: adminRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('body error from MembersCollection.find propagates with original Meteor.Error code intact', async () => {
+    // Targets the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper that this PR removed. members.participantNames is a read method, so
+    // it doesn't migrate to runMutation — just dropping the wrapper is the fix.
+    const originalFind = MembersCollection.find.bind(MembersCollection);
+    (MembersCollection as unknown as { find: unknown }).find = () => {
+      throw new Meteor.Error('test-participant-names-code', 'test-participant-names-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(adminUserId, 'members.participantNames', {}, {}),
+        'test-participant-names-code',
+      );
+    } finally {
+      (MembersCollection as unknown as { find: typeof originalFind }).find = originalFind;
+    }
+  });
+});
+
 describe('members.remove — migrated to mutation-pipeline (#102)', () => {
   let adminUserId: string;
   let targetUserId: string;

--- a/tests/server/membersMethods.test.ts
+++ b/tests/server/membersMethods.test.ts
@@ -144,9 +144,9 @@ describe('members.participantNames — legacy try/catch removed (#97)', () => {
   });
 
   it('body error from MembersCollection.find propagates with original Meteor.Error code intact', async () => {
-    // Targets the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
-    // wrapper that this PR removed. members.participantNames is a read method, so
-    // it doesn't migrate to runMutation — just dropping the wrapper is the fix.
+    // Defends against the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper sneaking back in — it would clobber the original error code into the
+    // message position. Read methods stay outside the runMutation pipeline.
     const originalFind = MembersCollection.find.bind(MembersCollection);
     (MembersCollection as unknown as { find: unknown }).find = () => {
       throw new Meteor.Error('test-participant-names-code', 'test-participant-names-message');

--- a/tests/server/specializationsMethods.test.ts
+++ b/tests/server/specializationsMethods.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { Meteor } from 'meteor/meteor';
 import SpecializationsCollection from '../../imports/api/collections/specializations.collection';
 import { assertRejectsWithCode, callAs, cleanupFixtures, createTestRole, createTestUser } from './fixtures';
@@ -12,14 +11,13 @@ describe('specializations.names — legacy try/catch removed (#97)', () => {
   });
 
   after(async () => {
-    await cleanupFixtures([SpecializationsCollection]);
+    await cleanupFixtures();
   });
 
   it('body error from SpecializationsCollection.find propagates with original Meteor.Error code intact', async () => {
-    // Targets the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
-    // wrapper that this PR removed. specializations.names is a read method with
-    // no live caller — purely a hygiene cleanup so future callers receive
-    // meaningful Meteor.Error codes instead of message-as-code blobs.
+    // Defends against the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper sneaking back in — it would clobber the original error code into the
+    // message position. Body errors must reach the caller untouched.
     const originalFind = SpecializationsCollection.find.bind(SpecializationsCollection);
     (SpecializationsCollection as unknown as { find: unknown }).find = () => {
       throw new Meteor.Error('test-spec-names-code', 'test-spec-names-message');

--- a/tests/server/specializationsMethods.test.ts
+++ b/tests/server/specializationsMethods.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import SpecializationsCollection from '../../imports/api/collections/specializations.collection';
+import { assertRejectsWithCode, callAs, cleanupFixtures, createTestRole, createTestUser } from './fixtures';
+
+describe('specializations.names — legacy try/catch removed (#97)', () => {
+  let userId: string;
+
+  before(async () => {
+    const roleId = await createTestRole({});
+    userId = await createTestUser({ roleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures([SpecializationsCollection]);
+  });
+
+  it('body error from SpecializationsCollection.find propagates with original Meteor.Error code intact', async () => {
+    // Targets the legacy `try { ... } catch (e) { throw new Meteor.Error(e.message) }`
+    // wrapper that this PR removed. specializations.names is a read method with
+    // no live caller — purely a hygiene cleanup so future callers receive
+    // meaningful Meteor.Error codes instead of message-as-code blobs.
+    const originalFind = SpecializationsCollection.find.bind(SpecializationsCollection);
+    (SpecializationsCollection as unknown as { find: unknown }).find = () => {
+      throw new Meteor.Error('test-spec-names-code', 'test-spec-names-message');
+    };
+    try {
+      await assertRejectsWithCode(
+        () => callAs(userId, 'specializations.names', []),
+        'test-spec-names-code',
+      );
+    } finally {
+      (SpecializationsCollection as unknown as { find: typeof originalFind }).find = originalFind;
+    }
+  });
+});


### PR DESCRIPTION
Closes the final two sites of the `try { ... } catch (e) { throw new Meteor.Error((e as Error).message) }` antipattern that PRD #97 user story 7 documents — completing the codebase-wide cleanup begun by the mutation-pipeline migration.

## What's left after #98, #99, #100, #101, #102, #132, #135

After grep'ing `server/` for the antipattern signature:

```
$ grep -rn "throw new Meteor.Error((error as Error).message)" server/
server/apis/members.server.ts:187: ...
server/apis/specializations.server.ts:16: ...
```

Just these two. Both are **read methods** (not mutations), so they don't fit the `runMutation` pipeline — the wrapper removal alone is the fix.

## Sites fixed

| Method | Caller status | Type | Action |
|---|---|---|---|
| `members.participantNames` | 1 live caller (`imports/ui/tasks/task.columns.tsx:25`) which already swallows errors with `.catch(() => {})` | Read (returns joined names) | Drop try/catch wrapper |
| `specializations.names` | No live callers (`grep -rn "specializations\.names"` in `imports/`/`client/` returns only the definition) | Read (returns joined names) | Drop try/catch wrapper — latent cleanup |

The `members.participantNames` caller already swallows errors, so the contract change has no observable effect on current code paths. The improvement is strictly hygienic: any future inspecting caller now receives the original `Meteor.Error` code intact, matching the doctrine PRD #97 user story 7 establishes.

## Test coverage

`tests/server/membersMethods.test.ts` gains 1 test (new `describe` block for `members.participantNames`). New file `tests/server/specializationsMethods.test.ts` adds 1 test (registered alphabetically in `tests/main.ts`). Both follow the body-error-propagation pattern from `membersMethods.test.ts:88-104`:

```
217 passing (was 215; +2 new tests)
```

Each test mocks the underlying collection's `find` to throw a coded `Meteor.Error`, calls the method via `callAs`, and asserts the original code (`'test-spec-names-code'` / `'test-participant-names-code'`) reaches the caller. The tests will fail if the legacy wrapper is ever re-introduced.

## Why this closes PRD #97 in practice

PRD #97's three-stage rollout is now complete:

| Stage | Issue | Status |
|---|---|---|
| PR 1 — introduce `mutation-pipeline` wrapper + refactor `crud.lib.ts` | #98 | ✅ Closed |
| PR 2 — `CollectionPermissionRegistry` + plural action-name normalization | #99 | ✅ Closed |
| PR 3..N — per-method migrations (`members.insert`/`update`/`remove`) | #100, #101, #102 | ✅ Closed |
| Out-of-band cleanups of the same antipattern in non-mutation methods | #131, #133, this PR | ✅ All addressed |

After this PR merges, the antipattern signature `throw new Meteor.Error((error as Error).message)` returns **zero matches** across `server/`. Worth closing #97 with a summary comment once this lands — I'll add the comment after merge.

## Acceptance criteria

- [x] Both methods no longer wrap body errors with `new Meteor.Error(error.message)`
- [x] Original `Meteor.Error` codes propagate (regression tests assert this directly)
- [x] `npm run typecheck` passes
- [x] All existing tests stay green (215 → 217; net +2 from new tests)

## Blocked by

None. PR #135 has merged; nothing else is in flight on `server/`.
