### PR TITLE
docs: tighten README — pin versions, fix MongoDB requirement, add Project Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ A web application for managing ArmA III communities. Built with Meteor.js, React
 
 ## Requirements
 
-- [Node.js and npm](https://nodejs.org/en)
-- [Meteor.js](https://docs.meteor.com/about/install.html)
-- [MongoDB Compass](https://www.mongodb.com/try/download/compass) (optional, for database inspection)
-- Text editor ([VS Code](https://code.visualstudio.com/download) recommended)
+- [Node.js 20.x](https://nodejs.org/en) (matches the version CI runs)
+- [Meteor.js 3.4+](https://docs.meteor.com/about/install.html)
+- A text editor — we use [VS Code](https://code.visualstudio.com/download) with ESLint and Prettier so contributions match project style
+- MongoDB itself is **not** required for development — Meteor bundles it. Install [MongoDB Compass](https://www.mongodb.com/try/download/compass) only if you want to inspect the database.
 
 ## Quick Start
 
@@ -44,7 +44,7 @@ The setup script will install Node.js, Meteor.js, and project dependencies autom
 ```bash
 git clone https://github.com/sentinel-web/community-manager.git
 cd community-manager
-meteor npm install
+meteor npm install   # first run downloads Meteor itself (~200 MB, 2-3 min)
 npm start
 ```
 
@@ -77,7 +77,7 @@ npm run visualize      # Production bundle size analysis
 npm run integrity-scan # Scan MongoDB for orphaned references
 ```
 
-`npm test` and `npm run e2e` are the two checks gated by CI on every PR and every push to `main`.
+`npm test`, `npm run typecheck`, and `npm run e2e` are gated by CI on every PR and every push to `main`.
 
 ## Docker Deployment
 
@@ -94,27 +94,21 @@ Requires external Traefik network for reverse proxy. See `docker-compose.yml` fo
 
 ## Tech Stack
 
-- **Backend:** Meteor.js 3.4+, MongoDB
+- **Language:** TypeScript (strict)
+- **Backend:** Meteor.js 3.4+, MongoDB, Mocha
 - **Frontend:** React 18, Ant Design
+- **E2E tests:** Playwright (chromium)
 - **Calendar:** react-big-calendar with rrule
 - **Kanban:** react-beautiful-dnd
 - **ORBAT:** react-organizational-chart
 
-## Optional VS Code Extensions
+## Project Map
 
-<details>
-<summary>Recommended extensions</summary>
-
-- Auto Rename Tag
-- ES7+ React/Redux/React-Native snippets
-- ESLint
-- GitLens
-- Path Intellisense
-- Prettier - Code Formatter
-- vscode-icons
-
-</details>
+- **Architecture, patterns, and coding guidelines:** [`CLAUDE.md`](CLAUDE.md)
+- **Testing strategy:** [`TESTING.md`](TESTING.md)
+- **Domain model and decisions:** [`CONTEXT.md`](CONTEXT.md)
+- **Issue triage labels:** [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md)
 
 ## Contributing
 
-See `CLAUDE.md` for coding guidelines and project patterns.
+See [`CLAUDE.md`](CLAUDE.md) for coding guidelines and project patterns. PRs require the `mocha + e2e` and `typecheck` checks to pass; `main` is protected with linear history.


### PR DESCRIPTION
Follow-up to #183 with the more substantive fixes.

## Changes

| Where | Before | After |
|---|---|---|
| Requirements | "Node.js and npm" with no version | Pinned to **Node.js 20.x** (matches CI) |
| Requirements | "Meteor.js" with no version | Pinned to **Meteor 3.4+** (matches ``.meteor/release``) |
| Requirements | MongoDB Compass listed as "optional" | Reworded — MongoDB is bundled by Meteor in dev; Compass is for inspection only |
| Manual Setup | ``meteor npm install`` with no warning | Added "first run downloads Meteor itself (~200 MB, 2-3 min)" so people don't think it's hung |
| CI-gated list | "test and e2e" | Now includes typecheck (added in #185) |
| Tech Stack | Omitted TypeScript, Mocha, Playwright | Added the missing foundations |
| VS Code Extensions | 7-item collapsible list | Replaced with one-line note about ESLint + Prettier |
| Project Map (new) | — | Added pointers to ``CLAUDE.md`` (architecture), ``TESTING.md`` (632 lines, was undiscoverable), ``CONTEXT.md``, and ``docs/agents/triage-labels.md`` |
| Contributing | One-line CLAUDE.md pointer | Added note about required CI checks and ``main`` being protected with linear history |

## Why

The previous README contained two soft traps for new contributors:
1. Listing MongoDB as a requirement (even softly) implied they need to install it. They don't — Meteor bundles a dev MongoDB.
2. No Node version pin meant contributors on Node 18 or 22 would hit subtle dep resolution issues.

It also had ~870 lines of internal docs (``CLAUDE.md``, ``TESTING.md``, ``CONTEXT.md``) that the README never linked to.

## Test plan

- [ ] CI ``mocha + e2e`` check passes
- [ ] All in-repo links resolve (verified: ``docs/adr/`` removed because it doesn't exist yet)
- [ ] Rendered badge still shows in the right column