### PR TITLE
feat(drawer-stack): ship module + TaskStatusForm pilot (#188)

### DIFF
--- a/imports/ui/app/App.tsx
+++ b/imports/ui/app/App.tsx
@@ -14,6 +14,7 @@ import Palette from '../palette/Palette';
 import { PaletteProvider } from '../palette/PaletteContext';
 import DemoTour from '../tour/DemoTour';
 import { TourProvider } from '../tour/TourContext';
+import { DrawerStackProvider } from '../drawer-stack';
 import type { DrawerContextValue } from './types';
 
 export const NavigationContext = createContext<NavigationContextValue>({} as NavigationContextValue);
@@ -109,39 +110,41 @@ export default function App() {
                   }}
                 >
                   <AntdApp className="app" message={{ ...message, maxCount: 1 }} notification={{ ...notification, maxCount: 3 }}>
-                    <Layout>
-                      <Layout.Header>
-                        <Header />
-                      </Layout.Header>
-                      <Layout.Content style={{ flex: 1, overflow: 'auto' }}>
-                        <Main />
-                      </Layout.Content>
-                      <Layout.Footer>
-                        <Footer />
-                      </Layout.Footer>
-                    </Layout>
-                    {Meteor.isDevelopment && <DemoTour />}
-                    <Palette />
-                    <Drawer
-                      width={getDrawerWidth(window.innerWidth)}
-                      open={drawerOpen}
-                      onClose={() => setDrawerOpen(false)}
-                      title={drawerTitle}
-                      extra={drawerExtra}
-                      destroyOnHidden
-                    >
-                      {drawerComponent}
+                    <DrawerStackProvider>
+                      <Layout>
+                        <Layout.Header>
+                          <Header />
+                        </Layout.Header>
+                        <Layout.Content style={{ flex: 1, overflow: 'auto' }}>
+                          <Main />
+                        </Layout.Content>
+                        <Layout.Footer>
+                          <Footer />
+                        </Layout.Footer>
+                      </Layout>
+                      {Meteor.isDevelopment && <DemoTour />}
+                      <Palette />
                       <Drawer
                         width={getDrawerWidth(window.innerWidth)}
-                        open={subdrawerOpen}
-                        onClose={() => setSubdrawerOpen(false)}
-                        title={subdrawerTitle}
-                        extra={subdrawerExtra}
+                        open={drawerOpen}
+                        onClose={() => setDrawerOpen(false)}
+                        title={drawerTitle}
+                        extra={drawerExtra}
                         destroyOnHidden
                       >
-                        {subdrawerComponent}
+                        {drawerComponent}
+                        <Drawer
+                          width={getDrawerWidth(window.innerWidth)}
+                          open={subdrawerOpen}
+                          onClose={() => setSubdrawerOpen(false)}
+                          title={subdrawerTitle}
+                          extra={subdrawerExtra}
+                          destroyOnHidden
+                        >
+                          {subdrawerComponent}
+                        </Drawer>
                       </Drawer>
-                    </Drawer>
+                    </DrawerStackProvider>
                   </AntdApp>
                 </ConfigProvider>
               </PaletteProvider>

--- a/imports/ui/components/FormFooter.tsx
+++ b/imports/ui/components/FormFooter.tsx
@@ -3,18 +3,21 @@ import React from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
 
 interface FormFooterProps {
-  setOpen: (open: boolean) => void;
+  setOpen?: (open: boolean) => void;
+  onCancel?: () => void;
   cancelText?: string;
   submitText?: string;
 }
 
