### PR TITLE
feat(drawer-stack): CollectionSelect auto-selects new entities (#190)

### DIFF
--- a/imports/ui/components/CollectionSelect.tsx
+++ b/imports/ui/components/CollectionSelect.tsx
@@ -8,6 +8,7 @@ import { useFind, useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React, { ComponentType, MouseEvent, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 import { DrawerContext, SubdrawerContext } from '../app/App';
 import type { DrawerContextValue } from '../app/types';
+import { useDrawerStack } from '../drawer-stack';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
 const empty = <></>;
@@ -36,6 +37,7 @@ interface CollectionSelectProps {
   subscription?: string;
   extra?: ReactNode;
   query?: Mongo.Selector<CollectionDoc>;
+  useDrawerStack?: boolean;
 }
 
 interface OptionShape {
@@ -57,10 +59,13 @@ const CollectionSelect = ({
   subscription,
   extra = empty,
   query = emptyQuery,
+  useDrawerStack: useDrawerStackPath = false,
 }: CollectionSelectProps) => {
   const { modal } = App.useApp();
   const drawer = useContext(DrawerContext) as DrawerContextValue;
   const subdrawer = useContext(SubdrawerContext) as DrawerContextValue;
+  const drawerStack = useDrawerStack();
+  const parentForm = Form.useFormInstance() as unknown as { setFieldValue: (path: NamePath, value: unknown) => void } | undefined;
   const { t } = useTranslation();
   const [limit, setLimit] = useState(20);
   const [searchValue, setSearchValue] = useState('');
@@ -96,19 +101,62 @@ const CollectionSelect = ({
   const isFormItem = useMemo(() => Boolean(name && label && rules), [name, label, rules]);
   const user = useTracker(() => Meteor.user(), []);
 
-  const handleCreate = useCallback(() => {
+  const writeBack = useCallback(
+    (insertedId: string) => {
+      // For multi-select, append; for single-select, replace. Mirror the
+      // change into Form state (when wrapped in Form.Item) and our local
+      // mirror so the new entity is auto-selected without further user
+      // action — the PRD's core UX payoff.
+      const nextValue: CollectionSelectValue = (() => {
+        if (mode === 'multiple' || mode === 'tags') {
+          const current = Array.isArray(value) ? value : value ? [value] : [];
+          if (current.includes(insertedId)) return current;
+          return [...current, insertedId];
+        }
+        return insertedId;
+      })();
+      if (parentForm && name) {
+        parentForm.setFieldValue(name, nextValue);
+      }
+      setValue(nextValue);
+      if (onChange) onChange(nextValue);
+    },
+    [mode, value, parentForm, name, onChange]
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (useDrawerStackPath) {
+      const inserted = await drawerStack.push<string, Record<string, unknown>>({
+        title: `${t('common.create')} ${label ?? ''}`,
+        Component: FormComponent as unknown as ComponentType<unknown>,
+        model: {},
+        extra,
+      });
+      if (inserted) writeBack(inserted);
+      return;
+    }
     const usedDrawer = !drawer.drawerOpen ? drawer : subdrawer;
     usedDrawer.setDrawerTitle(`${t('common.create')} ${label ?? ''}`);
     usedDrawer.setDrawerModel({});
     usedDrawer.setDrawerComponent(React.createElement(FormComponent!, { setOpen: usedDrawer.setDrawerOpen, useSubdrawer: drawer.drawerOpen }));
     usedDrawer.setDrawerExtra(extra);
     usedDrawer.setDrawerOpen(true);
-  }, [drawer, subdrawer, FormComponent, label, t, extra]);
+  }, [useDrawerStackPath, drawerStack, writeBack, drawer, subdrawer, FormComponent, label, t, extra]);
 
   const handleEdit = useCallback(
-    (e: MouseEvent<HTMLElement>, raw: CollectionDoc) => {
+    async (e: MouseEvent<HTMLElement>, raw: CollectionDoc) => {
       e.preventDefault();
       e.stopPropagation();
+      if (useDrawerStackPath) {
+        await drawerStack.push<string, Record<string, unknown>>({
+          title: `${t('common.edit')} ${label ?? ''}`,
+          Component: FormComponent as unknown as ComponentType<unknown>,
+          model: raw as Record<string, unknown>,
+          extra,
+        });
+        // Edit returns the same id; no auto-select work needed.
+        return;
+      }
       const usedDrawer = !drawer.drawerOpen ? drawer : subdrawer;
       usedDrawer.setDrawerTitle(`${t('common.edit')} ${label ?? ''}`);
       usedDrawer.setDrawerModel(raw as Record<string, unknown>);
@@ -116,7 +164,7 @@ const CollectionSelect = ({
       usedDrawer.setDrawerExtra(extra);
       usedDrawer.setDrawerOpen(true);
     },
-    [drawer, subdrawer, label, FormComponent, t, extra]
+    [useDrawerStackPath, drawerStack, drawer, subdrawer, label, FormComponent, t, extra]
   );
 
   const handleDelete = useCallback(

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -253,6 +253,7 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
         collection={RanksCollection as unknown as Mongo.Collection<CollectionDoc>}
         subscription="ranks"
         query={{ type: 'player' }}
+        useDrawerStack
       />
       <CollectionSelect
         defaultValue={model?.profile?.navyRankId}
@@ -264,6 +265,7 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
         collection={RanksCollection as unknown as Mongo.Collection<CollectionDoc>}
         subscription="ranks"
         query={{ type: 'zeus' }}
+        useDrawerStack
       />
       <PositionsSelect
         name={['profile', 'positionId']}

--- a/imports/ui/members/ranks/Ranks.tsx
+++ b/imports/ui/members/ranks/Ranks.tsx
@@ -19,6 +19,7 @@ const Ranks = () => {
         FormComponent={RanksForm}
         columnsFactory={getRankColumns}
         Collection={RanksCollection}
+        useDrawerStack
       />
     </div>
   );

--- a/imports/ui/members/ranks/RanksForm.tsx
+++ b/imports/ui/members/ranks/RanksForm.tsx
@@ -1,18 +1,12 @@
 import { App, ColorPicker, Form, Input, Select } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Rank } from '../../../api/types/rank';
-import { DrawerContext, SubdrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
 import RanksSelect from './RanksSelect';
-
-interface RanksFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
 
 interface RankFormValues {
   name: string;
@@ -23,19 +17,15 @@ interface RankFormValues {
   nextRankId?: string;
 }
 
-export default function RanksForm({ setOpen, useSubdrawer }: RanksFormProps) {
+export default function RanksForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<RankFormValues>();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
-
-  const drawer = useContext(useSubdrawer ? SubdrawerContext : DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return drawer.drawerModel as unknown as Rank & { _id?: string };
-  }, [drawer]);
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Rank> & { _id?: string }>();
 
   useEffect(() => {
-    if (Object.keys(model).length > 0) {
+    if (model && Object.keys(model).length > 0) {
       form.setFieldsValue(model as unknown as RankFormValues);
     } else {
       form.setFieldsValue({
@@ -49,25 +39,31 @@ export default function RanksForm({ setOpen, useSubdrawer }: RanksFormProps) {
   }, [model, form.setFieldsValue]);
 
   const handleSubmit = useCallback(
-    (values: RankFormValues) => {
+    async (values: RankFormValues) => {
       setLoading(true);
       const { name, description, previousRankId, nextRankId, type } = values;
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, previousRankId, nextRankId, type }];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'ranks.update' : 'ranks.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(model?._id ? t('messages.rankUpdated') : t('messages.rankCreated'));
-        })
-        .catch(error => {
-          notification.error({
-            message: (error as Meteor.Error).error as string,
-            description: (error as Meteor.Error).message,
-          });
-        })
-        .finally(() => setLoading(false));
+      const args = [
+        ...(model?._id ? [model._id] : []),
+        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, previousRankId, nextRankId, type },
+      ];
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'ranks.update' : 'ranks.insert',
+          ...args
+        )) as string | undefined;
+        message.success(model?._id ? t('messages.rankUpdated') : t('messages.rankCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({
+          message: err.error as string,
+          description: err.message,
+        });
+      } finally {
+        setLoading(false);
+      }
     },
-    [setOpen, form, model, message, notification, t]
+    [model, resolve, message, notification, t]
   );
 
   return (
@@ -102,7 +98,7 @@ export default function RanksForm({ setOpen, useSubdrawer }: RanksFormProps) {
         rules={[{ required: false, type: 'string' }]}
         defaultValue={model?.nextRankId as string | undefined}
       />
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 }

--- a/imports/ui/members/ranks/RanksSelect.tsx
+++ b/imports/ui/members/ranks/RanksSelect.tsx
@@ -29,6 +29,7 @@ const RanksSelect = ({ multiple, name, label, rules, defaultValue }: RanksSelect
       subscription="ranks"
       placeholder={t('common.selectRank')}
       extra={<></>}
+      useDrawerStack
     />
   );
 };

--- a/imports/ui/tasks/TaskFilter.tsx
+++ b/imports/ui/tasks/TaskFilter.tsx
@@ -58,6 +58,7 @@ export default function TaskFilter() {
         collection={TaskStatusCollection as unknown as Mongo.Collection<CollectionDoc>}
         mode="multiple"
         subscription="taskStatus"
+        useDrawerStack
       />
       <MembersSelect
         name="participants"

--- a/imports/ui/tasks/TaskForm.tsx
+++ b/imports/ui/tasks/TaskForm.tsx
@@ -100,6 +100,7 @@ export default function TaskForm() {
         collection={TaskStatusCollection as unknown as Mongo.Collection<CollectionDoc>}
         subscription="taskStatus"
         FormComponent={TaskStatusForm}
+        useDrawerStack
       />
       <Form.Item label={t('tasks.participants')} name="participants" rules={[{ required: false, type: 'array' }]}>
         <Select mode="multiple" placeholder={t('forms.placeholders.selectParticipants')} allowClear options={participantOptions} optionFilterProp="label" />
@@ -131,6 +132,7 @@ export default function TaskForm() {
         collection={TasksCollection as unknown as Mongo.Collection<CollectionDoc>}
         subscription="tasks"
         FormComponent={TaskForm}
+        useDrawerStack
       />
       <FormFooter onCancel={cancel} />
 


### PR DESCRIPTION
## Summary

The **user-visible payoff** of the DrawerStack initiative: when you click "+ New X" inline in a `CollectionSelect`, fill out X, and submit, X is now pre-selected in the parent form's field — eliminating the legacy "create, close, re-find" dance.

- `CollectionSelect` gains an opt-in `useDrawerStack` prop. When set:
  - `handleCreate` `await drawerStack.push(...)`; on resolve, writes the inserted id back via `Form.useFormInstance().setFieldValue(name, id)` (or local `handleChange` fallback for non-Form-Item usage).
  - `handleEdit` `await drawerStack.push(...)` (no auto-select work — same id stays selected).
- `RanksForm` migrated to `useDrawerFrame<string, Partial<Rank>>()`, resolves with the inserted rank id. It embeds `RanksSelect` recursively, so it also exercises unbounded-depth nesting.
- Call sites with migrated `FormComponent` flipped to `useDrawerStack`: `TaskForm`, `TaskFilter`, `MemberForm`, `RanksSelect`, `Ranks` page.
- Unmigrated `FormComponent` (e.g. `RolesForm`) stays on the legacy cascade; sweep PRs flip per batch.

Closes #190.

## Architecture notes

- **`Form.useFormInstance()` is the write-back seam.** When `CollectionSelect` is wrapped in a `Form.Item` (the `isFormItem` path), antd's `Form` is the source of truth — calling `form.setFieldValue(name, newId)` updates both the form state and the rendered Select. For standalone usage, `handleChange` updates the internal mirror and bubbles via the `onChange` prop.
- **Multi-select append, single-select replace.** `writeBack` checks `mode` and constructs the new value accordingly. De-dupe is performed for multi-select before append.
- **Edit doesn't auto-select.** The id is unchanged on edit, so we just `await push` for UX symmetry (the drawer renders inside the stack) but skip the `writeBack`.

## Tests

- `npm run typecheck` clean
- `npm test` 323 passing (no new unit tests; the change is shape-preserving — existing `drawerStackStore` tests cover the underlying cascade-down + resolve semantics)
- Playwright manual demo (verified locally):
  - **Single-depth auto-select**: Tasks → Create → click `+` on Task Status → fill name → Submit → outer drawer's Task Status field shows `"AutoSelect Demo Status"` (pre-selected) ✓
  - **Three-deep nesting (impossible under legacy)**: Ranks → Create (depth 1) → click `+` on Previous Rank (depth 2) → click `+` on Previous Rank (depth 3) → fill + Submit → depth-3 closes, depth-2's Previous Rank field shows `"Deep Nested Rank"` (pre-selected, auto-cascade through depth-2 unchanged) ✓
  - Zero console errors throughout

## Test plan

- [ ] Walk the demo above
- [ ] Smoke-test that pages using unmigrated `FormComponent` (e.g. MemberForm's role select → `RolesForm`) still open via the legacy cascade