### PR TITLE
feat(drawer-stack): events forms sweep (#191)

### DIFF
--- a/imports/ui/events/EventCalendar.tsx
+++ b/imports/ui/events/EventCalendar.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/de';
 import 'dayjs/locale/fr';
 import { useFind, useSubscribe } from 'meteor/react-meteor-data';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Calendar, dayjsLocalizer } from 'react-big-calendar';
 import type { CalendarEvent, DateRange, View } from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
@@ -12,8 +12,7 @@ import EventTypesCollection from '../../api/collections/eventTypes.collection';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
 import { useLanguage } from '../../i18n/LanguageContext';
 import type { EventDoc } from '../../api/types/event';
-import { DrawerContext } from '../app/App';
-import type { DrawerContextValue } from '../app/types';
+import { useDrawerStack } from '../drawer-stack';
 import EventDetailPopover from './EventDetailPopover';
 import EventForm from './EventForm';
 import { useTourRef } from '../tour/TourContext';
@@ -28,7 +27,7 @@ interface EventCalendarProps {
 const EventCalendar = ({ datasource, setFilter }: EventCalendarProps) => {
   const calendarRef = useTourRef('events-calendar');
   const { t, language } = useLanguage();
-  const drawer = useContext(DrawerContext) as DrawerContextValue;
+  const drawerStack = useDrawerStack();
 
   // Set dayjs locale based on current language
   useEffect(() => {
@@ -49,14 +48,18 @@ const EventCalendar = ({ datasource, setFilter }: EventCalendarProps) => {
   useSubscribe('eventTypes', { _id: { $in: eventTypeIds } });
   const eventTypes = useFind(() => EventTypesCollection.find({ _id: { $in: eventTypeIds } }), [datasource]);
 
-  const openForm = (event?: Record<string, unknown>) => {
-    const isEdit = !!event?._id;
-    const model = event || {};
-    drawer.setDrawerTitle(isEdit ? t('events.editEvent') : t('events.createEvent'));
-    drawer.setDrawerModel(model);
-    drawer.setDrawerComponent(<EventForm setOpen={drawer.setDrawerOpen} />);
-    drawer.setDrawerOpen(true);
-  };
+  const openForm = useCallback(
+    (event?: Record<string, unknown>) => {
+      const isEdit = !!event?._id;
+      const model = event || {};
+      void drawerStack.push<string, Record<string, unknown>>({
+        title: isEdit ? t('events.editEvent') : t('events.createEvent'),
+        Component: EventForm,
+        model,
+      });
+    },
+    [drawerStack, t]
+  );
 
   const onEventDrop = ({ event, start, end, allDay }: { event: CalendarEvent; start: Date; end: Date; allDay?: boolean }) => {
     openForm({ ...(event as Record<string, unknown>), start, end, allDay });

--- a/imports/ui/events/EventForm.tsx
+++ b/imports/ui/events/EventForm.tsx
@@ -5,15 +5,14 @@ import dayjs, { Dayjs } from 'dayjs';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { useFind, useSubscribe } from 'meteor/react-meteor-data';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import EventTypesCollection from '../../api/collections/eventTypes.collection';
 import SquadsCollection from '../../api/collections/squads.collection';
 import type { EventDoc } from '../../api/types/event';
 import type { CollectionDoc } from '../components/CollectionSelect';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
-import { DrawerContext } from '../app/App';
-import type { DrawerContextValue } from '../app/types';
+import { useDrawerFrame } from '../drawer-stack';
 import CollectionSelect from '../components/CollectionSelect';
 import MembersSelect from '../members/MembersSelect';
 import { getColorFromValues } from '../specializations/SpecializationForm';
@@ -45,27 +44,23 @@ export const getDateFromValues = (values: Record<string, unknown>, key = 'date')
   return val as Date | undefined;
 };
 
-interface EventFormProps {
-  setOpen: (open: boolean) => void;
-}
-
-const EventForm = ({ setOpen }: EventFormProps) => {
+const EventForm = () => {
   const { message, notification, modal } = App.useApp();
   const { t } = useTranslation();
-  const drawer = useContext(DrawerContext) as DrawerContextValue;
+  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<EventDoc>>();
 
   const model = useMemo(() => {
-    const data = (drawer.drawerModel || {}) as unknown as EventDoc;
+    const data = (rawModel || {}) as unknown as EventDoc;
     return {
       ...data,
       start: data.start ? dayjs(data.start) : null,
       end: data.end ? dayjs(data.end) : null,
       hosts: data.hosts || (data._id ? [] : [Meteor.userId()]),
     } as EventFormValues & { _id?: string };
-  }, [drawer]);
+  }, [rawModel]);
 
   const handleFinish = useCallback(
-    (values: EventFormValues) => {
+    async (values: EventFormValues) => {
       const wireValues = {
         ...values,
         color: getColorFromValues(values as unknown as Record<string, unknown>),
@@ -74,22 +69,19 @@ const EventForm = ({ setOpen }: EventFormProps) => {
       };
       const args = [...(model?._id ? [model._id] : []), wireValues];
       const endpoint = model?._id ? 'events.update' : 'events.insert';
-      const handleError = (error: Meteor.Error) => {
+      try {
+        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
+        message.success(model?._id ? t('messages.eventUpdated') : t('messages.eventCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
         notification.error({
-          message: error.error,
-          description: error.message,
+          message: err.error as string,
+          description: err.message,
         });
-      };
-      const handleSuccess = () => {
-        const text = model?._id ? t('messages.eventUpdated') : t('messages.eventCreated');
-        message.success(text);
-        setOpen(false);
-      };
-      Meteor.callAsync(endpoint, ...args)
-        .then(handleSuccess)
-        .catch(handleError);
+      }
     },
-    [model?._id, message, notification, setOpen, t]
+    [model?._id, message, notification, resolve, t]
   );
 
   const handleDelete = useCallback(() => {
@@ -99,20 +91,20 @@ const EventForm = ({ setOpen }: EventFormProps) => {
       cancelText: t('common.cancel'),
       okType: 'danger',
       onOk: async () => {
-        await Meteor.callAsync('events.remove', model._id)
-          .then(() => {
-            message.success(t('messages.eventDeleted'));
-            setOpen(false);
-          })
-          .catch((error: Meteor.Error) => {
-            notification.error({
-              message: error.error,
-              description: error.message,
-            });
+        try {
+          await Meteor.callAsync('events.remove', model._id);
+          message.success(t('messages.eventDeleted'));
+          cancel();
+        } catch (error) {
+          const err = error as Meteor.Error;
+          notification.error({
+            message: err.error as string,
+            description: err.message,
           });
+        }
       },
     });
-  }, [modal, message, setOpen, model, notification, t]);
+  }, [modal, message, cancel, model, notification, t]);
 
   const [form] = Form.useForm<EventFormValues>();
 
@@ -136,6 +128,7 @@ const EventForm = ({ setOpen }: EventFormProps) => {
         collection={EventTypesCollection as unknown as Mongo.Collection<CollectionDoc>}
         subscription="eventTypes"
         FormComponent={EventTypesForm}
+        useDrawerStack
       />
       <MembersSelect multiple grouped name="hosts" label={t('events.hosts')} rules={[{ type: 'array' }]} defaultValue={model.hosts} />
       <MembersSelect multiple grouped name="attendees" label={t('events.attendees')} rules={[{ type: 'array' }]} defaultValue={model.attendees} />

--- a/imports/ui/events/Events.tsx
+++ b/imports/ui/events/Events.tsx
@@ -82,6 +82,7 @@ export default function Events() {
         columnsFactory={getEventColumns}
         filterFactory={filterFactory}
         extra={<></>}
+        useDrawerStack
         headerExtra={
           <>
             <Col>
@@ -93,6 +94,7 @@ export default function Events() {
                 placeholder={t('events.filterByType')}
                 mode="multiple"
                 subscription="eventTypes"
+                useDrawerStack
               />
             </Col>
             {(['table', 'attendance'] as ViewType[]).includes(viewType) && (

--- a/imports/ui/events/event-types/EventTypes.tsx
+++ b/imports/ui/events/event-types/EventTypes.tsx
@@ -16,6 +16,7 @@ const EventTypes = () => {
       Collection={EventTypesCollection}
       FormComponent={EventTypesForm}
       columnsFactory={getEventTypeColumns}
+      useDrawerStack
     />
   );
 };

--- a/imports/ui/events/event-types/EventTypesForm.tsx
+++ b/imports/ui/events/event-types/EventTypesForm.tsx
@@ -1,30 +1,21 @@
 import { App, ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { DrawerContext, SubdrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '../../specializations/SpecializationForm';
+import type { EventType } from '../../../api/types';
 
-interface EventTypesFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
-
-export default function EventTypesForm({ setOpen, useSubdrawer = false }: EventTypesFormProps) {
+export default function EventTypesForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
-
-  const drawerCtx = useContext(useSubdrawer ? SubdrawerContext : DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return drawerCtx.drawerModel || {};
-  }, [drawerCtx]);
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<EventType>>();
 
   useEffect(() => {
-    if (Object.keys(model).length > 0) {
+    if (model && Object.keys(model).length > 0) {
       form.setFieldsValue(model);
     } else {
       form.setFieldsValue({
@@ -36,25 +27,25 @@ export default function EventTypesForm({ setOpen, useSubdrawer = false }: EventT
   }, [model, form.setFieldsValue]);
 
   const handleSubmit = useCallback(
-    (values: Record<string, unknown>) => {
+    async (values: Record<string, unknown>) => {
       setLoading(true);
       const { name, description } = values as { name: string; description?: string };
       const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'eventTypes.update' : 'eventTypes.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(model?._id ? t('messages.eventTypeUpdated') : t('messages.eventTypeCreated'));
-        })
-        .catch((error: Meteor.Error) => {
-          notification.error({
-            message: error.error,
-            description: error.message,
-          });
-        })
-        .finally(() => setLoading(false));
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'eventTypes.update' : 'eventTypes.insert',
+          ...args
+        )) as string | undefined;
+        message.success(model?._id ? t('messages.eventTypeUpdated') : t('messages.eventTypeCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({ message: err.error as string, description: err.message });
+      } finally {
+        setLoading(false);
+      }
     },
-    [setOpen, form, model, message, notification, t]
+    [model, resolve, message, notification, t]
   );
 
   return (
@@ -68,7 +59,7 @@ export default function EventTypesForm({ setOpen, useSubdrawer = false }: EventT
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 }


### PR DESCRIPTION
## Summary

Migrates the events-area forms off the legacy `DrawerContext`/`SubdrawerContext` two-context pattern. After this PR, no events-area file imports either legacy context.

- **EventForm**: drops `setOpen` + DrawerContext, consumes `useDrawerFrame<string, Partial<EventDoc>>()`, resolves with the inserted/updated event id; the inline EventTypes `CollectionSelect` flips to `useDrawerStack`. `handleDelete` calls `cancel()` once the entity is gone.
- **EventTypesForm**: drops `setOpen` + `useSubdrawer`, consumes `useDrawerFrame<string, Partial<EventType>>()`.
- **EventCalendar**: `openForm` routes through `drawerStack.push` instead of the legacy five-setter cascade.
- **Events.tsx** + **EventTypes.tsx**: Section opts in via `useDrawerStack`; the header-filter `CollectionSelect` also opts in since EventTypesForm is now migrated.

Closes #191.

## Tests

- `npm run typecheck` clean
- `npm test` 323 passing
- Playwright manual demo (verified locally):
  - Click empty calendar slot → EventForm opens via DrawerStack ✓
  - Click `+` on Event Type inside EventForm → EventTypesForm pushed at depth 2 ✓
  - Fill name + Submit → inner drawer closes, **outer EventForm's Event Type field auto-shows "Demo EventType via #191"** ✓
  - Zero new console errors (the two existing `destroyOnClose` and `defaultValue` antd deprecation warnings are pre-existing and out of scope)

## Test plan

- [ ] Verify calendar slot select still creates events via DrawerStack
- [ ] Verify drag-and-drop / resize on existing events opens edit drawer
- [ ] Verify the EventTypes admin table create/edit goes through DrawerStack
- [ ] Verify the EventTypes filter in the Events page header still works (now also exercises the new auto-select for inline create)