### PR TITLE
feat(palette): foundation — Cmd+K toggles an empty modal (#137)

### DIFF
--- a/imports/ui/app/App.tsx
+++ b/imports/ui/app/App.tsx
@@ -10,6 +10,8 @@ import type { NavigationContextValue } from '../navigation/navigation.hook';
 import useSettings from '../settings/settings.hook';
 import { getPreferedTheme } from '../theme/theme.hook';
 import type { ThemeContextValue, ThemeMode } from '../theme/theme.hook';
+import Palette from '../palette/Palette';
+import { PaletteProvider } from '../palette/PaletteContext';
 import DemoTour from '../tour/DemoTour';
 import { TourProvider } from '../tour/TourContext';
 import type { DrawerContextValue } from './types';
@@ -93,53 +95,56 @@ export default function App() {
             }}
           >
             <TourProvider>
-              <ConfigProvider
-                theme={{
-                  token: {
-                    colorPrimary: communityColor,
-                    borderRadius: 8,
-                    fontSize: 16,
-                    colorBgBase: theme === 'dark' ? '#282828' : '#f8f8f2',
-                    colorTextBase: theme === 'dark' ? '#f8f8f2' : '#282828',
-                  },
-                  algorithm: theme === 'dark' ? AntdTheme.darkAlgorithm : AntdTheme.defaultAlgorithm,
-                }}
-              >
-                <AntdApp className="app" message={{ ...message, maxCount: 1 }} notification={{ ...notification, maxCount: 3 }}>
-                  <Layout>
-                    <Layout.Header>
-                      <Header />
-                    </Layout.Header>
-                    <Layout.Content style={{ flex: 1, overflow: 'auto' }}>
-                      <Main />
-                    </Layout.Content>
-                    <Layout.Footer>
-                      <Footer />
-                    </Layout.Footer>
-                  </Layout>
-                  {Meteor.isDevelopment && <DemoTour />}
-                  <Drawer
-                    width={getDrawerWidth(window.innerWidth)}
-                    open={drawerOpen}
-                    onClose={() => setDrawerOpen(false)}
-                    title={drawerTitle}
-                    extra={drawerExtra}
-                    destroyOnHidden
-                  >
-                    {drawerComponent}
+              <PaletteProvider>
+                <ConfigProvider
+                  theme={{
+                    token: {
+                      colorPrimary: communityColor,
+                      borderRadius: 8,
+                      fontSize: 16,
+                      colorBgBase: theme === 'dark' ? '#282828' : '#f8f8f2',
+                      colorTextBase: theme === 'dark' ? '#f8f8f2' : '#282828',
+                    },
+                    algorithm: theme === 'dark' ? AntdTheme.darkAlgorithm : AntdTheme.defaultAlgorithm,
+                  }}
+                >
+                  <AntdApp className="app" message={{ ...message, maxCount: 1 }} notification={{ ...notification, maxCount: 3 }}>
+                    <Layout>
+                      <Layout.Header>
+                        <Header />
+                      </Layout.Header>
+                      <Layout.Content style={{ flex: 1, overflow: 'auto' }}>
+                        <Main />
+                      </Layout.Content>
+                      <Layout.Footer>
+                        <Footer />
+                      </Layout.Footer>
+                    </Layout>
+                    {Meteor.isDevelopment && <DemoTour />}
+                    <Palette />
                     <Drawer
                       width={getDrawerWidth(window.innerWidth)}
-                      open={subdrawerOpen}
-                      onClose={() => setSubdrawerOpen(false)}
-                      title={subdrawerTitle}
-                      extra={subdrawerExtra}
+                      open={drawerOpen}
+                      onClose={() => setDrawerOpen(false)}
+                      title={drawerTitle}
+                      extra={drawerExtra}
                       destroyOnHidden
                     >
-                      {subdrawerComponent}
+                      {drawerComponent}
+                      <Drawer
+                        width={getDrawerWidth(window.innerWidth)}
+                        open={subdrawerOpen}
+                        onClose={() => setSubdrawerOpen(false)}
+                        title={subdrawerTitle}
+                        extra={subdrawerExtra}
+                        destroyOnHidden
+                      >
+                        {subdrawerComponent}
+                      </Drawer>
                     </Drawer>
-                  </Drawer>
-                </AntdApp>
-              </ConfigProvider>
+                  </AntdApp>
+                </ConfigProvider>
+              </PaletteProvider>
             </TourProvider>
           </SubdrawerContext.Provider>
         </DrawerContext.Provider>

--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -1,0 +1,21 @@
+import { Modal } from 'antd';
+import React, { useContext } from 'react';
+import { PaletteContext } from './PaletteContext';
+
+export default function Palette() {
+  const { open, setOpen } = useContext(PaletteContext);
+
+  return (
+    <Modal
+      open={open}
+      onCancel={() => setOpen(false)}
+      footer={null}
+      closable={false}
+      destroyOnHidden
+      maskClosable
+      width={640}
+      style={{ top: 96 }}
+      styles={{ body: { padding: 0 } }}
+    />
+  );
+}

--- a/imports/ui/palette/PaletteContext.tsx
+++ b/imports/ui/palette/PaletteContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface PaletteContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+export const PaletteContext = createContext<PaletteContextValue>({} as PaletteContextValue);
+
+interface PaletteProviderProps {
+  children: ReactNode;
+}
+
+export function PaletteProvider({ children }: PaletteProviderProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = useCallback(() => setOpen(prev => !prev), []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setOpen(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const value = useMemo<PaletteContextValue>(() => ({ open, setOpen, toggle }), [open, toggle]);
+
+  return <PaletteContext.Provider value={value}>{children}</PaletteContext.Provider>;
+}


### PR DESCRIPTION
## Summary
- Add `PaletteContext` + `PaletteProvider` with global Cmd/Ctrl+K keydown listener.
- Render an empty Antd `Modal` at App level that opens/closes via the context.
- Esc, outside click, or re-pressing the hotkey all close it.

Closes #137.

## Test plan
- [ ] Press Cmd+K (Mac) / Ctrl+K (Win/Linux) from any route — empty modal opens.
- [ ] Press Esc — modal closes, focus returns to previous element.
- [ ] Click outside the modal — modal closes.
- [ ] Press the hotkey while modal is open — modal toggles closed.
- [ ] Browser default Ctrl+K (focus address bar) is suppressed while focus is in the app.
- [ ] All 217 unit tests pass (verified locally).