### PR TITLE
fix(palette): clean up typecheck errors and gate typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Install npm dependencies
         run: meteor npm ci
 
+      # Runs before mocha because tsc is sub-second after the cache hit and
+      # any type error invalidates the rest of the run anyway — fail fast.
+      - name: Type check
+        run: meteor npm run typecheck
+
       - name: Mocha unit tests
         run: meteor npm test
 

--- a/imports/i18n/index.ts
+++ b/imports/i18n/index.ts
@@ -10,6 +10,16 @@ export type ParamArgs<K extends LocaleKey> = keyof ExtractParams<(typeof transla
   ? []
   : [params: ExtractParams<(typeof translations)[K]['en']>];
 
+export type Translator = <K extends LocaleKey>(key: K, ...args: ParamArgs<K>) => string;
+
+// Subset of LocaleKey for translations that take no interpolation params.
+// Use this as the type of label-key fields stored in static config so callers
+// can do `t(config.labelKey)` without TS demanding a params argument for the
+// (potentially param-taking) keys also living in the LocaleKey union.
+export type ParameterlessLocaleKey = {
+  [K in LocaleKey]: ParamArgs<K> extends [] ? K : never;
+}[LocaleKey];
+
 export interface LocaleInfo {
   name: string;
   flag: string;

--- a/imports/ui/palette/Palette.tsx
+++ b/imports/ui/palette/Palette.tsx
@@ -94,7 +94,7 @@ export default function Palette() {
     if (recents.length === 0) return [];
     const groupLabel = t('palette.recent');
     const staticItems: PaletteItem[] = [...createItems, ...globalItems, ...navigateItems];
-    const itemByKey = new Map(staticItems.map(item => [`${item.kind}:${item.key}`, item] as const));
+    const itemByKey = new Map<string, PaletteItem>(staticItems.map(item => [`${item.kind}:${item.key}`, item]));
     return recents.slice(0, 5).flatMap<PaletteItem>(entry => {
       const id = `${entry.kind}:${entry.key}`;
       const original = itemByKey.get(id);

--- a/imports/ui/palette/palette.items.ts
+++ b/imports/ui/palette/palette.items.ts
@@ -1,8 +1,7 @@
 import type { Role } from '../../api/types';
+import type { ParameterlessLocaleKey, Translator } from '../../i18n';
 import { hasAccess } from '../navigation/Navigation';
 import type { PaletteItem } from './palette.types';
-
-type Translator = (key: string) => string;
 
 export interface PaletteEntityResults {
   members: Array<{ _id: string; username?: string; profile?: { name?: string; id?: number } }>;
@@ -16,7 +15,7 @@ export interface PaletteEntityResults {
 interface NavConfig {
   key: string;
   module: keyof Role;
-  labelKey: string;
+  labelKey: ParameterlessLocaleKey;
 }
 
 const NAV_ROUTES: NavConfig[] = [
@@ -43,7 +42,7 @@ const NAV_ROUTES: NavConfig[] = [
 interface CreateActionConfig {
   module: keyof Role;
   route: string;
-  labelKey: string;
+  labelKey: ParameterlessLocaleKey;
 }
 
 const CREATE_ACTIONS: CreateActionConfig[] = [

--- a/imports/ui/palette/palette.scoring.ts
+++ b/imports/ui/palette/palette.scoring.ts
@@ -1,7 +1,7 @@
-import Fuse from 'fuse.js';
+import Fuse, { type IFuseOptions } from 'fuse.js';
 import type { PaletteItem } from './palette.types';
 
-const FUSE_OPTIONS: Fuse.IFuseOptions<PaletteItem> = {
+const FUSE_OPTIONS: IFuseOptions<PaletteItem> = {
   keys: [{ name: 'label', weight: 1 }],
   threshold: 0.4,
   ignoreLocation: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.14.0",
         "@types/react-beautiful-dnd": "^13.1.8",
+        "@types/react-dom": "^18.3.7",
         "eslint": "^9.28.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.5",
@@ -5336,6 +5337,12 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -5351,11 +5358,12 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -5367,6 +5375,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-redux": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.14.0",
     "@types/react-beautiful-dnd": "^13.1.8",
+    "@types/react-dom": "^18.3.7",
     "eslint": "^9.28.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.5",

--- a/tests/server/paletteSearch.test.ts
+++ b/tests/server/paletteSearch.test.ts
@@ -27,13 +27,13 @@ describe('palette.search', () => {
     const adminRoleId = await createTestRole({ roles: true });
     adminUserId = await createTestUser({ roleId: adminRoleId });
 
-    const memberOnlyRoleId = await createTestRole({ members: { read: true, insert: false, update: false, delete: false } });
+    const memberOnlyRoleId = await createTestRole({ members: { read: true, create: false, update: false, delete: false } });
     memberOnlyUserId = await createTestUser({ roleId: memberOnlyRoleId });
 
     squadAId = await createTestDoc(SquadsCollection, { name: `${TEST_PREFIX}AlphaSquad` });
     squadBId = await createTestDoc(SquadsCollection, { name: `${TEST_PREFIX}BravoSquad` });
 
-    const scopedRoleId = await createTestRole({ members: { read: true, insert: false, update: false, delete: false } });
+    const scopedRoleId = await createTestRole({ members: { read: true, create: false, update: false, delete: false } });
     squadAUserId = await createTestUser({ roleId: scopedRoleId, profile: { squadId: squadAId } });
     squadBUserId = await createTestUser({ roleId: scopedRoleId, profile: { squadId: squadBId } });
 


### PR DESCRIPTION
Closes #182.

## Summary

Eight pre-existing TypeScript errors lived on main, all in or around the command palette. They date from before the typed translator was rolled out and from the fuse.js v6→v7 namespace removal. With them fixed, ``npm run typecheck`` is now clean and is added to the CI gate as a fast-fail step before mocha + e2e.

## Translator type drift (5 of 8 errors)

The local ``type Translator = (key: string) => string`` in ``palette.items.ts`` did not match the actual ``t`` returned by ``useLanguage``, which is ``<K extends LocaleKey>(key: K, ...args: ParamArgs<K>) => string``. Passing the narrow ``t`` to a parameter typed as the wide ``Translator`` failed via function-parameter contravariance.

- Exported the real ``Translator`` type from ``imports/i18n``
- Added a new ``ParameterlessLocaleKey`` helper (subset of ``LocaleKey`` for keys that take no interpolation params)
- Tightened ``labelKey`` fields on the static config arrays from ``string`` to ``ParameterlessLocaleKey`` — fixes the mismatch and catches future label-key typos at compile time

## Fuse.js v7 namespace removed (1 of 8)

Replaced ``Fuse.IFuseOptions<T>`` with the top-level ``IFuseOptions<T>`` named import. fuse.js v7 dropped the namespace shape that v6 used.

## Map key inference (1 of 8)

Loosened the ``recents → static item`` lookup ``Map`` to ``Map<string, ...>`` so the call site can pass a string-typed lookup key without TS inferring a narrower template-literal type.

## Test fixture key name (1 of 8)

Two ``paletteSearch.test.ts`` fixtures used ``insert: false`` but ``CrudPermission`` has ``create``, not ``insert``. The property was being silently dropped by the type system, with no semantic effect on the test. Renamed to match the type.

## CI gate

Added a ``Type check`` step to the workflow before mocha. ``tsc`` is sub-second after the cache hit and any type error invalidates the rest of the run anyway, so fail-fast.

## Test plan

- [ ] CI passes (mocha + e2e + new typecheck step)
- [ ] ``npm run typecheck`` exits 0 locally on this branch (verified — was 8 errors, now 0)
- [ ] No ``@ts-ignore`` or ``as any`` shortcuts used