### PR TITLE
perf(client): stable defaults + lazy state init + drop trivial useMemo

### DIFF
--- a/imports/ui/app/App.tsx
+++ b/imports/ui/app/App.tsx
@@ -30,8 +30,8 @@ interface AppSettings {
 export default function App() {
   const { message, notification } = AntdApp.useApp();
   const { communityColor } = useSettings() as unknown as AppSettings;
-  const [theme, setTheme] = useState<ThemeMode>(getPreferedTheme());
-  const [navigationValue, setNavigationValue] = useState<string>(getNavigationValue());
+  const [theme, setTheme] = useState<ThemeMode>(getPreferedTheme);
+  const [navigationValue, setNavigationValue] = useState<string>(getNavigationValue);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerComponent, setDrawerComponent] = useState<ReactNode>(empty);
   const [drawerExtra, setDrawerExtra] = useState<ReactNode>(empty);

--- a/imports/ui/components/CollectionSelect.tsx
+++ b/imports/ui/components/CollectionSelect.tsx
@@ -11,6 +11,7 @@ import type { DrawerContextValue } from '../app/types';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
 const empty = <></>;
+const emptyQuery: Mongo.Selector<CollectionDoc> = {};
 
 export type CollectionDoc = {
   _id?: string;
@@ -55,7 +56,7 @@ const CollectionSelect = ({
   FormComponent,
   subscription,
   extra = empty,
-  query = {},
+  query = emptyQuery,
 }: CollectionSelectProps) => {
   const { modal } = App.useApp();
   const drawer = useContext(DrawerContext) as DrawerContextValue;
@@ -77,8 +78,8 @@ const CollectionSelect = ({
     [searchValue]
   );
 
-  const valueLength = useMemo(() => (Array.isArray(value) ? value.length : 1), [value]);
-  const otherLimit = useMemo(() => (valueLength > limit ? valueLength : limit - valueLength), [limit, valueLength]);
+  const valueLength = Array.isArray(value) ? value.length : 1;
+  const otherLimit = valueLength > limit ? valueLength : limit - valueLength;
   const valueSubFilter = useMemo(() => ({ ...valueFilter, ...stableQuery }), [valueFilter, stableQuery]);
   const searchSubFilter = useMemo(() => ({ ...searchFilter, ...stableQuery }), [searchFilter, stableQuery]);
   useSubscribe(subscription, valueSubFilter, { limit: valueLength });

--- a/imports/ui/members/Members.tsx
+++ b/imports/ui/members/Members.tsx
@@ -33,7 +33,7 @@ export default function Members() {
     []
   );
 
-  const customView = useMemo(() => (viewType === 'squad' ? MembersSquadView : false), [viewType]);
+  const customView = viewType === 'squad' ? MembersSquadView : false;
 
   const expandable = useMemo(
     () => ({

--- a/imports/ui/section/Section.tsx
+++ b/imports/ui/section/Section.tsx
@@ -51,6 +51,8 @@ function defaultFilterFactory(input: string): Mongo.Selector<Record<string, unkn
   return { name: { $regex: input, $options: 'i' } };
 }
 
+const emptyGroupActions: GroupAction[] = [];
+
 function defaultColumnsFactory(): ReturnType<ColumnsFactory<Record<string, unknown>>> {
   return [];
 }
@@ -90,7 +92,7 @@ export default function Section<T extends { _id?: string }>({
   customView = false,
   permissionModule = null,
   expandable,
-  groupActions = [],
+  groupActions = emptyGroupActions,
 }: SectionProps<T>) {
   const [nameInput, setNameInput] = useState('');
   const [filter, setFilter] = useState<Mongo.Selector<T>>(() => filterFactory(''));

--- a/imports/ui/settings/Settings.tsx
+++ b/imports/ui/settings/Settings.tsx
@@ -13,6 +13,9 @@ import useSettings from './settings.hook';
 type TFn = LanguageContextValue['t'];
 type HandleChangeFn = (e: unknown, key: string) => void | Promise<void>;
 
+const emptyStringList: string[] = [];
+const noopHandleChange: HandleChangeFn = () => {};
+
 async function getEventValue(key: string, e: unknown): Promise<string | string[] | undefined> {
   switch (key) {
     case 'community-title':
@@ -133,7 +136,7 @@ interface CommunityNameBlackListSettingsProps {
   t: TFn;
 }
 
-function CommunityNameBlackListSettings({ communityNameBlackList = [], handleChange = () => {}, t }: CommunityNameBlackListSettingsProps) {
+function CommunityNameBlackListSettings({ communityNameBlackList = emptyStringList, handleChange = noopHandleChange, t }: CommunityNameBlackListSettingsProps) {
   const [value, setValue] = useState('');
 
   const handleClick = useCallback(() => {
@@ -196,7 +199,7 @@ interface CommunityIdBlackListSettingsProps {
   t: TFn;
 }
 
-function CommunityIdBlackListSettings({ communityIdBlackList = [], handleChange = () => {}, t }: CommunityIdBlackListSettingsProps) {
+function CommunityIdBlackListSettings({ communityIdBlackList = emptyStringList, handleChange = noopHandleChange, t }: CommunityIdBlackListSettingsProps) {
   const [value, setValue] = useState('');
 
   const handleClick = useCallback(() => {

--- a/imports/ui/table/header/GroupActionsBar.tsx
+++ b/imports/ui/table/header/GroupActionsBar.tsx
@@ -12,10 +12,12 @@ interface GroupActionsBarProps {
   loading?: boolean;
 }
 
+const emptyActions: BoundGroupAction[] = [];
+
 export default function GroupActionsBar({
   selectedCount = 0,
   onDelete,
-  groupActions = [],
+  groupActions = emptyActions,
   onClearSelection,
   loading = false,
 }: GroupActionsBarProps) {


### PR DESCRIPTION
## Summary

Second of the doctor cleanup PRs. Closes **9 of 14** render-correctness findings; 5 skipped as false positives with rationale below.

## Findings closed

| Pattern | Files | Count |
|---|---|---|
| ``rerender-memo-with-default-value`` — extract default ``[]`` / ``{}`` to module-level const | CollectionSelect, GroupActionsBar, Settings ×2, Section | 5 |
| ``rerender-lazy-state-init`` — ``useState(getX)`` instead of ``useState(getX())`` | App.tsx | 2 |
| ``no-usememo-simple-expression`` — strip useMemo from trivial ternaries | CollectionSelect, Members | 2 |

## Findings skipped, with rationale

**``rerender-state-only-in-handlers`` × 3** — false positives. Doctor's checker doesn't follow usage through early-return patterns. All three flagged states ARE read in JSX, just via ``if (loading) return <Spin />`` style early returns:
- ``MemberProfile.tsx:93`` ``loading`` — read at line 140
- ``SquadMembers.tsx:23`` ``loading`` — read at line 33
- ``Orbat.tsx:32`` ``squads`` — drives a re-render that re-runs the ``getOptions`` useCallback that populates ``options`` for JSX. Switching to ``useRef`` would break that cycle.

**``no-render-in-render`` × 2** — false positives. The flagged ``renderValue()`` and ``renderTags()`` are *functions* (lowercase, called once), not *components* (uppercase, used as ``<X />``). React reconciles their JSX output by structure, not function identity. The rule's real target is ``const SubComp = () => …`` defined inside a parent, which doesn't exist here.

## Test plan

- [x] ``npm test`` — 311 passing
- [x] ``npm run typecheck`` — 8 pre-existing palette errors, no new ones
- [ ] ``npm run e2e`` — will run before merge