### PR TITLE
ci: bump actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -37,7 +37,7 @@ jobs:
       # invalidates automatically.
       - name: Cache Meteor install
         id: cache-meteor
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.meteor
           key: meteor-${{ runner.os }}-${{ hashFiles('.meteor/release') }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: e2e/playwright-report/
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
           path: e2e/test-results/


### PR DESCRIPTION
Closes #181.

## Summary

GitHub deprecates Node 20 actions on the runner — forced to Node 24 by default on **2026-06-02**, Node 20 removed entirely on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The CI workflow added in #180 currently emits a deprecation annotation on every run.

## Changes

| Action | Before | After | Why |
|---|---|---|---|
| ``actions/checkout`` | v4 | v6 | Node 24 |
| ``actions/setup-node`` | v4 | v6 | Node 24 |
| ``actions/cache`` | v4 | v5 | Node 24 |
| ``actions/upload-artifact`` | v4 | v7 | Node 24 + adds optional unzipped uploads (we don't use it) |

Our usages stay on the simple inputs (name/path/retention-days for upload-artifact, etc.) that did not change shape across these majors, so no behavioural change is expected.

## Test plan

- [ ] CI ``mocha + e2e`` check passes
- [ ] The "Node.js 20 actions are deprecated" annotation no longer appears in the run summary
- [ ] Cache restore from the previous run still works (key unchanged)