### PR TITLE
perf: parallelize independent awaits across server bootstrap + admin paths

### DIFF
--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -74,8 +74,18 @@ export default function Orbat() {
       }
     }
 
-    const prepareData = async (squad: Squad) => {
-      const src = squad.image ? (await turnBase64ToImage(squad.image)).src : null;
+    // Two-phase build: race the per-squad image decoding in parallel, then
+    // assemble the tree sequentially so parents are placed before children
+    // look them up via findParentRecursive. The ordered traversal (roots →
+    // parents → children) preserves the prior tree-attachment semantics.
+    const orderedSquads = [...roots, ...parents, ...children];
+    const decoded = await Promise.all(
+      orderedSquads.map(async squad => ({
+        squad,
+        src: squad.image ? (await turnBase64ToImage(squad.image)).src : null,
+      })),
+    );
+    for (const { squad, src } of decoded) {
       const data: OrbatNode = {
         id: squad._id ?? '',
         name: squad.name,
@@ -92,10 +102,6 @@ export default function Orbat() {
       } else {
         parent.children.push(data);
       }
-    };
-
-    for (const squad of [...roots, ...parents, ...children]) {
-      await prepareData(squad);
     }
     return preparedOrbatOptions;
   }, [squads, findParentRecursive]);

--- a/server/apis/backup.server.ts
+++ b/server/apis/backup.server.ts
@@ -67,7 +67,12 @@ if (Meteor.isServer) {
         },
       };
 
