### PR TITLE
docs(palette): close translation open question + minor de tweak (#145)

### DIFF
--- a/docs/prds/cmd-k-palette.md
+++ b/docs/prds/cmd-k-palette.md
@@ -206,5 +206,5 @@ Total estimate: ~3 working days.
 
 ## Open questions
 
-- Translations for German and French — defer to translator review or stub in English first?
+- ~~Translations for German and French — defer to translator review or stub in English first?~~ Resolved (#145): all 20 `palette.*` keys translated as best-effort during implementation. A native German/French review pass is still recommended before broad release; flag in #145 once a reviewer has signed off.
 - Should the palette show a tooltip "Press ⌘K" somewhere on first session for discoverability, given there's no visible button?

--- a/imports/i18n/translations.ts
+++ b/imports/i18n/translations.ts
@@ -394,7 +394,7 @@ export const translations = {
   "palette.noResults": { en: "No results", de: "Keine Ergebnisse", fr: "Aucun résultat" },
   "palette.placeholder": { en: "Search…", de: "Suchen…", fr: "Rechercher…" },
   "palette.questionnaires": { en: "Questionnaires", de: "Fragebögen", fr: "Questionnaires" },
-  "palette.recent": { en: "Recent", de: "Zuletzt verwendet", fr: "Récent" },
+  "palette.recent": { en: "Recent", de: "Zuletzt", fr: "Récent" },
   "palette.resultCount": { en: "{{count}} results", de: "{{count}} Ergebnisse", fr: "{{count}} résultats" },
   "palette.registrations": { en: "Registrations", de: "Bewerbungen", fr: "Inscriptions" },
   "palette.squads": { en: "Squads", de: "Trupps", fr: "Escouades" },


### PR DESCRIPTION
## Summary
- All 20 `palette.*` keys are already translated to en/de/fr (filled in by prior slices on a best-effort basis).
- One refinement: shorten German `palette.recent` from 'Zuletzt verwendet' to 'Zuletzt' for compact rendering.
- Update the PRD: mark the translations open question as resolved with a note that **native-speaker review is still recommended** before broad release. The agent cannot substitute for a native reviewer.

Closes #145.

## Test plan
- [ ] All translations render in en/de/fr without clipping at default modal width.
- [ ] Native German + French speaker review queued as a follow-up before the feature is broadly announced.