### PR TITLE
ci: split typecheck into its own parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Pure-Node typecheck — no Meteor binary needed. Module resolution for
+  # 'meteor/*' is satisfied by ambient declarations in imports/types/meteor.d.ts,
+  # not by anything Meteor itself generates. Runs in ~40s with a warm npm cache,
+  # in parallel with the slow test job, so type errors surface in under a minute.
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
   test:
     name: mocha + e2e
     runs-on: ubuntu-latest
@@ -53,11 +77,6 @@ jobs:
 
       - name: Install npm dependencies
         run: meteor npm ci
-
-      # Runs before mocha because tsc is sub-second after the cache hit and
-      # any type error invalidates the rest of the run anyway — fail fast.
-      - name: Type check
-        run: meteor npm run typecheck
 
       - name: Mocha unit tests
         run: meteor npm test


### PR DESCRIPTION
## Summary

The typecheck step added in #185 ran serially inside the ``mocha + e2e`` job, behind a 1-2 min Meteor install (~30s with warm cache). Promoted to its own job so type errors surface in ~40s in parallel with the slow test job.

## Changes

- Added a new ``typecheck`` job that runs in parallel with ``mocha + e2e``
- Removed the inline ``Type check`` step from the test job
- The typecheck job uses plain ``npm ci`` (not ``meteor npm ci``) — module resolution for ``meteor/*`` is satisfied by ambient declarations in ``imports/types/meteor.d.ts``, so it skips Meteor entirely
- Test job name unchanged (``mocha + e2e``) so existing branch protection still satisfies

## Post-merge action required

After this lands, **update branch protection on ``main`` to also require the ``typecheck`` check.** Until that toggle flips, typecheck failures are observational only.

## Test plan

- [ ] Both ``typecheck`` and ``mocha + e2e`` checks appear and pass on this PR
- [ ] ``typecheck`` job completes in well under 1 min (target: 40s warm)
- [ ] After merge, follow up with: ``gh api -X PUT repos/sentinel-web/community-manager/branches/main/protection/required_status_checks/contexts -f contexts[]=mocha+e2e -f contexts[]=typecheck``