-      for (const collectionName of BACKUP_COLLECTIONS) {
+      // Every collection fetch is independent — race them through
+      // Promise.all instead of waterfalling. Mutations to the shared
+      // `backup` object are safe under interleaved awaits because JS is
+      // single-threaded between yield points, and each iteration writes
+      // disjoint keys (totalDocuments uses `+=`, atomic in JS).
+      await Promise.all(BACKUP_COLLECTIONS.map(async collectionName => {
         try {
           const Collection = getCollection(collectionName);
           const documents = await Collection.find({}).fetchAsync();
@@ -79,7 +84,7 @@ if (Meteor.isServer) {
           backup.collections[collectionName] = [];
           backup.meta.collectionCounts[collectionName] = 0;
         }
-      }
+      }));
 
       try {
         const settings = await SettingsCollection.find({}).fetchAsync();
@@ -132,7 +137,8 @@ if (Meteor.isServer) {
         },
       };
 
-      for (const collectionName of BACKUP_COLLECTIONS) {
+      // See parallelization rationale on backup.create above — same pattern.
+      await Promise.all(BACKUP_COLLECTIONS.map(async collectionName => {
         try {
           const Collection = getCollection(collectionName);
           const documents = await Collection.find({}).fetchAsync();
@@ -144,7 +150,7 @@ if (Meteor.isServer) {
           backup.collections[collectionName] = [];
           backup.meta.collectionCounts[collectionName] = 0;
         }
-      }
+      }));
 
       try {
         const settings = await SettingsCollection.find({}).fetchAsync();
@@ -209,15 +215,17 @@ if (Meteor.isServer) {
         safetyBackup,
       };
 
+      // Outer loop stays sequential — inserting collections in declared order
+      // preserves any implicit FK ordering. Inner inserts are parallelized
+      // because every doc within a collection is independent (fixed _ids,
+      // no intra-collection ordering dependency).
       for (const collectionName of BACKUP_COLLECTIONS) {
         if (backupData.collections[collectionName]) {
           try {
             const Collection = getCollection(collectionName);
             await Collection.removeAsync({});
             const documents = backupData.collections[collectionName];
-            for (const doc of documents) {
-              await Collection.insertAsync(doc as never);
-            }
+            await Promise.all(documents.map(doc => Collection.insertAsync(doc as never)));
             results.restored[collectionName] = documents.length;
           } catch (error) {
             await createLog('backup.restore.error', { collection: collectionName, error: (error as Error).message });
@@ -229,9 +237,7 @@ if (Meteor.isServer) {
       if (backupData.collections.settings) {
         try {
           await SettingsCollection.removeAsync({});
-          for (const doc of backupData.collections.settings) {
-            await SettingsCollection.insertAsync(doc as never);
-          }
+          await Promise.all(backupData.collections.settings.map(doc => SettingsCollection.insertAsync(doc as never)));
           results.restored.settings = backupData.collections.settings.length;
         } catch (error) {
           await createLog('backup.restore.error', { collection: 'settings', error: (error as Error).message });
@@ -243,16 +249,22 @@ if (Meteor.isServer) {
         try {
           const currentUserId = this.userId;
           await MembersCollection.removeAsync({ _id: { $ne: currentUserId } } as never);
-          for (const doc of backupData.collections.users as Array<{ _id: string }>) {
-            if (doc._id === currentUserId) continue;
-            try {
-              await MembersCollection.insertAsync(doc as never);
-            } catch (insertError) {
-              if (!(insertError as Error).message.includes('duplicate key')) {
-                throw insertError;
+          // Per-doc try/catch swallows duplicate-key errors (the current user
+          // is left in place pre-wipe, so a backup containing their id would
+          // otherwise reject). Promise.all preserves that behavior because
+          // each map callback owns its own try/catch.
+          await Promise.all(
+            (backupData.collections.users as Array<{ _id: string }>).map(async doc => {
+              if (doc._id === currentUserId) return;
+              try {
+                await MembersCollection.insertAsync(doc as never);
+              } catch (insertError) {
+                if (!(insertError as Error).message.includes('duplicate key')) {
+                  throw insertError;
+                }
               }
-            }
-          }
+            }),
+          );
           results.restored.users = backupData.collections.users.length;
         } catch (error) {
           await createLog('backup.restore.error', { collection: 'users', error: (error as Error).message });

--- a/server/apis/demoData.server.ts
+++ b/server/apis/demoData.server.ts
@@ -23,25 +23,29 @@ import { validateUserId, checkPermission } from '../main';
 import { createLog } from './logs.server';
 
 async function wipeAllCollections(): Promise<void> {
-  await AttendancesCollection.removeAsync({});
-  await DiscoveryTypesCollection.removeAsync({});
-  await EventsCollection.removeAsync({});
-  await EventTypesCollection.removeAsync({});
-  await LogsCollection.removeAsync({});
-  await MedalsCollection.removeAsync({});
-  await MembersCollection.removeAsync({});
-  await PositionsCollection.removeAsync({});
-  await ProfilePicturesCollection.removeAsync({});
-  await QuestionnairesCollection.removeAsync({});
-  await QuestionnaireResponsesCollection.removeAsync({});
-  await RanksCollection.removeAsync({});
-  await RegistrationsCollection.removeAsync({});
-  await RolesCollection.removeAsync({});
-  await SettingsCollection.removeAsync({});
-  await SpecializationsCollection.removeAsync({});
-  await SquadsCollection.removeAsync({});
-  await TasksCollection.removeAsync({});
-  await TaskStatusCollection.removeAsync({});
+  // Every collection-wipe is independent — racing them through Promise.all
+  // turns a 19-step waterfall into a single round-trip.
+  await Promise.all([
+    AttendancesCollection.removeAsync({}),
+    DiscoveryTypesCollection.removeAsync({}),
+    EventsCollection.removeAsync({}),
+    EventTypesCollection.removeAsync({}),
+    LogsCollection.removeAsync({}),
+    MedalsCollection.removeAsync({}),
+    MembersCollection.removeAsync({}),
+    PositionsCollection.removeAsync({}),
+    ProfilePicturesCollection.removeAsync({}),
+    QuestionnairesCollection.removeAsync({}),
+    QuestionnaireResponsesCollection.removeAsync({}),
+    RanksCollection.removeAsync({}),
+    RegistrationsCollection.removeAsync({}),
+    RolesCollection.removeAsync({}),
+    SettingsCollection.removeAsync({}),
+    SpecializationsCollection.removeAsync({}),
+    SquadsCollection.removeAsync({}),
+    TasksCollection.removeAsync({}),
+    TaskStatusCollection.removeAsync({}),
+  ]);
 }
 
 // Seed data definitions: typed loosely since they mix schema fields with seed-only _id values.
@@ -276,42 +280,55 @@ function createAvatarDataUri(initial: string, color: string): string {
 }
 
 async function insertDemoData(): Promise<void> {
-  for (const role of ROLES) await RolesCollection.insertAsync(role as never);
-  for (const squad of SQUADS) await SquadsCollection.insertAsync(squad as never);
-  for (const rank of RANKS) await RanksCollection.insertAsync(rank as never);
-  for (const spec of SPECIALIZATIONS) await SpecializationsCollection.insertAsync(spec as never);
-  for (const medal of MEDALS) await MedalsCollection.insertAsync(medal as never);
-  for (const position of POSITIONS) await PositionsCollection.insertAsync(position as never);
-  for (const dt of DISCOVERY_TYPES) await DiscoveryTypesCollection.insertAsync(dt as never);
-  for (const et of EVENT_TYPES) await EventTypesCollection.insertAsync(et as never);
-  for (const ts of TASK_STATUSES) await TaskStatusCollection.insertAsync(ts as never);
+  // Reference data: every seed item within a collection inserts independently
+  // (fixed explicit _ids, no intra-collection ordering dependency). Run each
+  // collection's seed in parallel via Promise.all. Keeping the collections
+  // themselves sequential preserves the implicit FK ordering for any future
+  // referential-integrity layer that may validate inserts (ranks before
+  // specializations that require a rank, etc.).
+  await Promise.all(ROLES.map(role => RolesCollection.insertAsync(role as never)));
+  await Promise.all(SQUADS.map(squad => SquadsCollection.insertAsync(squad as never)));
+  await Promise.all(RANKS.map(rank => RanksCollection.insertAsync(rank as never)));
+  await Promise.all(SPECIALIZATIONS.map(spec => SpecializationsCollection.insertAsync(spec as never)));
+  await Promise.all(MEDALS.map(medal => MedalsCollection.insertAsync(medal as never)));
+  await Promise.all(POSITIONS.map(position => PositionsCollection.insertAsync(position as never)));
+  await Promise.all(DISCOVERY_TYPES.map(dt => DiscoveryTypesCollection.insertAsync(dt as never)));
+  await Promise.all(EVENT_TYPES.map(et => EventTypesCollection.insertAsync(et as never)));
+  await Promise.all(TASK_STATUSES.map(ts => TaskStatusCollection.insertAsync(ts as never)));
 
-  const memberIds: string[] = [];
-  for (let i = 0; i < MEMBERS.length; i++) {
-    const member = MEMBERS[i];
-    const userId = await Accounts.createUserAsync({ username: member.username, password: member.password });
-    const avatarDataUri = createAvatarDataUri(member.profile.name[0], AVATAR_COLORS[i % AVATAR_COLORS.length]);
-    const picId = await ProfilePicturesCollection.insertAsync({ value: avatarDataUri });
-    await MembersCollection.updateAsync(userId, { $set: { profile: { ...member.profile, profilePictureId: picId } } } as never);
-    memberIds.push(userId);
-  }
+  // Members: each member's three-step chain (account create → avatar insert →
+  // profile attach) stays sequential because each step depends on the previous
+  // step's id. Across members the chains are independent — Promise.all
+  // preserves array order in the result, so memberIds[i] stays aligned with
+  // MEMBERS[i], which createAttendances and createTasks rely on for index-
+  // based lookups.
+  const memberIds: string[] = await Promise.all(
+    MEMBERS.map(async (member, i) => {
+      const userId = await Accounts.createUserAsync({ username: member.username, password: member.password });
+      const avatarDataUri = createAvatarDataUri(member.profile.name[0], AVATAR_COLORS[i % AVATAR_COLORS.length]);
+      const picId = await ProfilePicturesCollection.insertAsync({ value: avatarDataUri });
+      await MembersCollection.updateAsync(userId, { $set: { profile: { ...member.profile, profilePictureId: picId } } } as never);
+      return userId;
+    }),
+  );
 
   const events = createEvents();
-  for (const event of events) await EventsCollection.insertAsync(event as never);
+  await Promise.all(events.map(event => EventsCollection.insertAsync(event as never)));
 
   const attendances = createAttendances(memberIds);
-  for (const att of attendances) await AttendancesCollection.insertAsync(att as never);
+  await Promise.all(attendances.map(att => AttendancesCollection.insertAsync(att as never)));
 
   const tasks = createTasks(memberIds);
-  for (const task of tasks) await TasksCollection.insertAsync(task as never);
+  await Promise.all(tasks.map(task => TasksCollection.insertAsync(task as never)));
 
+  // Questionnaire must exist before its responses (FK questionnaireId: 'q-1').
   await QuestionnairesCollection.insertAsync(createQuestionnaire() as never);
   const responses = createQuestionnaireResponses(memberIds);
-  for (const resp of responses) await QuestionnaireResponsesCollection.insertAsync(resp as never);
+  await Promise.all(responses.map(resp => QuestionnaireResponsesCollection.insertAsync(resp as never)));
 
-  for (const reg of REGISTRATIONS) await RegistrationsCollection.insertAsync(reg as never);
+  await Promise.all(REGISTRATIONS.map(reg => RegistrationsCollection.insertAsync(reg as never)));
 
-  for (const setting of SETTINGS) await SettingsCollection.insertAsync(setting as never);
+  await Promise.all(SETTINGS.map(setting => SettingsCollection.insertAsync(setting as never)));
 }
 
 if (Meteor.isServer) {

--- a/server/apis/events.server.ts
+++ b/server/apis/events.server.ts
@@ -80,9 +80,13 @@ if (Meteor.isServer) {
       const event = await EventsCollection.findOneAsync(eventId);
       if (!event) throw new Meteor.Error(404, 'Event not found');
 
-      const eventType = event.eventType ? await EventTypesCollection.findOneAsync(event.eventType) : null;
-      const hosts = await resolveNames(event.hosts);
-      const attendees = await resolveNames(event.attendees);
+      // Event-type lookup, host names, and attendee names are independent —
+      // race them via Promise.all instead of waterfalling.
+      const [eventType, hosts, attendees] = await Promise.all([
+        event.eventType ? EventTypesCollection.findOneAsync(event.eventType) : Promise.resolve(null),
+        resolveNames(event.hosts),
+        resolveNames(event.attendees),
+      ]);
 
       return {
         ...event,

--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -119,9 +119,13 @@ if (Meteor.isServer) {
         [memberId, data] as const,
         async ([targetId, changes]) => {
           // Existence check + squad-scope reject stay as code in the body — both
-          // are 1-site variations and out of scope for the registry.
-          const targetMember = await getMemberById(targetId);
-          const role = await getUserRole(callerUserId);
+          // are 1-site variations and out of scope for the registry. The target-
+          // member lookup and the caller-role lookup hit different collections
+          // with no dependency between them — race them via Promise.all.
+          const [targetMember, role] = await Promise.all([
+            getMemberById(targetId),
+            getUserRole(callerUserId),
+          ]);
           if (!isOfficerOrAdmin(role)) {
             const viewer = await MembersCollection.findOneAsync(callerUserId!);
             if (viewer?.profile?.squadId && targetMember?.profile?.squadId !== viewer.profile.squadId) {
@@ -258,8 +262,12 @@ if (Meteor.isServer) {
 
       const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
       const squadIds = [...new Set(members.flatMap(m => m.profile?.squadId ? [m.profile.squadId] : []))];
-      const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
-      const squads = await SquadsCollection.find({ _id: { $in: squadIds } }).fetchAsync();
+      // Ranks and squads are independent lookups — race them via Promise.all
+      // instead of waterfalling.
+      const [ranks, squads] = await Promise.all([
+        RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync(),
+        SquadsCollection.find({ _id: { $in: squadIds } }).fetchAsync(),
+      ]);
       const rankNameById = new Map(ranks.map(r => [r._id, r.name]));
       const squadNameById = new Map(squads.map(s => [s._id, s.name]));
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -195,19 +195,18 @@ async function createTestData(): Promise<void> {
 }
 
 async function createDatabaseIndexes(): Promise<void> {
-  await MembersCollection.rawCollection().createIndex({ 'profile.squadId': 1 });
-  await MembersCollection.rawCollection().createIndex({ 'profile.rankId': 1 });
-
-  await AttendancesCollection.rawCollection().createIndex({ eventId: 1 });
-
-  await LogsCollection.rawCollection().createIndex({ createdAt: -1 });
-  await LogsCollection.rawCollection().createIndex({ action: 1 });
-
-  await EventsCollection.rawCollection().createIndex({ eventType: 1 });
-
-  await TasksCollection.rawCollection().createIndex({ status: 1 });
-
-  await RegistrationsCollection.rawCollection().createIndex({ discoveryType: 1 });
+  // Every createIndex call is independent — race them on startup instead of
+  // running 8 sequential round-trips. Mongo will dedupe if any already exist.
+  await Promise.all([
+    MembersCollection.rawCollection().createIndex({ 'profile.squadId': 1 }),
+    MembersCollection.rawCollection().createIndex({ 'profile.rankId': 1 }),
+    AttendancesCollection.rawCollection().createIndex({ eventId: 1 }),
+    LogsCollection.rawCollection().createIndex({ createdAt: -1 }),
+    LogsCollection.rawCollection().createIndex({ action: 1 }),
+    EventsCollection.rawCollection().createIndex({ eventType: 1 }),
+    TasksCollection.rawCollection().createIndex({ status: 1 }),
+    RegistrationsCollection.rawCollection().createIndex({ discoveryType: 1 }),
+  ]);
 }
 
 if (Meteor.isServer) {


### PR DESCRIPTION
## Summary

Tackles 29 of the 56 `async-parallel` / `async-await-in-loop` findings react-doctor flagged in PR #172, focusing on the highest-leverage paths: server startup, bulk admin operations, and one N+1-shaped UI query. Each change wraps independent operations in `Promise.all` so they race instead of waterfalling.

## What changed

| File | Findings | Notable wins |
|---|---|---|
| `server/main.ts` | 1 → 0 | 8 startup createIndex calls in parallel — trims ~hundred ms off every boot |
| `server/apis/demoData.server.ts` | 18 → 0 | Demo-data wipe goes from 19 round-trips to 1. Seed inserts parallelize within each collection |
| `server/apis/backup.server.ts` | 6 → 0 | Per-collection fetch + per-doc restore inserts parallelize; outer restore loop kept sequential for FK safety |
| `server/apis/members.server.ts` | 2 → 0 | `members.update` and `members.groupedOptions` lookups race |
| `server/apis/events.server.ts` | 1 → 0 | `events.detail` event-type + hosts + attendees all race |
| `imports/ui/orbat/Orbat.tsx` | 1 → 0 | Two-phase: image decode races in parallel, tree assembly stays sequential |

**Deferred** (1 finding):
- `server/crud.lib.ts:219` (`bulkRemove` inner loop) — conflicts with PR #170's integrity wiring on this exact function. Pick up there or as a follow-up after #170 lands.

## Correctness notes

- **Ordering preserved where it matters.** `demoData.insertDemoData` keeps its outer-loop order so FK targets exist before referrers (ranks before specializations, questionnaire before responses). Within each loop the seed items are independent (fixed explicit `_ids`).
- **`memberIds` order preserved** via `Promise.all(MEMBERS.map(...))`, which returns results in array order — `createAttendances` and `createTasks` rely on `memberIds[i]` aligning with `MEMBERS[i]`.
- **Backup `+=` on shared counter** is safe: JS is single-threaded between await points, and `totalDocuments += documents.length` happens after each iteration's await resumes — no torn writes.
- **Per-iteration try/catch preserved** in the restore loops, including the duplicate-key swallowing on the users path.
- **Orbat tree-build stays sequential** in its second phase so `findParentRecursive` always sees a parent before its children look it up; only the I/O (image decoding) races.

## Test plan

- [x] `npm test` — 235 passing, no regressions
- [x] `npm run typecheck` — clean (no new errors)
- [ ] Manual: run `demoData.generate` in dev — verify all collections wipe + seed cleanly and the UI renders normally
- [ ] Manual: take a backup, restore it — verify counts in the restore result match expectations
- [ ] Manual: load the ORBAT view with several squads + images — tree should render correctly with parents above children