### PR TITLE
fix: replace array-index React keys with stable composites

### DIFF
--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -216,13 +216,13 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
               label: translateLabel(key),
               children:
                 key === 'specializations' && Array.isArray(value) && value.length > 0
-                  ? (value as Specialization[]).map((spec, i) =>
+                  ? (value as Specialization[]).map(spec =>
                       spec.linkToFile ? (
-                        <a key={i} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
+                        <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
                           <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
                         </a>
                       ) : (
-                        <Tag key={i}>{spec.name}</Tag>
+                        <Tag key={spec.name}>{spec.name}</Tag>
                       )
                     )
                   : key === 'specializations'

--- a/imports/ui/members/MemberProfile.tsx
+++ b/imports/ui/members/MemberProfile.tsx
@@ -36,8 +36,8 @@ function AttendancePieChart({ data, title }: AttendancePieChartProps) {
       <ResponsiveContainer width="100%" height={200}>
         <PieChart>
           <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={70} label>
-            {chartData.map((entry, index) => (
-              <Cell key={index} fill={entry.color} />
+            {chartData.map(entry => (
+              <Cell key={entry.name} fill={entry.color} />
             ))}
           </Pie>
           <Tooltip />
@@ -256,13 +256,13 @@ export default function MemberProfile({ memberId }: MemberProfileProps) {
               {
                 label: t('members.specializations'),
                 children: Array.isArray(profileStats.specializations) && profileStats.specializations.length > 0
-                  ? profileStats.specializations.map((spec, i) =>
+                  ? profileStats.specializations.map(spec =>
                       spec.linkToFile ? (
-                        <a key={i} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
+                        <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
                           <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
                         </a>
                       ) : (
-                        <Tag key={i}>{spec.name}</Tag>
+                        <Tag key={spec.name}>{spec.name}</Tag>
                       )
                     )
                   : '-',

--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -240,8 +240,8 @@ const ORBAT_AdvancedLabel = ({ option, items }: ORBAT_AdvancedLabelProps) => {
         )}
         <Typography.Text type="secondary">{option.descritpion}</Typography.Text>
         {items?.length > 0 ? (
-          items.map((item, index) => (
-            <div key={index}>
+          items.map(item => (
+            <div key={item.label}>
               <Typography.Text strong>{item.label}</Typography.Text>{' '}
               <Typography.Text>{item.children}</Typography.Text>
             </div>

--- a/imports/ui/questionnaires/QuestionnaireResponseForm.tsx
+++ b/imports/ui/questionnaires/QuestionnaireResponseForm.tsx
@@ -48,29 +48,36 @@ const QuestionnaireResponseForm = ({ setOpen, onSuccess }: QuestionnaireResponse
   const renderQuestionField = (question: Question, index: number) => {
     const fieldName = `question_${index}`;
     const rules = question.required ? [{ required: true, message: t('questionnaires.questionRequired') }] : [];
+    // Question type doesn't carry an _id, so we build a stable composite key
+    // from type + text. Far less collision-prone than the bare array index
+    // and stable across re-renders even if AntD reorders Form.Items
+    // internally. (The form-state binding still uses the index via
+    // `fieldName` — that contract is set by the response submit shape on
+    // the server, not by the React reconciliation key.)
+    const key = `${question.type}:${question.text}`;
 
     switch (question.type) {
       case 'text':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Input placeholder={t('questionnaires.enterAnswer')} />
           </Form.Item>
         );
       case 'textarea':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Input.TextArea placeholder={t('questionnaires.enterAnswer')} autoSize={{ minRows: 3 }} />
           </Form.Item>
         );
       case 'number':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <InputNumber placeholder={t('questionnaires.enterNumber')} style={{ width: '100%' }} />
           </Form.Item>
         );
       case 'select':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Select
               placeholder={t('questionnaires.selectOption')}
               options={(question.options || []).map(opt => ({ value: opt, label: opt }))}
@@ -79,7 +86,7 @@ const QuestionnaireResponseForm = ({ setOpen, onSuccess }: QuestionnaireResponse
         );
       case 'multiselect':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Select
               mode="multiple"
               placeholder={t('questionnaires.selectOptions')}
@@ -89,13 +96,13 @@ const QuestionnaireResponseForm = ({ setOpen, onSuccess }: QuestionnaireResponse
         );
       case 'rating':
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Rate />
           </Form.Item>
         );
       default:
         return (
-          <Form.Item key={index} label={question.text} name={fieldName} rules={rules}>
+          <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
             <Input placeholder={t('questionnaires.enterAnswer')} />
           </Form.Item>
         );

--- a/imports/ui/questionnaires/ResponseDetailView.tsx
+++ b/imports/ui/questionnaires/ResponseDetailView.tsx
@@ -46,7 +46,9 @@ const ResponseDetailView = () => {
         <Space direction="vertical" style={{ width: '100%' }} size="middle">
           {(questionnaire.questions || []).map((question, index) => {
             const answer = answers?.find(a => a.questionIndex === index);
-            return <AnswerDisplay key={index} question={question} answer={answer} t={t} />;
+            // Same stable-key rationale as QuestionnaireResponseForm: Question
+            // type carries no _id, so we use type:text as a stable composite.
+            return <AnswerDisplay key={`${question.type}:${question.text}`} question={question} answer={answer} t={t} />;
           })}
         </Space>
       </div>
@@ -71,8 +73,8 @@ const AnswerDisplay = ({ question, answer, t }: AnswerDisplayProps) => {
       case 'multiselect':
         return (
           <Space wrap>
-            {(value as string[]).map((v, i) => (
-              <Tag key={i}>{v}</Tag>
+            {(value as string[]).map(v => (
+              <Tag key={v}>{v}</Tag>
             ))}
           </Space>
         );


### PR DESCRIPTION
## Summary

Closes the 15 `no-array-index-as-key` findings from react-doctor (PR #172). Array-index keys cause subtle reconciliation bugs when the list reorders, gets filtered, or has items inserted/removed mid-array — React reuses the component at position N for whatever item is now there, carrying stale internal state and triggering unnecessary unmount/remount cycles.

Zero behavioural change. The keys only affect React's internal reconciliation; rendered output and form/data semantics are unchanged.

## Files touched

| File | Findings | Replacement key |
|---|---|---|
| `imports/ui/questionnaires/QuestionnaireResponseForm.tsx` | 7 | `${question.type}:${question.text}` |
| `imports/ui/questionnaires/ResponseDetailView.tsx` | 2 | `${question.type}:${question.text}` for outer questions; `v` (the tag value itself) for inner multiselect tags |
| `imports/ui/members/MemberProfile.tsx` | 3 | `entry.name` for pie chart cells; `spec.name` for specialization tags |
| `imports/ui/dashboard/Dashboard.tsx` | 2 | `spec.name` for specialization tags (same pattern as MemberProfile) |
| `imports/ui/orbat/Orbat.tsx` | 1 | `item.label` (formatted "rank-id name", unique within a squad roster) |

## Design note — form-state vs reconciliation key

In `QuestionnaireResponseForm.tsx`, the AntD `Form.Item`'s `name` prop stays index-derived (`question_${index}`) because the server-side response submit shape (`{ questionIndex, value }`) is index-indexed. The React reconciliation `key` and the form-state name are intentionally decoupled — the former gets a stable composite so reorderings don't trigger spurious remounts; the latter stays index-indexed because that's what the server contract expects.

Same story in `ResponseDetailView.tsx`.

## Test plan

- [x] `npm test` — 235 passing, no regressions
- [x] `npm run typecheck` — clean
- [ ] Manual: open a questionnaire response form — fill in some answers, see them persist correctly on submit
- [ ] Manual: view a submitted response — answers align with the right questions
- [ ] Manual: open a member profile — pie chart renders, specialization tags display
- [ ] Manual: open the ORBAT view — popover member lists render correctly