### PR TITLE
feat(palette): Recents with frecency in localStorage + hybrid empty state (#143)

### DIFF
--- a/imports/i18n/translations.ts
+++ b/imports/i18n/translations.ts
@@ -394,6 +394,7 @@ export const translations = {
   "palette.noResults": { en: "No results", de: "Keine Ergebnisse", fr: "Aucun résultat" },
   "palette.placeholder": { en: "Search…", de: "Suchen…", fr: "Rechercher…" },
   "palette.questionnaires": { en: "Questionnaires", de: "Fragebögen", fr: "Questionnaires" },
+  "palette.recent": { en: "Recent", de: "Zuletzt verwendet", fr: "Récent" },
   "palette.registrations": { en: "Registrations", de: "Bewerbungen", fr: "Inscriptions" },
   "palette.squads": { en: "Squads", de: "Trupps", fr: "Escouades" },
   "palette.switchLanguage": { en: "Switch language", de: "Sprache wechseln", fr: "Changer de langue" },

--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -12,6 +12,7 @@ import useTheme from '../theme/theme.hook';
 import { PaletteContext } from './PaletteContext';
 import { getCreatePaletteItems, getEntityPaletteItems, getGlobalPaletteItems, getNavigatePaletteItems } from './palette.items';
 import type { PaletteEntityResults } from './palette.items';
+import { addRecent, frecencyScore, readRecents, type RecentEntry } from './palette.recents';
 import type { PaletteItem } from './palette.types';
 
 const EMPTY_ENTITY_RESULTS: PaletteEntityResults = {
@@ -41,6 +42,7 @@ export default function Palette() {
   const [query, setQuery] = useState('');
   const [highlighted, setHighlighted] = useState(0);
   const [entityResults, setEntityResults] = useState<PaletteEntityResults>(EMPTY_ENTITY_RESULTS);
+  const [recents, setRecents] = useState<RecentEntry[]>([]);
   const inputRef = useRef<React.ComponentRef<typeof Input>>(null);
 
   const navigate = useCallback(
@@ -87,14 +89,56 @@ export default function Palette() {
   );
   const entityItems = useMemo<PaletteItem[]>(() => getEntityPaletteItems(entityResults, t, navigate), [entityResults, t, navigate]);
 
+  const recentItems = useMemo<PaletteItem[]>(() => {
+    if (recents.length === 0) return [];
+    const groupLabel = t('palette.recent');
+    const staticItems: PaletteItem[] = [...createItems, ...globalItems, ...navigateItems];
+    const itemByKey = new Map(staticItems.map(item => [`${item.kind}:${item.key}`, item] as const));
+    return recents
+      .slice(0, 5)
+      .map(entry => {
+        const id = `${entry.kind}:${entry.key}`;
+        const original = itemByKey.get(id);
+        if (original) {
+          return { ...original, key: `recent:${id}`, group: groupLabel };
+        }
+        if (entry.kind !== 'entity') return null;
+        const collection = entry.key.split(':')[1];
+        if (!collection) return null;
+        return {
+          kind: 'entity',
+          key: `recent:${id}`,
+          label: entry.label,
+          group: groupLabel,
+          onSelect: () => navigate(collection),
+        } as PaletteItem;
+      })
+      .filter((item): item is PaletteItem => item !== null);
+  }, [recents, createItems, globalItems, navigateItems, t, navigate]);
+
+  const recencyBoost = useMemo(() => {
+    const map = new Map<string, number>();
+    const now = Date.now();
+    recents.forEach(entry => {
+      map.set(`${entry.kind}:${entry.key}`, frecencyScore(entry, now));
+    });
+    return map;
+  }, [recents]);
+
   const filteredItems = useMemo<PaletteItem[]>(() => {
     const trimmed = query.trim().toLowerCase();
     const matches = (item: PaletteItem) => item.label.toLowerCase().includes(trimmed);
+    const sortByRecency = (items: PaletteItem[]) =>
+      [...items].sort((a, b) => ((recencyBoost.get(`${a.kind}:${a.key}`) ?? 0) < (recencyBoost.get(`${b.kind}:${b.key}`) ?? 0) ? 1 : -1));
     if (!trimmed) {
-      return [...createItems, ...globalItems, ...navigateItems];
+      return [...recentItems, ...sortByRecency(createItems), ...globalItems, ...sortByRecency(navigateItems)];
     }
-    return [...entityItems, ...createItems.filter(matches), ...globalItems.filter(matches), ...navigateItems.filter(matches)];
-  }, [navigateItems, createItems, globalItems, entityItems, query]);
+    const filteredCreate = sortByRecency(createItems.filter(matches));
+    const filteredGlobal = globalItems.filter(matches);
+    const filteredNav = sortByRecency(navigateItems.filter(matches));
+    const filteredEntity = sortByRecency(entityItems);
+    return [...filteredEntity, ...filteredCreate, ...filteredGlobal, ...filteredNav];
+  }, [recentItems, navigateItems, createItems, globalItems, entityItems, query, recencyBoost]);
 
   const groupedItems = useMemo(() => {
     const groups: { label: string; items: PaletteItem[] }[] = [];
@@ -116,6 +160,7 @@ export default function Palette() {
       setQuery('');
       setHighlighted(0);
       setEntityResults(EMPTY_ENTITY_RESULTS);
+      setRecents(readRecents());
     }
   }, [open]);
 
@@ -144,6 +189,19 @@ export default function Palette() {
     };
   }, [query, open]);
 
+  const recordSelection = useCallback((item: PaletteItem) => {
+    const baseKey = item.key.startsWith('recent:') ? item.key.slice('recent:'.length).split(':').slice(1).join(':') : item.key;
+    addRecent({ kind: item.kind, key: baseKey, label: item.label });
+  }, []);
+
+  const selectItem = useCallback(
+    (item: PaletteItem) => {
+      recordSelection(item);
+      item.onSelect();
+    },
+    [recordSelection]
+  );
+
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.key === 'ArrowDown') {
@@ -155,10 +213,10 @@ export default function Palette() {
       } else if (event.key === 'Enter') {
         event.preventDefault();
         const item = filteredItems[highlighted];
-        if (item) item.onSelect();
+        if (item) selectItem(item);
       }
     },
