### PR TITLE
fix(section): remove duplicate delete-confirm modal

### DIFF
--- a/e2e/pages/events.page.ts
+++ b/e2e/pages/events.page.ts
@@ -152,7 +152,7 @@ export class EventsPage extends BasePage {
     await deleteBtn.click();
     const modal = this.page.locator('.ant-modal-confirm');
     await modal.waitFor({ state: 'visible' });
-    await modal.locator('button:has-text("Yes")').click();
+    await modal.locator('.ant-btn-primary').click();
     await modal.waitFor({ state: 'hidden', timeout: 10000 });
   }
 

--- a/e2e/pages/members.page.ts
+++ b/e2e/pages/members.page.ts
@@ -90,7 +90,7 @@ export class MembersPage extends BasePage {
     await deleteBtn.click();
     const modal = this.page.locator('.ant-modal-confirm');
     await modal.waitFor({ state: 'visible' });
-    await modal.locator('button:has-text("Yes")').click();
+    await modal.locator('.ant-btn-primary').click();
     await modal.waitFor({ state: 'hidden', timeout: 10000 });
   }
 

--- a/e2e/pages/section.page.ts
+++ b/e2e/pages/section.page.ts
@@ -108,10 +108,12 @@ export class SectionPage extends BasePage {
     const deleteBtn = row.locator('button.ant-btn-dangerous').first();
     await deleteBtn.scrollIntoViewIfNeeded();
     await deleteBtn.click();
-    // Confirm the modal dialog
+    // Confirm the modal dialog. The OK button text varies (it's "Delete" for
+    // the single-row Section modal post-integrity-work) but it's always the
+    // primary button — target by class to stay label/locale-agnostic.
     const modal = this.page.locator('.ant-modal-confirm');
     await modal.waitFor({ state: 'visible' });
-    await modal.locator('button:has-text("Yes")').click();
+    await modal.locator('.ant-btn-primary').click();
     await modal.waitFor({ state: 'hidden', timeout: 10000 });
   }
 

--- a/imports/ui/table/body/actions/TableActions.tsx
+++ b/imports/ui/table/body/actions/TableActions.tsx
@@ -1,4 +1,4 @@
-import { App, Button, Col, Row } from 'antd';
+import { Button, Col, Row } from 'antd';
 import React, { ComponentType, MouseEvent, useCallback } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
@@ -21,27 +21,19 @@ export default function TableActions<T>({
   canUpdate = true,
   canDelete = true,
 }: TableActionsProps<T>) {
-  const { modal } = App.useApp();
   const { t } = useTranslation();
   const styles = {
     button: {
       width: '100%',
     },
   };
+  // Section.handleDelete owns the confirmation modal (it pre-fetches the
+  // integrity preview before showing it). This handler just forwards.
   const handleRemove = useCallback(
     (e: ClickEvent) => {
-      modal.confirm({
-        title: t('modals.deleteEntry'),
-        content: t('modals.deleteEntryConfirm'),
-        okText: t('common.yes'),
-        cancelText: t('common.cancel'),
-        okType: 'danger',
-        onOk: () => handleDelete(e, record),
-        closable: true,
-        maskClosable: true,
-      });
+      handleDelete(e, record);
     },
-    [modal, handleDelete, record, t]
+    [handleDelete, record]
   );
 
   if (!canUpdate && !canDelete && !extra) {


### PR DESCRIPTION
## Summary

PR #170 added a preview-aware ``modal.confirm`` to ``Section.handleDelete`` but didn't notice that the *existing* ``TableActions.handleRemove`` was already wrapping the row-delete button in its own ``modal.confirm`` (with ``okText: t('common.yes')``). Result: every single-row delete now opens two modals in sequence — users have to click ""Yes"" and then ""Delete"".

This regression surfaces in the e2e suite as **15 failing specs** (every section's create/verify/delete flow). The locator log shows two ``.ant-modal-confirm`` dialogs labelled ""Delete Entry"" overlapping — the first (zoom-leave-active, ""Yes"" button just clicked) and the second (zoom-appear-active, the new preview modal).

## Fix

| File | Change |
|---|---|
| ``imports/ui/table/body/actions/TableActions.tsx`` | Drop the wrapper ``modal.confirm``. ``handleRemove`` now forwards the click straight to ``handleDelete``. The integrity-aware modal in ``Section.handleDelete`` is the authoritative confirmation. |
| ``e2e/pages/section.page.ts`` | The OK button changed label from ""Yes"" to ""Delete"". Switch the locator to ``.ant-btn-primary`` so it stays label- and locale-agnostic going forward. |

Server-side behaviour is unchanged — integrity preview, block/setNull/pull/cascade, audit logging, all untouched. This is purely the client-side confirmation flow.

## Why this slipped past #170's tests

#170's mocha suite (76 new tests) covers ``enforceIntegrityOnDelete``, ``previewIntegrity``, audit shape, permission gating, edge coverage — all server-side. The client-side modal change wasn't tested because the e2e suite doesn't run in CI on this repo. Worth wiring up.

## Test plan

- [ ] ``npm test`` — should remain 311 passing
- [ ] ``npm run e2e`` — should now pass the 15 specs that were failing
- [ ] Manual: delete a row in any section — single modal opens with the impact preview; clicking ""Delete"" performs the delete
- [ ] Manual: delete a row that has FK refs (e.g. a Rank held by a Member) — preview shows ""in use by N members"", OK button disabled, click ""Cancel"" closes cleanly