### PR TITLE
perf(server): Map-based lookups + selective parallelisation

### DIFF
--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -64,10 +64,16 @@ export default function Orbat() {
     const roots: Squad[] = [];
     const parents: Squad[] = [];
     const children: Squad[] = [];
+    // Build a single Set of squad IDs that appear as someone's parent — turns
+    // the inner "does anything reference me?" lookup from O(n²) into O(n).
+    const referencedParentIds = new Set(squads.flatMap(s => s.parentSquadId ? [s.parentSquadId] : []));
+    const seen = new Set<string>();
     for (const squad of squads) {
-      if (!squad.parentSquadId && !roots.find(s => s._id === squad._id)) {
+      if (seen.has(squad._id!)) continue;
+      seen.add(squad._id!);
+      if (!squad.parentSquadId) {
         roots.push(squad);
-      } else if (!parents.find(s => s._id === squad._id) && squads.find(s => s.parentSquadId === squad._id)) {
+      } else if (referencedParentIds.has(squad._id!)) {
         parents.push(squad);
       } else {
         children.push(squad);

--- a/server/apis/orbat.server.ts
+++ b/server/apis/orbat.server.ts
@@ -23,9 +23,11 @@ async function orbatPopoverItems(squadId: string = ''): Promise<OrbatPopoverItem
   const positions = positionIds.length > 0
     ? await PositionsCollection.find({ _id: { $in: positionIds } }).mapAsync(p => ({ value: p._id, label: p.name }))
     : [];
+  const rankLabelById = new Map(ranks.map(r => [r.value, r.label]));
+  const positionLabelById = new Map(positions.map(p => [p.value, p.label]));
   for (const member of members) {
-    const rankName = ranks.find(r => r.value === member.profile?.rankId)?.label || '-';
-    const positionName = member.profile?.positionId ? positions.find(p => p.value === member.profile?.positionId)?.label : null;
+    const rankName = (member.profile?.rankId ? rankLabelById.get(member.profile.rankId) : undefined) || '-';
+    const positionName = member.profile?.positionId ? positionLabelById.get(member.profile.positionId) : null;
     const label = positionName ? `${positionName} - ${rankName}` : rankName;
     items.push({
       label,

--- a/server/apis/questionnaireResponses.server.ts
+++ b/server/apis/questionnaireResponses.server.ts
@@ -103,8 +103,9 @@ if (Meteor.isServer) {
       const requiredQuestions = (questionnaire.questions || [])
         .flatMap((q, index) => (q.required ? [{ ...q, index }] : []));
 
+      const answerByIndex = new Map(answers.map(a => [a.questionIndex, a]));
       for (const question of requiredQuestions) {
-        const answer = answers.find(a => a.questionIndex === question.index);
+        const answer = answerByIndex.get(question.index);
         if (!answer || answer.value === undefined || answer.value === null || answer.value === '') {
           throw new Meteor.Error(400, `Question "${question.text}" is required`);
         }

--- a/server/integrity.ts
+++ b/server/integrity.ts
@@ -324,8 +324,14 @@ export async function previewIntegrityBulk(
   const cascaded: EffectsByCollection = {};
   const blockedIds: string[] = [];
 
-  for (const id of targetIds) {
-    const preview = await previewIntegrity(target, id, ctx);
+  // Each previewIntegrity creates its own `visited` Set internally, so the
+  // per-id previews are independent and safe to race. The accumulator merge
+  // happens after all settle — Promise.all preserves order so perId keys stay
+  // stable.
+  const previews = await Promise.all(targetIds.map(id => previewIntegrity(target, id, ctx)));
+  for (let i = 0; i < targetIds.length; i++) {
+    const id = targetIds[i];
+    const preview = previews[i];
     perId[id] = preview;
     if (preview.blockedBy.length > 0) blockedIds.push(id);
 
@@ -507,17 +513,22 @@ export async function validateForeignKeys(
   const written = extractWrittenFKs(source, modifier);
   if (written.length === 0) return;
 
-  for (const { edge, value } of written) {
-    const TargetCollection = getCollection(edge.target);
-    const exists = await TargetCollection.findOneAsync({ _id: value } as never);
-    if (!exists) {
-      throw new Meteor.Error(
-        'foreign_key_invalid',
-        `${edge.field} references non-existent ${edge.target} ${value}`,
-        { field: edge.field, target: edge.target, value },
-      );
-    }
-  }
+  // Race the existence checks — each hits a different target collection and
+  // value, no dependency between them. If any FK is invalid we still throw,
+  // just on whichever query resolves first rather than strict iteration order.
+  await Promise.all(
+    written.map(async ({ edge, value }) => {
+      const TargetCollection = getCollection(edge.target);
+      const exists = await TargetCollection.findOneAsync({ _id: value } as never);
+      if (!exists) {
+        throw new Meteor.Error(
+          'foreign_key_invalid',
+          `${edge.field} references non-existent ${edge.target} ${value}`,
+          { field: edge.field, target: edge.target, value },
+        );
+      }
+    }),
+  );
 }
 
 // ────────────────────────────────────────────────────────────
@@ -569,16 +580,23 @@ export async function scanForOrphans(): Promise<OrphanRecord[]> {
 
   for (const [source, entry] of Object.entries(COLLECTION_REGISTRY) as Array<[CrudCollectionName, typeof COLLECTION_REGISTRY[CrudCollectionName]]>) {
     if (!entry.foreignKeys) continue;
-    for (const edge of entry.foreignKeys) {
-      const referencedIds = await getDistinctReferencedIds(source, edge);
+    // Race the per-edge scans within one collection — each edge targets a
+    // different collection and has no dependency on its siblings.
+    const edgeScans = await Promise.all(
+      entry.foreignKeys.map(async edge => {
+        const referencedIds = await getDistinctReferencedIds(source, edge);
+        if (referencedIds.size === 0) return { edge, referencedIds, existingIds: new Set<string>() };
+        const TargetCollection = getCollection(edge.target);
+        const existingDocs = await TargetCollection.find(
+          { _id: { $in: Array.from(referencedIds.keys()) } } as never,
+          { fields: { _id: 1 } as never } as never,
+        ).fetchAsync();
+        const existingIds = new Set(existingDocs.map(d => (d as { _id: string })._id));
+        return { edge, referencedIds, existingIds };
+      }),
+    );
+    for (const { edge, referencedIds, existingIds } of edgeScans) {
       if (referencedIds.size === 0) continue;
-
-      const TargetCollection = getCollection(edge.target);
-      const existingDocs = await TargetCollection.find(
-        { _id: { $in: Array.from(referencedIds.keys()) } } as never,
-        { fields: { _id: 1 } as never } as never,
-      ).fetchAsync();
-      const existingIds = new Set(existingDocs.map(d => (d as { _id: string })._id));
 
       for (const [referencedId, sourceIds] of referencedIds) {
         if (existingIds.has(referencedId)) continue;

--- a/server/mutation-pipeline.ts
+++ b/server/mutation-pipeline.ts
@@ -141,9 +141,10 @@ export async function runMutation<TArgs extends readonly unknown[], TResult>(
     } else if (descriptor.auditShape) {
       let payload = buildStandardPayload(descriptor.auditShape, args, result);
       if (descriptor.redact?.length) {
+        const redactSet = new Set(descriptor.redact);
         const redacted: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(payload)) {
-          if (!descriptor.redact.includes(key)) redacted[key] = value;
+          if (!redactSet.has(key)) redacted[key] = value;
         }
         payload = redacted;
       }


### PR DESCRIPTION
## Summary

First of ~5 themed PRs working through doctor's 164 findings. This one closes **11 of 25** ""server perf"" findings: ``js-index-maps`` (6), ``js-set-map-lookups`` (1), and ``async-await-in-loop`` (4). The remaining 14 are documented false positives or load-bearing sequentials.

## What landed

| File | Pattern | Findings closed |
|---|---|---|
| ``server/apis/orbat.server.ts`` | rank-label + position-label Maps built once | js-index-maps × 2 |
| ``server/apis/questionnaireResponses.server.ts`` | answer-by-questionIndex Map | js-index-maps × 1 |
| ``imports/ui/orbat/Orbat.tsx`` | seen-Set dedup + referencedParentIds-Set | js-index-maps × 3 |
| ``server/mutation-pipeline.ts`` | redact-Set built once before payload scan | js-set-map-lookups × 1 |
| ``server/integrity.ts`` | previewBulk / validateForeignKeys / scanForOrphans inner — all parallel | await-in-loop × 4 |

## What was *intentionally* skipped

| Finding | Reason |
|---|---|
| ``integrity.ts`` js-index-maps × 6 | False positives — Mongo cursor ``.find()`` mistaken for ``Array.find()`` |
| ``integrity.ts`` await-in-loop × 2 (cascade) | Shared ``visited`` Set for cycle detection — racing breaks safety invariant |
| ``crud.lib.ts:231`` bulkRemove | Sequential is load-bearing for integrity layer (cross-referencing deletes) |
| ``backup.server.ts:226`` | Explicitly sequential for FK ordering during restore (source comment says so) |
| ``demoData.server.ts`` × 3 | FK ordering required by #170's ``validateForeignKeys`` — ranks must exist before specializations that reference them |
| ``Palette.tsx:129`` toSorted | Requires ES2023 lib target; existing ``[...arr].sort()`` is already immutable |

## Test plan

- [x] ``npm test`` — 311 passing
- [x] ``npm run typecheck`` — 8 pre-existing palette errors, no new ones
- [ ] ``npm run e2e`` — will run after merge