-    [filteredItems, highlighted]
+    [filteredItems, highlighted, selectItem]
   );
 
   const setNavOnPopstate = useCallback(() => {
@@ -219,7 +277,7 @@ export default function Palette() {
                     role="option"
                     aria-selected={isHighlighted}
                     onMouseEnter={() => setHighlighted(itemIndex)}
-                    onClick={() => item.onSelect()}
+                    onClick={() => selectItem(item)}
                     style={{
                       padding: '8px 16px',
                       cursor: 'pointer',

--- a/imports/ui/palette/palette.recents.ts
+++ b/imports/ui/palette/palette.recents.ts
@@ -1,0 +1,86 @@
+import type { PaletteItemKind } from './palette.types';
+
+const STORAGE_KEY = 'cm.palette.recents';
+const MAX_ENTRIES = 10;
+const STALE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+const HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000;
+
+export interface RecentEntry {
+  kind: PaletteItemKind;
+  key: string;
+  label: string;
+  ts: number;
+  count: number;
+}
+
+function isRecentEntry(value: unknown): value is RecentEntry {
+  if (!value || typeof value !== 'object') return false;
+  const e = value as Record<string, unknown>;
+  return (
+    (e.kind === 'navigate' || e.kind === 'action' || e.kind === 'entity') &&
+    typeof e.key === 'string' &&
+    typeof e.label === 'string' &&
+    typeof e.ts === 'number' &&
+    typeof e.count === 'number'
+  );
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+export function frecencyScore(entry: { ts: number; count: number }, now: number = Date.now()): number {
+  const recency = Math.exp(-(now - entry.ts) / HALF_LIFE_MS);
+  return Math.log10(entry.count + 1) * recency;
+}
+
+export function readRecents(now: number = Date.now()): RecentEntry[] {
+  const storage = safeStorage();
+  if (!storage) return [];
+  const raw = storage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const fresh = parsed.filter(isRecentEntry).filter(e => now - e.ts < STALE_AFTER_MS);
+    return fresh.sort((a, b) => frecencyScore(b, now) - frecencyScore(a, now)).slice(0, MAX_ENTRIES);
+  } catch {
+    return [];
+  }
+}
+
+function writeRecents(entries: RecentEntry[]): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignored: localStorage may be full or disabled
+  }
+}
+
+export function addRecent(entry: Omit<RecentEntry, 'ts' | 'count'>, now: number = Date.now()): RecentEntry[] {
+  const existing = readRecents(now);
+  const matchIdx = existing.findIndex(e => e.kind === entry.kind && e.key === entry.key);
+  let next: RecentEntry[];
+  if (matchIdx >= 0) {
+    const merged: RecentEntry = { ...existing[matchIdx], label: entry.label, ts: now, count: existing[matchIdx].count + 1 };
+    next = [merged, ...existing.slice(0, matchIdx), ...existing.slice(matchIdx + 1)];
+  } else {
+    next = [{ ...entry, ts: now, count: 1 }, ...existing];
+  }
+  next = next.sort((a, b) => frecencyScore(b, now) - frecencyScore(a, now)).slice(0, MAX_ENTRIES);
+  writeRecents(next);
+  return next;
+}
+
+export function removeRecent(kind: PaletteItemKind, key: string): RecentEntry[] {
+  const existing = readRecents();
+  const next = existing.filter(e => !(e.kind === kind && e.key === key));
+  writeRecents(next);
+  return next;
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -8,6 +8,7 @@ import './server/i18n.extractParams.test';
 import './server/i18n.invariants.test';
 import './server/membersMethods.test';
 import './server/mutationPipeline.test';
+import './server/paletteRecents.test';
 import './server/paletteSearch.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';

--- a/tests/server/paletteRecents.test.ts
+++ b/tests/server/paletteRecents.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { frecencyScore } from '../../imports/ui/palette/palette.recents';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('frecencyScore', () => {
+  const now = Date.now();
+
+  it('higher count outranks lower count when timestamps are equal', () => {
+    const a = frecencyScore({ ts: now, count: 5 }, now);
+    const b = frecencyScore({ ts: now, count: 1 }, now);
+    assert.ok(a > b, `expected count=5 (${a}) to outrank count=1 (${b})`);
+  });
+
+  it('more-recent timestamp outranks older when counts are equal', () => {
+    const recent = frecencyScore({ ts: now - DAY_MS, count: 1 }, now);
+    const stale = frecencyScore({ ts: now - 7 * DAY_MS, count: 1 }, now);
+    assert.ok(recent > stale, `expected recent (${recent}) > stale (${stale})`);
+  });
+
+  it('1-day-old count=2 outranks 7-day-old count=1', () => {
+    const a = frecencyScore({ ts: now - 1 * DAY_MS, count: 2 }, now);
+    const b = frecencyScore({ ts: now - 7 * DAY_MS, count: 1 }, now);
+    assert.ok(a > b, `expected fresh frequent (${a}) to outrank stale rare (${b})`);
+  });
+
+  it('decays toward zero for very old entries', () => {
+    const ancient = frecencyScore({ ts: now - 365 * DAY_MS, count: 50 }, now);
+    assert.ok(ancient < 0.001, `expected near-zero score for 1-year-old entry, got ${ancient}`);
+  });
+
+  it('returns positive scores for valid entries', () => {
+    const score = frecencyScore({ ts: now, count: 1 }, now);
+    assert.ok(score > 0, `expected positive score, got ${score}`);
+  });
+});


### PR DESCRIPTION
## Summary
- New `palette.recents.ts` helper with localStorage-backed read/add/remove + frecency formula `log10(count+1) * exp(-(now-ts)/14d)`.
- Capped at 10 entries; entries older than 30 days pruned on next read.
- Empty palette renders `Recents` group (max 5) on top, then Create-X, global controls, and Nav.
- While searching, recency is folded into result ordering within each group.
- Each successful selection upserts the item via `addRecent`.
- Survives missing localStorage (private mode) gracefully.
- 1 new i18n key (`palette.recent`) + 5 frecency unit tests.

Closes #143.

## Test plan
- [ ] Select 5 items, refresh, see them in 'Recents' on top of empty palette.
- [ ] More-recent items rank higher than older ones.
- [ ] No errors in private/incognito where localStorage may be unavailable.
- [ ] All 230 tests pass (verified locally).