### PR TITLE
ci: add mocha + Playwright e2e gate on PRs and main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel in-flight runs for the same PR / branch when new commits arrive — the
+# old run's results would be stale anyway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: mocha + e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # Meteor install is ~200 MB and takes 1-2 min. Cache the entire user
+      # install dir, keyed on the .meteor/release pin so a Meteor version bump
+      # invalidates automatically.
+      - name: Cache Meteor install
+        id: cache-meteor
+        uses: actions/cache@v4
+        with:
+          path: ~/.meteor
+          key: meteor-${{ runner.os }}-${{ hashFiles('.meteor/release') }}
+
+      - name: Install Meteor
+        if: steps.cache-meteor.outputs.cache-hit != 'true'
+        run: |
+          METEOR_VERSION="$(cat .meteor/release | cut -d@ -f2)"
+          curl "https://install.meteor.com/?release=${METEOR_VERSION}" | sh
+
+      - name: Add Meteor to PATH
+        run: echo "$HOME/.meteor" >> "$GITHUB_PATH"
+
+      - name: Install npm dependencies
+        run: meteor npm ci
+
+      - name: Mocha unit tests
+        run: meteor npm test
+
+      # Playwright browser binaries + their system deps. The --with-deps flag
+      # handles the Debian/Ubuntu apt installs Playwright needs (libnss3 etc).
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright e2e
+        run: meteor npm run e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: e2e/test-results/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [main]
 
+# Read-only token: this workflow only checks out code and uploads artifacts. It
+# never pushes, comments, or releases, so we drop write scope as defence in depth.
+permissions:
+  contents: read
+
 # Cancel in-flight runs for the same PR / branch when new commits arrive — the
 # old run's results would be stale anyway.
 concurrency:


### PR DESCRIPTION
## Summary

First CI workflow on the repo. Runs ``npm test`` (mocha, ~5s) and ``npm run e2e`` (Playwright full suite, ~3-5 min on CI) on every PR and every push to ``main``. This PR itself will be the workflow's first run — meta self-test.

## What's gated

| Step | Why |
|---|---|
| ``meteor npm test`` (mocha) | Free safety net — server-side unit tests are 5 seconds after Meteor boots |
| ``npx playwright install --with-deps chromium`` | Browser + apt deps for Ubuntu runner |
| ``meteor npm run e2e`` | Full 105-spec Playwright suite |

## What's deliberately *not* gated yet

- ``npm run typecheck`` — 8 pre-existing palette errors live on ``main`` today (the Fuse.js typing issues acknowledged in #170's PR body). Adding typecheck now would block every PR. Worth a follow-up cleanup PR + a separate gate.
- ``npm run doctor`` — too many open findings to gate on; would also block every PR.

## Caching

- Meteor install (``~/.meteor``, ~200 MB) — keyed on ``.meteor/release`` so version bumps invalidate automatically.
- ``node_modules`` — handled by ``setup-node``'s built-in npm cache.
- Playwright browsers — pulled fresh per run (small enough not to bother caching).

Cold first run: ~6-8 min. Subsequent runs with warm caches: ~3-5 min.

## Failure artifacts

On a failed e2e run, two artifacts upload for 7-day retention:
- ``playwright-report/`` — HTML report you can open locally
- ``test-results/`` — per-spec videos, screenshots, traces (``npx playwright show-trace path/to/trace.zip``)

## Concurrency

PR pushes cancel the superseded run via ``concurrency: cancel-in-progress``. Pushes to ``main`` queue (no cancel) so every merge gets verified.

## Test plan

- [ ] This PR's own CI run must pass (self-test)
- [ ] After merge: update branch protection on ``main`` to require the ""mocha + e2e"" check
- [ ] Follow-up: clean up the palette typecheck errors so typecheck can join the gate