### PR TITLE
feat(palette): a11y polish — focus trap return + aria-live announcer (#144)

### DIFF
--- a/imports/i18n/translations.ts
+++ b/imports/i18n/translations.ts
@@ -395,6 +395,7 @@ export const translations = {
   "palette.placeholder": { en: "Search…", de: "Suchen…", fr: "Rechercher…" },
   "palette.questionnaires": { en: "Questionnaires", de: "Fragebögen", fr: "Questionnaires" },
   "palette.recent": { en: "Recent", de: "Zuletzt verwendet", fr: "Récent" },
+  "palette.resultCount": { en: "{{count}} results", de: "{{count}} Ergebnisse", fr: "{{count}} résultats" },
   "palette.registrations": { en: "Registrations", de: "Bewerbungen", fr: "Inscriptions" },
   "palette.squads": { en: "Squads", de: "Trupps", fr: "Escouades" },
   "palette.switchLanguage": { en: "Switch language", de: "Sprache wechseln", fr: "Changer de langue" },

--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -228,6 +228,20 @@ export default function Palette() {
     return () => window.removeEventListener('popstate', setNavOnPopstate);
   }, [setNavOnPopstate]);
 
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setAnnouncement('');
+      return;
+    }
+    const total = filteredItems.length;
+    const handle = setTimeout(() => {
+      setAnnouncement(total === 0 ? t('palette.noResults') : t('palette.resultCount', { count: total }));
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [filteredItems.length, open, t]);
+
   let runningIndex = -1;
 
   return (
@@ -238,14 +252,25 @@ export default function Palette() {
       closable={false}
       destroyOnHidden
       maskClosable
+      keyboard
+      focusTriggerAfterClose
       width={640}
       style={{ top: 96 }}
       styles={{ body: { padding: 0 } }}
+      aria-label={t('palette.placeholder')}
       afterOpenChange={isOpen => {
         if (isOpen) inputRef.current?.focus();
       }}
     >
       <div style={{ display: 'flex', flexDirection: 'column', maxHeight: '60vh' }}>
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          style={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', border: 0 }}
+        >
+          {announcement}
+        </div>
         <Input
           ref={inputRef}
           placeholder={t('palette.placeholder')}


### PR DESCRIPTION
## Summary
- Add `focusTriggerAfterClose` to `Modal` so focus returns to the previously focused element on close.
- Visually hidden `role=status aria-live=polite` region announces result count after 250ms settle.
- Antd Modal already traps Tab focus; verified there's no escape to background.
- 1 new i18n key (`palette.resultCount` with `{{count}}` param).

## Notes for reviewer
- Manual screen-reader pass with NVDA/VoiceOver was not run by an agent — recommend a human pass before final ship.

Closes #144.

## Test plan
- [ ] After typing, NVDA/VoiceOver hears '12 results' (or 'No results') ~250ms after the user stops.
- [ ] Closing the palette returns focus to the element focused before opening.
- [ ] Tab cycles within the modal only.
- [ ] All 230 tests pass (verified locally).