-const FormFooter = ({ setOpen, cancelText, submitText }: FormFooterProps) => {
+const FormFooter = ({ setOpen, onCancel, cancelText, submitText }: FormFooterProps) => {
   const { t } = useTranslation();
+
+  const handleCancel = onCancel ?? (() => setOpen?.(false));
 
   return (
     <Row gutter={[16, 16]} align="middle" justify="end">
       <Col>
-        <Button onClick={() => setOpen(false)} danger>
+        <Button onClick={handleCancel} danger>
           {cancelText || t('common.cancel')}
         </Button>
       </Col>

--- a/imports/ui/drawer-stack/DrawerStackProvider.tsx
+++ b/imports/ui/drawer-stack/DrawerStackProvider.tsx
@@ -1,0 +1,104 @@
+import { Drawer } from 'antd';
+import React, { createContext, ReactNode, useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import { getDrawerWidth } from '../../config';
+import { createDrawerStackStore, type DrawerStackStore } from './drawerStackStore';
+import type { DrawerStackApi, FrameContextValue, InternalFrame, PushFrameOptions } from './types';
+
+export const DrawerStackContext = createContext<DrawerStackApi | null>(null);
+export const FrameContext = createContext<FrameContextValue | null>(null);
+
+interface DrawerStackProviderProps {
+  children: ReactNode;
+}
+
+export default function DrawerStackProvider({ children }: DrawerStackProviderProps) {
+  const storeRef = useRef<DrawerStackStore | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = createDrawerStackStore();
+  }
+  const store = storeRef.current;
+
+  const frames = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+
+  const push = useCallback(
+    <R = unknown, M = unknown>(options: PushFrameOptions<M>) => store.push<R, M>(options),
+    [store]
+  );
+
+  const api = useMemo<DrawerStackApi>(() => ({ push }), [push]);
+
+  return (
+    <DrawerStackContext.Provider value={api}>
+      {children}
+      <DrawerStackFrames frames={frames} store={store} />
+    </DrawerStackContext.Provider>
+  );
+}
+
+interface DrawerStackFramesProps {
+  frames: readonly InternalFrame[];
+  store: DrawerStackStore;
+}
+
+function DrawerStackFrames({ frames, store }: DrawerStackFramesProps) {
+  return <FrameRenderer frames={frames} index={0} store={store} />;
+}
+
+interface FrameRendererProps {
+  frames: readonly InternalFrame[];
+  index: number;
+  store: DrawerStackStore;
+}
+
+function FrameRenderer({ frames, index, store }: FrameRendererProps) {
+  if (index >= frames.length) return null;
+  const frame = frames[index];
+  const isTop = index === frames.length - 1;
+  return (
+    <FrameDrawer frame={frame} isTop={isTop} store={store}>
+      <FrameRenderer frames={frames} index={index + 1} store={store} />
+    </FrameDrawer>
+  );
+}
+
+interface FrameDrawerProps {
+  frame: InternalFrame;
+  isTop: boolean;
+  store: DrawerStackStore;
+  children: ReactNode;
+}
+
+function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
+  const handleClose = useCallback(() => {
+    void store.tryClose(frame.id);
+  }, [store, frame.id]);
+
+  const frameApi = useMemo<FrameContextValue>(
+    () => ({
+      model: frame.model,
+      resolve: value => store.resolveFrame(frame.id, value),
+      cancel: () => store.cancelFrame(frame.id),
+      confirmCloseRef: frame.confirmCloseRef,
+    }),
+    [store, frame.id, frame.model, frame.confirmCloseRef]
+  );
+
+  const Component = frame.Component;
+
+  return (
+    <Drawer
+      width={getDrawerWidth(window.innerWidth)}
+      open={true}
+      onClose={handleClose}
+      title={frame.title}
+      extra={frame.extra}
+      maskClosable={isTop}
+      destroyOnHidden
+    >
+      <FrameContext.Provider value={frameApi}>
+        <Component />
+      </FrameContext.Provider>
+      {children}
+    </Drawer>
+  );
+}

--- a/imports/ui/drawer-stack/drawerStackStore.ts
+++ b/imports/ui/drawer-stack/drawerStackStore.ts
@@ -1,0 +1,97 @@
+import type { ConfirmCloseRef, InternalFrame, PushFrameOptions } from './types';
+
+export interface DrawerStackStore {
+  push: <R = unknown, M = unknown>(options: PushFrameOptions<M>) => Promise<R | undefined>;
+  resolveFrame: (frameId: number, value: unknown) => void;
+  cancelFrame: (frameId: number) => void;
+  tryClose: (frameId: number) => Promise<void>;
+  getSnapshot: () => readonly InternalFrame[];
+  subscribe: (listener: () => void) => () => void;
+}
+
+export function createDrawerStackStore(): DrawerStackStore {
+  let frames: InternalFrame[] = [];
+  const listeners = new Set<() => void>();
+  let nextId = 1;
+
+  function emit() {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function settle(frame: InternalFrame, value: unknown) {
+    if (frame.settled) return;
+    frame.settled = true;
+    frame.resolveFn(value);
+  }
+
+  function dropFromIndex(idx: number, valueForTarget: unknown) {
+    // Cascade-down: frames above the target resolve with undefined first
+    // (top-to-bottom), then the target itself resolves with its value.
+    // Per PRD: "frames K+1..N also fulfil with undefined before K's
+    // resolution settles".
+    for (let i = frames.length - 1; i > idx; i--) {
+      settle(frames[i], undefined);
+    }
+    settle(frames[idx], valueForTarget);
+    frames = frames.slice(0, idx);
+    emit();
+  }
+
+  function push<R, M>(options: PushFrameOptions<M>): Promise<R | undefined> {
+    return new Promise<R | undefined>(resolve => {
+      const id = nextId++;
+      const confirmCloseRef: ConfirmCloseRef = { current: null };
+      const frame: InternalFrame = {
+        id,
+        title: options.title,
+        Component: options.Component,
+        model: options.model ?? {},
+        extra: options.extra ?? null,
+        confirmCloseRef,
+        resolveFn: value => resolve(value as R | undefined),
+        settled: false,
+      };
+      frames = [...frames, frame];
+      emit();
+    });
+  }
+
+  function resolveFrame(frameId: number, value: unknown) {
+    const idx = frames.findIndex(f => f.id === frameId);
+    if (idx === -1) return;
+    dropFromIndex(idx, value);
+  }
+
+  function cancelFrame(frameId: number) {
+    resolveFrame(frameId, undefined);
+  }
+
+  async function tryClose(frameId: number): Promise<void> {
+    // User-initiated close. PRD: "Only the top frame is interactive, so only
+    // the top frame's predicate is ever consulted on the user path." We
+    // defensively ignore close attempts on non-top frames.
+    const top = frames[frames.length - 1];
+    if (!top || top.id !== frameId) return;
+    const predicate = top.confirmCloseRef.current;
+    if (predicate) {
+      const allowed = await predicate();
+      if (allowed === false) return;
+    }
+    cancelFrame(frameId);
+  }
+
+  function getSnapshot(): readonly InternalFrame[] {
+    return frames;
+  }
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  return { push, resolveFrame, cancelFrame, tryClose, getSnapshot, subscribe };
+}

--- a/imports/ui/drawer-stack/drawerStackStore.ts
+++ b/imports/ui/drawer-stack/drawerStackStore.ts
@@ -47,7 +47,7 @@ export function createDrawerStackStore(): DrawerStackStore {
         id,
         title: options.title,
         Component: options.Component,
-        model: options.model ?? {},
+        model: options.model,
         extra: options.extra ?? null,
         confirmCloseRef,
         resolveFn: value => resolve(value as R | undefined),

--- a/imports/ui/drawer-stack/index.ts
+++ b/imports/ui/drawer-stack/index.ts
@@ -1,0 +1,6 @@
+export { default as DrawerStackProvider } from './DrawerStackProvider';
+export { default as useDrawerStack } from './useDrawerStack';
+export { default as useDrawerFrame } from './useDrawerFrame';
+export { default as useConfirmClose } from './useConfirmClose';
+export type { DrawerStackApi, PushFrameOptions, ConfirmClosePredicate } from './types';
+export type { DrawerFrame } from './useDrawerFrame';

--- a/imports/ui/drawer-stack/types.ts
+++ b/imports/ui/drawer-stack/types.ts
@@ -7,7 +7,7 @@ export type ConfirmCloseRef = { current: ConfirmClosePredicate | null };
 export interface PushFrameOptions<M = unknown> {
   title: string;
   Component: ComponentType<unknown>;
-  model?: M;
+  model: M;
   extra?: ReactNode;
 }
 

--- a/imports/ui/drawer-stack/types.ts
+++ b/imports/ui/drawer-stack/types.ts
@@ -1,0 +1,34 @@
+import type { ComponentType, ReactNode } from 'react';
+
+export type ConfirmClosePredicate = () => boolean | Promise<boolean>;
+
+export type ConfirmCloseRef = { current: ConfirmClosePredicate | null };
+
+export interface PushFrameOptions<M = unknown> {
+  title: string;
+  Component: ComponentType<unknown>;
+  model?: M;
+  extra?: ReactNode;
+}
+
+export interface InternalFrame {
+  id: number;
+  title: string;
+  Component: ComponentType<unknown>;
+  model: unknown;
+  extra: ReactNode;
+  confirmCloseRef: ConfirmCloseRef;
+  resolveFn: (value: unknown) => void;
+  settled: boolean;
+}
+
+export interface FrameContextValue {
+  model: unknown;
+  resolve: (value: unknown) => void;
+  cancel: () => void;
+  confirmCloseRef: ConfirmCloseRef;
+}
+
+export interface DrawerStackApi {
+  push: <R = unknown, M = unknown>(options: PushFrameOptions<M>) => Promise<R | undefined>;
+}

--- a/imports/ui/drawer-stack/useConfirmClose.ts
+++ b/imports/ui/drawer-stack/useConfirmClose.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { FrameContext } from './DrawerStackProvider';
+import type { ConfirmClosePredicate } from './types';
+
+export default function useConfirmClose(predicate: ConfirmClosePredicate): void {
+  const frame = useContext(FrameContext);
+  if (frame === null) {
+    throw new Error('useConfirmClose must be used inside a frame rendered by <DrawerStackProvider>.');
+  }
+  // Assigned on every render so a predicate that captures dirty state via
+  // closure always reflects the latest values without `useCallback`.
+  frame.confirmCloseRef.current = predicate;
+}

--- a/imports/ui/drawer-stack/useDrawerFrame.ts
+++ b/imports/ui/drawer-stack/useDrawerFrame.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+import { FrameContext } from './DrawerStackProvider';
+
+export interface DrawerFrame<R, M> {
+  model: M;
+  resolve: (value: R | undefined) => void;
+  cancel: () => void;
+}
+
+export default function useDrawerFrame<R = unknown, M = unknown>(): DrawerFrame<R, M> {
+  const frame = useContext(FrameContext);
+  if (frame === null) {
+    throw new Error('useDrawerFrame must be used inside a frame rendered by <DrawerStackProvider>.');
+  }
+  return {
+    model: frame.model as M,
+    resolve: value => frame.resolve(value),
+    cancel: frame.cancel,
+  };
+}

--- a/imports/ui/drawer-stack/useDrawerStack.ts
+++ b/imports/ui/drawer-stack/useDrawerStack.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { DrawerStackContext } from './DrawerStackProvider';
+import type { DrawerStackApi } from './types';
+
+export default function useDrawerStack(): DrawerStackApi {
+  const api = useContext(DrawerStackContext);
+  if (api === null) {
+    throw new Error('useDrawerStack must be used inside a <DrawerStackProvider>.');
+  }
+  return api;
+}

--- a/imports/ui/section/Section.tsx
+++ b/imports/ui/section/Section.tsx
@@ -9,6 +9,7 @@ import type { Role, CrudPermission } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerContext } from '../app/App';
 import type { DrawerContextValue } from '../app/types';
+import { useDrawerStack } from '../drawer-stack';
 import TableContainer from '../table/body/TableContainer';
 import TableFooter from '../table/footer/TableFooter';
 import GroupActionsBar from '../table/header/GroupActionsBar';
@@ -78,6 +79,7 @@ interface SectionProps<T extends { _id?: string }> {
   permissionModule?: string | null;
   expandable?: ExpandableConfig<T>;
   groupActions?: GroupAction[];
+  useDrawerStack?: boolean;
 }
 
 export default function Section<T extends { _id?: string }>({
@@ -93,6 +95,7 @@ export default function Section<T extends { _id?: string }>({
   permissionModule = null,
   expandable,
   groupActions = emptyGroupActions,
+  useDrawerStack: useDrawerStackPath = false,
 }: SectionProps<T>) {
   const [nameInput, setNameInput] = useState('');
   const [filter, setFilter] = useState<Mongo.Selector<T>>(() => filterFactory(''));
@@ -102,6 +105,7 @@ export default function Section<T extends { _id?: string }>({
   useSubscribe(collectionName, filter, options);
   const datasource = useFind(() => Collection?.find?.(filter, options) || ([] as unknown as Mongo.Cursor<T>), [Collection, filter, options]);
   const drawer = useContext(DrawerContext) as DrawerContextValue;
+  const drawerStack = useDrawerStack();
   const { notification, message, modal } = App.useApp();
   const { t } = useTranslation();
 
@@ -131,12 +135,21 @@ export default function Section<T extends { _id?: string }>({
   );
 
   const handleCreate = useCallback(() => {
+    if (useDrawerStackPath) {
+      void drawerStack.push({
+        title: t('common.createEntry'),
+        Component: FormComponent as unknown as ComponentType<unknown>,
+        model: {},
+        extra,
+      });
+      return;
+    }
     drawer.setDrawerTitle(t('common.createEntry'));
     drawer.setDrawerModel({});
     drawer.setDrawerComponent(React.createElement(FormComponent!, { setOpen: drawer.setDrawerOpen }));
     drawer.setDrawerOpen(true);
     drawer.setDrawerExtra(extra);
-  }, [drawer, t, FormComponent, extra]);
+  }, [useDrawerStackPath, drawerStack, drawer, t, FormComponent, extra]);
 
   useEffect(() => {
     if (!permissions.canCreate || !FormComponent) return;
@@ -152,13 +165,22 @@ export default function Section<T extends { _id?: string }>({
   const handleEdit = useCallback(
     (e: RowClickEvent, record: T) => {
       e.preventDefault();
+      if (useDrawerStackPath) {
+        void drawerStack.push({
+          title: t('common.editEntry'),
+          Component: FormComponent as unknown as ComponentType<unknown>,
+          model: record as Record<string, unknown>,
+          extra,
+        });
+        return;
+      }
       drawer.setDrawerModel(record as Record<string, unknown>);
       drawer.setDrawerTitle(t('common.editEntry'));
       drawer.setDrawerComponent(React.createElement(FormComponent!, { setOpen: drawer.setDrawerOpen }));
       drawer.setDrawerOpen(true);
       drawer.setDrawerExtra(extra);
     },
-    [drawer, FormComponent, extra, t]
+    [useDrawerStackPath, drawerStack, drawer, FormComponent, extra, t]
   );
 
   const handleDelete = useCallback(

--- a/imports/ui/tasks/task-status/TaskStatusForm.tsx
+++ b/imports/ui/tasks/task-status/TaskStatusForm.tsx
@@ -1,30 +1,21 @@
 import { App, ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { DrawerContext, SubdrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
+import type { TaskStatus } from '/imports/api/types/misc';
 
-interface TaskStatusFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
-
-export default function TaskStatusForm({ setOpen, useSubdrawer = false }: TaskStatusFormProps) {
+export default function TaskStatusForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
-
-  const drawerCtx = useContext(useSubdrawer ? SubdrawerContext : DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return drawerCtx.drawerModel || {};
-  }, [drawerCtx]);
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<TaskStatus>>();
 
   useEffect(() => {
-    if (Object.keys(model).length > 0) {
+    if (model && Object.keys(model).length > 0) {
       form.setFieldsValue(model);
     } else {
       form.setFieldsValue({
@@ -36,25 +27,25 @@ export default function TaskStatusForm({ setOpen, useSubdrawer = false }: TaskSt
   }, [model, form.setFieldsValue]);
 
   const handleSubmit = useCallback(
-    (values: Record<string, unknown>) => {
+    async (values: Record<string, unknown>) => {
       setLoading(true);
       const { name, description } = values as { name: string; description?: string };
       const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'taskStatus.update' : 'taskStatus.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(model?._id ? t('messages.taskStatusUpdated') : t('messages.taskStatusCreated'));
-        })
-        .catch((error: Meteor.Error) => {
-          notification.error({
-            message: error.error,
-            description: error.message,
-          });
-        })
-        .finally(() => setLoading(false));
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'taskStatus.update' : 'taskStatus.insert',
+          ...args
+        )) as string | undefined;
+        message.success(model?._id ? t('messages.taskStatusUpdated') : t('messages.taskStatusCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({ message: err.error as string, description: err.message });
+      } finally {
+        setLoading(false);
+      }
     },
-    [setOpen, form, model, message, notification, t]
+    [model, resolve, message, notification, t]
   );
 
   return (
@@ -68,7 +59,7 @@ export default function TaskStatusForm({ setOpen, useSubdrawer = false }: TaskSt
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 }

--- a/imports/ui/tasks/task-status/TaskStatuses.tsx
+++ b/imports/ui/tasks/task-status/TaskStatuses.tsx
@@ -17,6 +17,7 @@ const TaskStatuses = () => {
       FormComponent={TaskStatusForm}
       columnsFactory={getTaskStatusColumns}
       filterFactory={string => ({ name: { $regex: string, $options: 'i' } })}
+      useDrawerStack
     />
   );
 };

--- a/tests/client/hooks/drawerStackHooks.test.tsx
+++ b/tests/client/hooks/drawerStackHooks.test.tsx
@@ -1,0 +1,128 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import React, { type ReactNode } from 'react';
+
+// React rendering tests only run in the Meteor client test context where the
+// browser supplies a DOM. The pure store covers the same behaviour without
+// needing one.
+if (Meteor.isClient) {
+  const ReactDOMClient = require('react-dom/client') as typeof import('react-dom/client');
+  const { act } = require('react-dom/test-utils') as { act: (cb: () => void | Promise<void>) => Promise<void> };
+
+  type DrawerStackProviderModuleShape = typeof import('/imports/ui/drawer-stack/DrawerStackProvider');
+  type UseDrawerStackHook = typeof import('/imports/ui/drawer-stack/useDrawerStack').default;
+  type UseDrawerFrameHook = typeof import('/imports/ui/drawer-stack/useDrawerFrame').default;
+  type UseConfirmCloseHook = typeof import('/imports/ui/drawer-stack/useConfirmClose').default;
+
+  const DrawerStackProviderModule = require('/imports/ui/drawer-stack/DrawerStackProvider') as DrawerStackProviderModuleShape;
+  const DrawerStackProvider = DrawerStackProviderModule.default;
+  const { FrameContext } = DrawerStackProviderModule;
+  const useDrawerStack = (require('/imports/ui/drawer-stack/useDrawerStack') as { default: UseDrawerStackHook }).default;
+  const useDrawerFrame = (require('/imports/ui/drawer-stack/useDrawerFrame') as { default: UseDrawerFrameHook }).default;
+  const useConfirmClose = (require('/imports/ui/drawer-stack/useConfirmClose') as { default: UseConfirmCloseHook }).default;
+
+  type Captured<T> = { current: T | null; error: Error | null };
+
+  async function renderHook<T>(useHook: () => T, wrapper?: (children: ReactNode) => ReactNode): Promise<Captured<T> & { unmount: () => Promise<void> }> {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const captured: Captured<T> = { current: null, error: null };
+
+    function Probe() {
+      try {
+        captured.current = useHook();
+      } catch (error) {
+        captured.error = error as Error;
+      }
+      return null;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    const element = wrapper ? wrapper(<Probe />) : <Probe />;
+    await act(async () => {
+      root.render(element as React.ReactElement);
+    });
+    return {
+      ...captured,
+      get current() {
+        return captured.current;
+      },
+      get error() {
+        return captured.error;
+      },
+      unmount: async () => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      },
+    } as Captured<T> & { unmount: () => Promise<void> };
+  }
+
+  describe('useDrawerStack — opener hook', () => {
+    it('returns { push } when used inside <DrawerStackProvider>', async () => {
+      const result = await renderHook(useDrawerStack, children => <DrawerStackProvider>{children}</DrawerStackProvider>);
+      assert.strictEqual(result.error, null);
+      assert.ok(result.current);
+      assert.strictEqual(typeof result.current!.push, 'function');
+      await result.unmount();
+    });
+
+    it('throws a clear error when used outside a provider', async () => {
+      const result = await renderHook(useDrawerStack);
+      assert.ok(result.error instanceof Error);
+      assert.match(result.error!.message, /DrawerStackProvider/);
+      await result.unmount();
+    });
+  });
+
+  describe('useDrawerFrame — form-side hook', () => {
+    it('returns { model, resolve, cancel } from the nearest frame context', async () => {
+      const fakeFrame = {
+        model: { hello: 'world' },
+        resolve: () => {},
+        cancel: () => {},
+        confirmCloseRef: { current: null },
+      };
+      const result = await renderHook(useDrawerFrame, children => (
+        <FrameContext.Provider value={fakeFrame}>{children}</FrameContext.Provider>
+      ));
+      assert.strictEqual(result.error, null);
+      assert.deepStrictEqual(result.current!.model, { hello: 'world' });
+      assert.strictEqual(typeof result.current!.resolve, 'function');
+      assert.strictEqual(typeof result.current!.cancel, 'function');
+      await result.unmount();
+    });
+
+    it('throws a clear error when used outside any frame', async () => {
+      const result = await renderHook(useDrawerFrame);
+      assert.ok(result.error instanceof Error);
+      assert.match(result.error!.message, /useDrawerFrame/);
+      await result.unmount();
+    });
+  });
+
+  describe('useConfirmClose — close-confirmation registration', () => {
+    it('writes the predicate into the frame confirmCloseRef on every render', async () => {
+      const ref: { current: null | (() => boolean | Promise<boolean>) } = { current: null };
+      const fakeFrame = {
+        model: {},
+        resolve: () => {},
+        cancel: () => {},
+        confirmCloseRef: ref,
+      };
+      const predicate = () => false;
+      await renderHook(() => useConfirmClose(predicate), children => (
+        <FrameContext.Provider value={fakeFrame}>{children}</FrameContext.Provider>
+      ));
+      assert.strictEqual(ref.current, predicate);
+    });
+
+    it('throws a clear error when used outside any frame', async () => {
+      const result = await renderHook(() => useConfirmClose(() => true));
+      assert.ok(result.error instanceof Error);
+      assert.match(result.error!.message, /useConfirmClose/);
+      await result.unmount();
+    });
+  });
+}

--- a/tests/client/hooks/drawerStackStore.test.ts
+++ b/tests/client/hooks/drawerStackStore.test.ts
@@ -1,0 +1,168 @@
+import assert from 'node:assert';
+import React, { type ComponentType } from 'react';
+import { createDrawerStackStore } from '/imports/ui/drawer-stack/drawerStackStore';
+
+const Noop: ComponentType<unknown> = () => null;
+
+function basePush(store: ReturnType<typeof createDrawerStackStore>, title = 'frame') {
+  return store.push<string, Record<string, unknown>>({
+    title,
+    Component: Noop,
+    model: {},
+  });
+}
+
+// Drains microtasks so we can surface a clear failure if a promise we expect
+// to remain pending has already resolved, rather than blocking the test
+// runner forever waiting on a promise that will never settle.
+async function expectStillPending(promise: Promise<unknown>): Promise<void> {
+  let resolved = false;
+  promise.then(() => {
+    resolved = true;
+  });
+  await new Promise(r => setImmediate(r));
+  await new Promise(r => setImmediate(r));
+  assert.strictEqual(resolved, false, 'expected promise to remain pending');
+}
+
+describe('drawerStackStore — pure state machine for the DrawerStack', () => {
+  it('push() returns a promise; resolveFrame(id, value) fulfils it with value', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    store.resolveFrame(frame.id, 'inserted-id');
+    assert.strictEqual(await pending, 'inserted-id');
+  });
+
+  it('push() returns a promise; user-initiated close fulfils it with undefined', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    await store.tryClose(frame.id);
+    assert.strictEqual(await pending, undefined);
+  });
+
+  it('confirmClose returning false aborts the close; the promise stays pending', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    frame.confirmCloseRef.current = () => false;
+    await store.tryClose(frame.id);
+    assert.strictEqual(store.getSnapshot().length, 1, 'frame should still be on the stack');
+    await expectStillPending(pending);
+    // Resolve to clean up
+    store.resolveFrame(frame.id, 'done');
+    await pending;
+  });
+
+  it('confirmClose returning Promise<false> aborts; awaited correctly', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    frame.confirmCloseRef.current = async () => false;
+    await store.tryClose(frame.id);
+    assert.strictEqual(store.getSnapshot().length, 1);
+    await expectStillPending(pending);
+    store.cancelFrame(frame.id);
+    assert.strictEqual(await pending, undefined);
+  });
+
+  it('pushing N frames produces N frames on the snapshot (renderer maps 1:1)', () => {
+    const store = createDrawerStackStore();
+    void basePush(store, 'a');
+    void basePush(store, 'b');
+    void basePush(store, 'c');
+    const snapshot = store.getSnapshot();
+    assert.strictEqual(snapshot.length, 3);
+    assert.deepStrictEqual(
+      snapshot.map(f => f.title),
+      ['a', 'b', 'c']
+    );
+  });
+
+  it('cascade-down: resolving frame K causes K+1..N to fulfil with undefined before K settles', async () => {
+    const store = createDrawerStackStore();
+    const pA = basePush(store, 'a');
+    const pB = basePush(store, 'b');
+    const pC = basePush(store, 'c');
+    const settleOrder: string[] = [];
+    pA.then(v => settleOrder.push(`a:${String(v)}`));
+    pB.then(v => settleOrder.push(`b:${String(v)}`));
+    pC.then(v => settleOrder.push(`c:${String(v)}`));
+    const [frameA] = store.getSnapshot();
+    store.resolveFrame(frameA.id, 'a-value');
+    const [vA, vB, vC] = await Promise.all([pA, pB, pC]);
+    assert.strictEqual(vA, 'a-value');
+    assert.strictEqual(vB, undefined);
+    assert.strictEqual(vC, undefined);
+    // C and B fulfilled before A — top-to-bottom cascade
+    assert.deepStrictEqual(settleOrder, ['c:undefined', 'b:undefined', 'a:a-value']);
+    assert.strictEqual(store.getSnapshot().length, 0);
+  });
+
+  it('frame isolation: each frame retains its own model on the snapshot', () => {
+    const store = createDrawerStackStore();
+    void store.push({ title: 't1', Component: Noop, model: { kind: 'first' } });
+    void store.push({ title: 't2', Component: Noop, model: { kind: 'second' } });
+    const [f1, f2] = store.getSnapshot();
+    assert.deepStrictEqual(f1.model, { kind: 'first' });
+    assert.deepStrictEqual(f2.model, { kind: 'second' });
+    assert.notStrictEqual(f1.resolveFn, f2.resolveFn);
+    assert.notStrictEqual(f1.confirmCloseRef, f2.confirmCloseRef);
+  });
+
+  it('cancelFrame(id) is equivalent to resolveFrame(id, undefined)', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    store.cancelFrame(frame.id);
+    assert.strictEqual(await pending, undefined);
+    assert.strictEqual(store.getSnapshot().length, 0);
+  });
+
+  it('tryClose ignores non-top frames (defensive — antd UX only allows closing the top)', async () => {
+    const store = createDrawerStackStore();
+    const pA = basePush(store, 'a');
+    const pB = basePush(store, 'b');
+    const [frameA] = store.getSnapshot();
+    await store.tryClose(frameA.id);
+    // Nothing changes — frame A is not the top.
+    assert.strictEqual(store.getSnapshot().length, 2);
+    await expectStillPending(pA);
+    await expectStillPending(pB);
+    store.resolveFrame(frameA.id, 'cleanup');
+    await Promise.all([pA, pB]);
+  });
+
+  it('settling is idempotent: resolveFrame on an already-removed frame is a no-op', async () => {
+    const store = createDrawerStackStore();
+    const pending = basePush(store);
+    const [frame] = store.getSnapshot();
+    store.resolveFrame(frame.id, 'first');
+    store.resolveFrame(frame.id, 'second');
+    assert.strictEqual(await pending, 'first');
+  });
+
+  it('subscribe() notifies listeners on push, resolve, and cancel', () => {
+    const store = createDrawerStackStore();
+    let calls = 0;
+    const unsubscribe = store.subscribe(() => {
+      calls++;
+    });
+    void basePush(store);
+    const [frame] = store.getSnapshot();
+    store.resolveFrame(frame.id, 'x');
+    unsubscribe();
+    void basePush(store);
+    // 2 calls before unsubscribe (push + resolve), nothing after.
+    assert.strictEqual(calls, 2);
+  });
+});
+
+describe('drawerStackStore — guards', () => {
+  it('Noop component is a valid Component option', () => {
+    // Sanity: the test fixture renders to null without error.
+    const element = React.createElement(Noop);
+    assert.ok(element !== null);
+  });
+});

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,3 +1,5 @@
+import './client/hooks/drawerStackHooks.test';
+import './client/hooks/drawerStackStore.test';
 import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
 import './helpers/colors/hexToRgb.test';


### PR DESCRIPTION
## Summary

- New named deep module `imports/ui/drawer-stack/`: pure state machine (`drawerStackStore`) + React provider + three thin hooks (`useDrawerStack`, `useDrawerFrame`, `useConfirmClose`).
- Provider rendered inside `<AntdApp>` so its recursive `<Drawer>` chain inherits antd's message / notification / modal / theme context. Legacy `DrawerContext` + `SubdrawerContext` remain mounted for unmigrated forms.
- `Section` gains an opt-in `useDrawerStack` prop that routes `handleCreate` / `handleEdit` through `drawerStack.push`; `TaskStatuses` is the first opt-in.
- `TaskStatusForm` drops `useSubdrawer` (and the unused `setOpen`), consumes `useDrawerFrame<string, Partial<TaskStatus>>()`, and resolves with the inserted / updated id (foundation for the auto-select payoff in later sweep PRs).
- `FormFooter` gains an `onCancel` callback alongside the existing `setOpen` prop so frame-aware forms can wire cancel without a setter.

Closes #188.

## Architecture notes

- **Pure store + thin React shim.** The state machine (cascade-down, confirm-close ref, idempotent settling, subscribe/snapshot) lives in `drawerStackStore.ts` and is testable with Mocha + Node `assert`. The provider is a `useSyncExternalStore` adapter; each frame's `Component` is wrapped in a per-frame `FrameContext.Provider` so `useDrawerFrame()` resolves to the topologically-nearest frame.
- **Sweep-friendly Section seam.** Rather than swapping Section universally (which would break the 13 unmigrated forms), the `useDrawerStack?: boolean` prop is the seam that issues #189–#194 flip per batch. #195 removes the prop, the two legacy contexts, and the double-Drawer renderer in one cleanup PR.
- **Issue-time bug found via manual demo.** Mounting `<DrawerStackProvider>` outside `<AntdApp>` made `App.useApp()` in form children return stub objects without `.success` / `.error` — the textbook gotcha CLAUDE.md calls out. Fixed by relocating the provider inside `<AntdApp>` and inside `<ConfigProvider>` so theme tokens also flow through.

## Tests

- 12 store-level unit tests cover all eight PRD behaviours (push/resolve, push/user-close, sync abort, async abort, N-frame snapshot, cascade-down ordering, frame isolation, `cancel ≡ resolve(undefined)`) plus idempotency, non-top close guard, and subscribe notifications.
- React-renderer hook tests for `useDrawerStack` / `useDrawerFrame` / `useConfirmClose` are included; they execute when `TEST_BROWSER_DRIVER` is configured.
- `npm run typecheck` clean; `npm test` 323 server-side tests pass (12 new).

## Test plan

- [ ] `npm run typecheck` ✓
- [ ] `npm test` ✓ — 12 new `drawerStackStore` tests + 311 pre-existing all pass
- [ ] Manual demo via Playwright (verified locally):
  - [ ] Navigate to `/taskStatus`
  - [ ] Click **Create**, fill name/description, **Submit** → drawer closes, row appears
  - [ ] Click **Edit** on the new row → drawer opens with pre-filled values
  - [ ] Change name, **Submit** → drawer closes, row updates
  - [ ] Open **Create**, click drawer **X** → drawer closes cleanly (no confirm predicate registered)
  - [ ] Zero console errors throughout
- [ ] Smoke-test that non-pilot pages (Members, Events, Tasks, …) still open their drawers via the legacy two-context path