### PR TITLE
perf: combine .map().filter() / .filter().map() into single-pass flatMap

### DIFF
--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -120,29 +120,29 @@ export default function Dashboard() {
             label: t('dashboard.collectionStats'),
             children: (
               <Row gutter={[16, 16]}>
-                {Object.entries(stats)
-                  .filter(([key]) => key !== 'profile')
-                  .map(([key, value]) => {
-                    const translateStatKey = (k: string): string => {
-                      const labelKey = STATS_LABEL_KEYS[k as keyof typeof STATS_LABEL_KEYS];
-                      return labelKey ? t(labelKey) : k;
-                    };
-                    return typeof value === 'object' ? (
-                      Object.keys(value as Record<string, number>).map(childKey => (
-                        <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
-                          <Card variant="outlined">
-                            <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={(value as Record<string, number>)[childKey]} />
-                          </Card>
-                        </Col>
-                      ))
-                    ) : (
-                      <Col xs={24} md={12} lg={8} xxl={6} key={key}>
+                {Object.entries(stats).flatMap(([key, value]) => {
+                  if (key === 'profile') return [];
+                  const translateStatKey = (k: string): string => {
+                    const labelKey = STATS_LABEL_KEYS[k as keyof typeof STATS_LABEL_KEYS];
+                    return labelKey ? t(labelKey) : k;
+                  };
+                  if (typeof value === 'object') {
+                    return Object.keys(value as Record<string, number>).map(childKey => (
+                      <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
                         <Card variant="outlined">
-                          <Statistic title={translateStatKey(key)} value={value as number} />
+                          <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={(value as Record<string, number>)[childKey]} />
                         </Card>
                       </Col>
-                    );
-                  })}
+                    ));
+                  }
+                  return [
+                    <Col xs={24} md={12} lg={8} xxl={6} key={key}>
+                      <Card variant="outlined">
+                        <Statistic title={translateStatKey(key)} value={value as number} />
+                      </Card>
+                    </Col>,
+                  ];
+                })}
               </Row>
             ),
           },
@@ -193,12 +193,11 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
             sm: 1,
             lg: 3,
           }}
-          items={Object.entries(profileStats ?? {})
-            .filter(([key]) => oneThirdWidthKeys.includes(key))
-            .map(([key, value]) => ({
-              label: translateLabel(key),
-              children: value as React.ReactNode,
-            }))}
+          items={Object.entries(profileStats ?? {}).flatMap(([key, value]) =>
+            oneThirdWidthKeys.includes(key)
+              ? [{ label: translateLabel(key), children: value as React.ReactNode }]
+              : []
+          )}
           bordered
         />
       </Col>
@@ -210,25 +209,24 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
           styles={{
             content: { whiteSpace: 'pre-wrap' },
           }}
