### PR TITLE
feat(palette): Fuse.js fuzzy ranking across the union of static + entity items

### DIFF
--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -13,6 +13,7 @@ import { PaletteContext } from './PaletteContext';
 import { getCreatePaletteItems, getEntityPaletteItems, getGlobalPaletteItems, getNavigatePaletteItems } from './palette.items';
 import type { PaletteEntityResults } from './palette.items';
 import { addRecent, frecencyScore, readRecents, type RecentEntry } from './palette.recents';
+import { scoreItems } from './palette.scoring';
 import type { PaletteItem } from './palette.types';
 
 const EMPTY_ENTITY_RESULTS: PaletteEntityResults = {
@@ -126,18 +127,16 @@ export default function Palette() {
   }, [recents]);
 
   const filteredItems = useMemo<PaletteItem[]>(() => {
-    const trimmed = query.trim().toLowerCase();
-    const matches = (item: PaletteItem) => item.label.toLowerCase().includes(trimmed);
+    const trimmed = query.trim();
     const sortByRecency = (items: PaletteItem[]) =>
       [...items].sort((a, b) => (recencyBoost.get(`${b.kind}:${b.key}`) ?? 0) - (recencyBoost.get(`${a.kind}:${a.key}`) ?? 0));
     if (!trimmed) {
       return [...recentItems, ...sortByRecency(createItems), ...globalItems, ...sortByRecency(navigateItems)];
     }
-    const filteredCreate = sortByRecency(createItems.filter(matches));
-    const filteredGlobal = globalItems.filter(matches);
-    const filteredNav = sortByRecency(navigateItems.filter(matches));
-    const filteredEntity = sortByRecency(entityItems);
-    return [...filteredEntity, ...filteredCreate, ...filteredGlobal, ...filteredNav];
+    const union = [...entityItems, ...createItems, ...globalItems, ...navigateItems];
+    const scored = scoreItems(trimmed, union, { recencyBoost });
+    const ranked = scored.map(s => s.item);
+    return ranked;
   }, [recentItems, navigateItems, createItems, globalItems, entityItems, query, recencyBoost]);
 
   const groupedItems = useMemo(() => {

--- a/imports/ui/palette/palette.scoring.ts
+++ b/imports/ui/palette/palette.scoring.ts
@@ -1,0 +1,49 @@
+import Fuse from 'fuse.js';
+import type { PaletteItem } from './palette.types';
+
+const FUSE_OPTIONS: Fuse.IFuseOptions<PaletteItem> = {
+  keys: [{ name: 'label', weight: 1 }],
+  threshold: 0.4,
+  ignoreLocation: true,
+  includeScore: true,
+  isCaseSensitive: false,
+  shouldSort: true,
+  minMatchCharLength: 1,
+};
+
+const PREFIX_BOOST = 0.4;
+const RECENCY_WEIGHT = 0.3;
+
+export interface ScoreOptions {
+  recencyBoost?: Map<string, number>;
+}
+
+export interface ScoredItem {
+  item: PaletteItem;
+  score: number;
+}
+
+export function scoreItems(query: string, items: PaletteItem[], options: ScoreOptions = {}): ScoredItem[] {
+  const trimmed = query.trim();
+  if (!trimmed) return items.map(item => ({ item, score: 0 }));
+
+  const fuse = new Fuse(items, FUSE_OPTIONS);
+  const lowerQuery = trimmed.toLowerCase();
+  const recencyBoost = options.recencyBoost;
+
+  const matches = fuse.search(trimmed);
+  return matches.map(match => {
+    let score = match.score ?? 1;
+    const lowerLabel = match.item.label.toLowerCase();
+    if (lowerLabel.startsWith(lowerQuery)) {
+      score = Math.max(0, score - PREFIX_BOOST);
+    }
+    if (recencyBoost) {
+      const boost = recencyBoost.get(`${match.item.kind}:${match.item.key}`);
+      if (boost !== undefined) {
+        score = Math.max(0, score - boost * RECENCY_WEIGHT);
+      }
+    }
+    return { item: match.item, score };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@babel/runtime": "^7.25.4",
         "@swc/helpers": "^0.5.17",
         "antd": "^5.20.2",
+        "fuse.js": "^7.3.0",
         "jszip": "^3.10.1",
         "meteor-node-stubs": "^1.2.7",
         "react": "^18.3.1",
@@ -8127,6 +8128,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/runtime": "^7.25.4",
     "@swc/helpers": "^0.5.17",
     "antd": "^5.20.2",
+    "fuse.js": "^7.3.0",
     "jszip": "^3.10.1",
     "meteor-node-stubs": "^1.2.7",
     "react": "^18.3.1",

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -9,6 +9,7 @@ import './server/i18n.invariants.test';
 import './server/membersMethods.test';
 import './server/mutationPipeline.test';
 import './server/paletteRecents.test';
+import './server/paletteScoring.test';
 import './server/paletteSearch.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';

--- a/tests/server/paletteScoring.test.ts
+++ b/tests/server/paletteScoring.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+import { scoreItems } from '../../imports/ui/palette/palette.scoring';
+import type { PaletteItem } from '../../imports/ui/palette/palette.types';
+
+function makeItem(label: string, key: string = label, kind: PaletteItem['kind'] = 'navigate'): PaletteItem {
+  return {
+    kind,
+    key,
+    label,
+    group: 'Test',
+    onSelect: () => {},
+  };
+}
+
+describe('palette scoring (Fuse + boosts)', () => {
+  it('returns items unchanged when query is empty', () => {
+    const items = [makeItem('Alpha'), makeItem('Bravo')];
+    const out = scoreItems('', items);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].item.label, 'Alpha');
+    assert.strictEqual(out[1].item.label, 'Bravo');
+  });
+
+  it('finds typo matches (vipr -> Viper)', () => {
+    const items = [makeItem('Wolverine'), makeItem('Viper'), makeItem('Hammer')];
+    const out = scoreItems('vipr', items);
+    assert.ok(
+      out.some(s => s.item.label === 'Viper'),
+      'Fuse should find Viper for query "vipr"'
+    );
+  });
+
+  it('boosts prefix matches above mid-word matches', () => {
+    const items = [makeItem('Watermark'), makeItem('Members')];
+    const out = scoreItems('mem', items);
+    const memIdx = out.findIndex(s => s.item.label === 'Members');
+    const waterIdx = out.findIndex(s => s.item.label === 'Watermark');
+    assert.ok(memIdx !== -1, 'Members should match');
+    if (waterIdx !== -1) {
+      assert.ok(memIdx < waterIdx, 'expected prefix match Members to rank above mid-word Watermark');
+    }
+  });
+
+  it('applies recency boost to lower the score of recent items', () => {
+    const items = [makeItem('Members', 'nav:members'), makeItem('Medals', 'nav:medals')];
+    const recencyBoost = new Map<string, number>([['navigate:nav:members', 1.0]]);
+    const out = scoreItems('me', items, { recencyBoost });
+    const membersIdx = out.findIndex(s => s.item.label === 'Members');
+    const medalsIdx = out.findIndex(s => s.item.label === 'Medals');
+    assert.ok(membersIdx !== -1 && medalsIdx !== -1, 'both items should match');
+    assert.ok(membersIdx <= medalsIdx, 'expected boosted Members to rank at or above Medals');
+  });
+
+  it('returns empty array for queries with no matches', () => {
+    const items = [makeItem('Alpha'), makeItem('Bravo')];
+    const out = scoreItems('xqz123nomatch', items);
+    assert.strictEqual(out.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
Implements the deferred PRD slice #4. Replaces the substring filter with Fuse.js fuzzy scoring when the user is typing.

- Adds `fuse.js` (~12 KB gzipped).
- New `palette.scoring.ts` builds a Fuse index over the union of nav/create/global/entity items per query.
- Single `label` search key; `threshold: 0.4`, `ignoreLocation: true`.
- Prefix boost: `-0.4` to score when label starts with query.
- Recency boost: `-0.3 * frecency` for items previously selected.
- Empty-state ordering (Recents + statics) unchanged.

5 new unit tests:
- empty query returns items unchanged
- typo ('vipr') still finds 'Viper'
- prefix matches rank above mid-word
- recency boost lifts boosted items
- no-match query returns empty

## Test plan
- [ ] Type 'vipr' in palette → Viper appears.
- [ ] Type 'mem' → 'Members' ranks above 'Medals' if no recents, otherwise the recent one ranks first.
- [ ] All 235 unit tests pass.