-          items={Object.entries(profileStats ?? {})
-            .filter(([key]) => fullWidthKeys.includes(key))
-            .map(([key, value]) => ({
-              label: translateLabel(key),
-              children:
-                key === 'specializations' && Array.isArray(value) && value.length > 0
-                  ? (value as Specialization[]).map(spec =>
-                      spec.linkToFile ? (
-                        <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
-                          <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
-                        </a>
-                      ) : (
-                        <Tag key={spec.name}>{spec.name}</Tag>
-                      )
+          items={Object.entries(profileStats ?? {}).flatMap(([key, value]) => {
+            if (!fullWidthKeys.includes(key)) return [];
+            const children =
+              key === 'specializations' && Array.isArray(value) && value.length > 0
+                ? (value as Specialization[]).map(spec =>
+                    spec.linkToFile ? (
+                      <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
+                        <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
+                      </a>
+                    ) : (
+                      <Tag key={spec.name}>{spec.name}</Tag>
                     )
-                  : key === 'specializations'
-                    ? '-'
-                    : value as React.ReactNode,
-            }))}
+                  )
+                : key === 'specializations'
+                  ? '-'
+                  : (value as React.ReactNode);
+            return [{ label: translateLabel(key), children }];
+          })}
           bordered
         />
       </Col>

--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -95,26 +95,23 @@ export default function Palette() {
     const groupLabel = t('palette.recent');
     const staticItems: PaletteItem[] = [...createItems, ...globalItems, ...navigateItems];
     const itemByKey = new Map(staticItems.map(item => [`${item.kind}:${item.key}`, item] as const));
-    return recents
-      .slice(0, 5)
-      .map(entry => {
-        const id = `${entry.kind}:${entry.key}`;
-        const original = itemByKey.get(id);
-        if (original) {
-          return { ...original, key: `recent:${id}`, group: groupLabel };
-        }
-        if (entry.kind !== 'entity') return null;
-        const collection = entry.key.split(':')[1];
-        if (!collection) return null;
-        return {
-          kind: 'entity',
-          key: `recent:${id}`,
-          label: entry.label,
-          group: groupLabel,
-          onSelect: () => navigate(collection),
-        } as PaletteItem;
-      })
-      .filter((item): item is PaletteItem => item !== null);
+    return recents.slice(0, 5).flatMap<PaletteItem>(entry => {
+      const id = `${entry.kind}:${entry.key}`;
+      const original = itemByKey.get(id);
+      if (original) {
+        return [{ ...original, key: `recent:${id}`, group: groupLabel }];
+      }
+      if (entry.kind !== 'entity') return [];
+      const collection = entry.key.split(':')[1];
+      if (!collection) return [];
+      return [{
+        kind: 'entity',
+        key: `recent:${id}`,
+        label: entry.label,
+        group: groupLabel,
+        onSelect: () => navigate(collection),
+      } as PaletteItem];
+    });
   }, [recents, createItems, globalItems, navigateItems, t, navigate]);
 
   const recencyBoost = useMemo(() => {

--- a/imports/ui/palette/palette.items.ts
+++ b/imports/ui/palette/palette.items.ts
@@ -106,13 +106,17 @@ export function getCreatePaletteItems(
 ): PaletteItem[] {
   if (!role) return [];
   const groupLabel = t('palette.actions');
-  return CREATE_ACTIONS.filter(action => hasCreateAccess(role, action.module)).map(action => ({
-    kind: 'action' as const,
-    key: `action:create:${action.route}`,
-    label: t(action.labelKey),
-    group: groupLabel,
-    onSelect: () => navigateWithAction(action.route, 'create'),
-  }));
+  return CREATE_ACTIONS.flatMap(action =>
+    hasCreateAccess(role, action.module)
+      ? [{
+          kind: 'action' as const,
+          key: `action:create:${action.route}`,
+          label: t(action.labelKey),
+          group: groupLabel,
+          onSelect: () => navigateWithAction(action.route, 'create'),
+        }]
+      : []
+  );
 }
 
 export function getEntityPaletteItems(results: PaletteEntityResults, t: Translator, navigate: (route: string) => void): PaletteItem[] {
@@ -180,11 +184,15 @@ export function getEntityPaletteItems(results: PaletteEntityResults, t: Translat
 export function getNavigatePaletteItems(role: Role | undefined, t: Translator, navigate: (route: string) => void): PaletteItem[] {
   if (!role) return [];
   const groupLabel = t('palette.navigate');
-  return NAV_ROUTES.filter(route => hasAccess(role, route.module)).map(route => ({
-    kind: 'navigate' as const,
-    key: `nav:${route.key}`,
-    label: t(route.labelKey),
-    group: groupLabel,
-    onSelect: () => navigate(route.key),
-  }));
+  return NAV_ROUTES.flatMap(route =>
+    hasAccess(role, route.module)
+      ? [{
+          kind: 'navigate' as const,
+          key: `nav:${route.key}`,
+          label: t(route.labelKey),
+          group: groupLabel,
+          onSelect: () => navigate(route.key),
+        }]
+      : []
+  );
 }

--- a/imports/ui/palette/palette.recents.ts
+++ b/imports/ui/palette/palette.recents.ts
@@ -46,7 +46,7 @@ export function readRecents(now: number = Date.now()): RecentEntry[] {
   try {
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    const fresh = parsed.filter(isRecentEntry).filter(e => now - e.ts < STALE_AFTER_MS);
+    const fresh = parsed.filter(e => isRecentEntry(e) && now - e.ts < STALE_AFTER_MS);
     return fresh.sort((a, b) => frecencyScore(b, now) - frecencyScore(a, now)).slice(0, MAX_ENTRIES);
   } catch {
     return [];

--- a/imports/ui/specializations/specializations.columns.tsx
+++ b/imports/ui/specializations/specializations.columns.tsx
@@ -27,7 +27,7 @@ const SpecializationTags = ({ specializations }: SpecializationTagsProps) => {
     if (!specializations?.length) setValues([]);
     Meteor.callAsync('specializations.options')
       .then((res: OptionShape[]) => {
-        const data = res.filter(option => specializations!.includes(option.value)).map(option => option);
+        const data = res.filter(option => specializations!.includes(option.value));
         setValues(data);
       })
       .catch(() => {});

--- a/imports/ui/squads/squads.columns.tsx
+++ b/imports/ui/squads/squads.columns.tsx
@@ -25,7 +25,7 @@ export const SquadTags = ({ squadIds }: SquadTagsProps) => {
     Meteor.callAsync('squads.options')
       .then(options => {
         if (cancelled) return;
-        const filtered = (options as SquadOption[]).filter(option => squadIds.includes(option.value)).map(option => option);
+        const filtered = (options as SquadOption[]).filter(option => squadIds.includes(option.value));
         setSquadNames(filtered);
       })
       .catch(() => {});

--- a/server/apis/events.server.ts
+++ b/server/apis/events.server.ts
@@ -17,7 +17,7 @@ interface ResolvedMember {
 async function resolveNames(userIds: string[] | undefined): Promise<ResolvedMember[]> {
   if (!userIds?.length) return [];
   const members = await MembersCollection.find({ _id: { $in: userIds } }, { fields: { 'profile.rankId': 1, 'profile.id': 1, 'profile.name': 1 } }).fetchAsync();
-  const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
+  const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
   const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
   const rankMap = new Map(ranks.map(r => [r._id, r.name]));
   return members.map(m => ({

--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -200,7 +200,7 @@ if (Meteor.isServer) {
 
       const members = await MembersCollection.find({}, { fields: { 'profile.rankId': 1, 'profile.id': 1, 'profile.name': 1 } }).fetchAsync();
 
-      const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
+      const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
       const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
       const rankNameById = new Map(ranks.map(r => [r._id, r.name]));
 
@@ -217,7 +217,7 @@ if (Meteor.isServer) {
       validateObject(options, false);
       const members = await MembersCollection.find(filter, options).fetchAsync();
 
-      const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
+      const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
       const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
       const rankNameById = new Map(ranks.map(r => [r._id, r.name]));
 
@@ -256,8 +256,8 @@ if (Meteor.isServer) {
 
       const members = await MembersCollection.find({}, { fields: { 'profile.rankId': 1, 'profile.id': 1, 'profile.name': 1, 'profile.squadId': 1 } }).fetchAsync();
 
-      const rankIds = [...new Set(members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x)))];
-      const squadIds = [...new Set(members.map(m => m.profile?.squadId).filter((x): x is string => Boolean(x)))];
+      const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
+      const squadIds = [...new Set(members.flatMap(m => m.profile?.squadId ? [m.profile.squadId] : []))];
       const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
       const squads = await SquadsCollection.find({ _id: { $in: squadIds } }).fetchAsync();
       const rankNameById = new Map(ranks.map(r => [r._id, r.name]));

--- a/server/apis/orbat.server.ts
+++ b/server/apis/orbat.server.ts
@@ -17,9 +17,9 @@ async function orbatPopoverItems(squadId: string = ''): Promise<OrbatPopoverItem
   validateObject(squad, false);
   const members = await MembersCollection.find({ 'profile.squadId': squadId }).fetchAsync();
   const items: OrbatPopoverItem[] = [];
-  const rankIds = members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x));
+  const rankIds = members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []);
   const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).mapAsync(r => ({ value: r._id, label: r.name }));
-  const positionIds = members.map(m => m.profile?.positionId).filter((x): x is string => Boolean(x));
+  const positionIds = members.flatMap(m => m.profile?.positionId ? [m.profile.positionId] : []);
   const positions = positionIds.length > 0
     ? await PositionsCollection.find({ _id: { $in: positionIds } }).mapAsync(p => ({ value: p._id, label: p.name }))
     : [];

--- a/server/apis/questionnaireResponses.server.ts
+++ b/server/apis/questionnaireResponses.server.ts
@@ -101,8 +101,7 @@ if (Meteor.isServer) {
       }
 
       const requiredQuestions = (questionnaire.questions || [])
-        .map((q, index) => ({ ...q, index }))
-        .filter(q => q.required);
+        .flatMap((q, index) => (q.required ? [{ ...q, index }] : []));
 
       for (const question of requiredQuestions) {
         const answer = answers.find(a => a.questionIndex === question.index);

--- a/server/apis/squads.server.ts
+++ b/server/apis/squads.server.ts
@@ -19,8 +19,8 @@ async function squadMembers(this: Meteor.MethodThisType, squadId: string = ''): 
   validateString(squadId, false);
   const members = await MembersCollection.find({ 'profile.squadId': squadId }).fetchAsync();
   if (members.length === 0) return [];
-  const rankIds = members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x));
-  const positionIds = members.map(m => m.profile?.positionId).filter((x): x is string => Boolean(x));
+  const rankIds = members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []);
+  const positionIds = members.flatMap(m => m.profile?.positionId ? [m.profile.positionId] : []);
   const ranks = rankIds.length > 0
     ? await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync()
     : [];


### PR DESCRIPTION
## Summary

Closes the 19 `js-combine-iterations` findings from react-doctor (PR #172) by collapsing two-pass chains into single-pass `flatMap` operations. Zero behavioural change — every chain produces the same observable result; we just stop iterating the array twice.

## The dominant pattern

This codebase has a recurring shape: *extract a unique set of IDs from a list of docs, then go look them up.* The classic form is `.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x))` — two passes plus a type predicate to teach TypeScript that the falsy values are gone.

The flatMap form does both jobs in one pass and the typing falls out naturally:

```ts
// before
members.map(m => m.profile?.rankId).filter((x): x is string => Boolean(x))
// after
members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : [])
```

No type predicate needed — the empty-array case contributes nothing, the single-element case is statically typed.

## Files touched

| File | Findings | Pattern |
|---|---|---|
| `server/apis/members.server.ts` | 4 | rankId × 3 + squadId × 1 |
| `server/apis/orbat.server.ts` | 2 | rankId + positionId |
| `server/apis/squads.server.ts` | 2 | rankId + positionId |
| `server/apis/events.server.ts` | 1 | rankId extraction in resolveNames |
| `server/apis/questionnaireResponses.server.ts` | 1 | required-question filter merged with the index-attaching map |
| `imports/ui/dashboard/Dashboard.tsx` | 3 | stats grid + two profile-description filter/map chains |
| `imports/ui/palette/palette.items.ts` | 2 | getCreatePaletteItems + getNavigatePaletteItems |
| `imports/ui/palette/palette.recents.ts` | 1 | double `.filter()` collapsed to a single predicate |
| `imports/ui/palette/Palette.tsx` | 1 | recent-items map+filter-null collapsed via flatMap with PaletteItem return type |
| `imports/ui/squads/squads.columns.tsx` | 1 | dropped no-op `.map(option => option)` after the filter |
| `imports/ui/specializations/specializations.columns.tsx` | 1 | same pattern — dropped identity map |

## Test plan

- [x] `npm test` — 235 passing, no regressions
- [x] `npm run typecheck` — clean (the explicit type-predicate `(x): x is string` filters are gone but TypeScript still narrows correctly because `flatMap` returns the element type, not `T | undefined`)
- [ ] Manual: load the dashboard — stats render, profile section renders specializations and full-width fields correctly
- [ ] Manual: open the palette (Cmd+K) — recents render at top, create/navigate items respect permissions
- [ ] Manual: open the ORBAT view — squad popovers show rank+position labels