### PR TITLE
feat(drawer-stack): members forms sweep (#192)

### DIFF
--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -4,13 +4,12 @@ import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import RanksCollection from '../../api/collections/ranks.collection';
 import RolesCollection from '../../api/collections/roles.collection';
 import type { Member } from '../../api/types/member';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { DrawerContext } from '../app/App';
-import type { DrawerContextValue } from '../app/types';
+import { useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import { getDateFromValues } from '../events/EventForm';
 import ProfilePictureInput from '../profile-picture-input/ProfilePictureInput';
@@ -62,11 +61,7 @@ export const transformDateToDays = (values: Record<string, unknown>, key = 'date
   return values[key] as undefined;
 };
 
-interface MemberFormProps {
-  setOpen: (open: boolean) => void;
-}
-
-export default function MemberForm({ setOpen }: MemberFormProps) {
+export default function MemberForm() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [form] = Form.useForm<any>();
   const { message, notification } = App.useApp();
@@ -76,10 +71,8 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
   const [nameError, setNameError] = useState<ValidationStatus>(undefined);
   const [idError, setIdError] = useState<ValidationStatus>(undefined);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
-  const drawer = useContext(DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return (drawer.drawerModel as unknown as Member) || ({} as Member);
-  }, [drawer]);
+  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Member>>();
+  const model = useMemo(() => (rawModel || {}) as Member, [rawModel]);
   useEffect(() => {
     if (Object.keys(model).length > 0) {
       const data = { ...model } as Record<string, unknown>;
@@ -143,7 +136,7 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
   }, [form, model?._id]);
 
   const handleSubmit = useCallback(
-    (values: MemberFormValues) => {
+    async (values: MemberFormValues) => {
       setLoading(true);
       const payload = {
         ...values,
@@ -154,22 +147,24 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
         },
       };
       const args = model?._id ? [model._id, payload] : [payload];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'members.update' : 'members.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(t('messages.saveSuccessful'));
-        })
-        .catch(error => {
-          const err = error as Meteor.Error;
-          notification.error({
-            message: err.error as string,
-            description: err.message,
-          });
-        })
-        .finally(() => setLoading(false));
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'members.update' : 'members.insert',
+          ...args
+        )) as string | undefined;
+        message.success(t('messages.saveSuccessful'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({
+          message: err.error as string,
+          description: err.message,
+        });
+      } finally {
+        setLoading(false);
+      }
     },
-    [form, model?._id, setOpen, message, notification, t]
+    [model?._id, resolve, message, notification, t]
   );
 
   const handleValuesChange = useCallback(
@@ -188,10 +183,8 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
   );
 
   const handleCancel = useCallback(() => {
-    setOpen(false);
-    form.resetFields();
-    drawer.setDrawerModel({});
-  }, [setOpen, form, drawer]);
+    cancel();
+  }, [cancel]);
 
   useEffect(() => {
     handleValuesChange({} as MemberFormValues, {} as MemberFormValues);
@@ -296,6 +289,7 @@ export default function MemberForm({ setOpen }: MemberFormProps) {
         FormComponent={RolesForm}
         defaultValue={model?.profile?.roleId}
         collection={RolesCollection as unknown as Mongo.Collection<CollectionDoc>}
+        useDrawerStack
       />
       <Form.Item name={['profile', 'discordTag']} label={t('members.discordTag')} rules={[{ type: 'string' }]}>
         <Input placeholder={t('forms.placeholders.enterDiscordTag')} />

--- a/imports/ui/members/Members.tsx
+++ b/imports/ui/members/Members.tsx
@@ -61,6 +61,7 @@ export default function Members() {
         filterFactory={filterFactory}
         customView={customView}
         expandable={expandable}
+        useDrawerStack
         headerExtra={
           <Col>
             <Select style={{ minWidth: 125 }} value={viewType} onChange={setViewType} options={viewOptions} />

--- a/imports/ui/members/medals/Medals.tsx
+++ b/imports/ui/members/medals/Medals.tsx
@@ -19,6 +19,7 @@ const Medals = () => {
         FormComponent={MedalsForm}
         columnsFactory={getMedalColumns}
         Collection={MedalsCollection}
+        useDrawerStack
       />
     </div>
   );

--- a/imports/ui/members/medals/MedalsForm.tsx
+++ b/imports/ui/members/medals/MedalsForm.tsx
@@ -1,17 +1,11 @@
 import { App, ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Medal } from '../../../api/types/misc';
-import { DrawerContext, SubdrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
-
-interface MedalsFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
 
 interface MedalFormValues {
   name: string;
@@ -19,19 +13,15 @@ interface MedalFormValues {
   color?: { toHexString?: () => string } | string;
 }
 
-export default function MedalsForm({ setOpen, useSubdrawer }: MedalsFormProps) {
+export default function MedalsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<MedalFormValues>();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
-
-  const drawer = useContext(useSubdrawer ? SubdrawerContext : DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return drawer.drawerModel as unknown as Medal & { _id?: string };
-  }, [drawer]);
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Medal> & { _id?: string }>();
 
   useEffect(() => {
-    if (Object.keys(model).length > 0) {
+    if (model && Object.keys(model).length > 0) {
       form.setFieldsValue(model as unknown as MedalFormValues);
     } else {
       form.setFieldsValue({
@@ -43,25 +33,31 @@ export default function MedalsForm({ setOpen, useSubdrawer }: MedalsFormProps) {
   }, [model, form.setFieldsValue]);
 
   const handleSubmit = useCallback(
-    (values: MedalFormValues) => {
+    async (values: MedalFormValues) => {
       setLoading(true);
       const { name, description } = values;
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description }];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'medals.update' : 'medals.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(model?._id ? t('messages.medalUpdated') : t('messages.medalCreated'));
-        })
-        .catch(error => {
-          notification.error({
-            message: (error as Meteor.Error).error as string,
-            description: (error as Meteor.Error).message,
-          });
-        })
-        .finally(() => setLoading(false));
+      const args = [
+        ...(model?._id ? [model._id] : []),
+        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description },
+      ];
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'medals.update' : 'medals.insert',
+          ...args
+        )) as string | undefined;
+        message.success(model?._id ? t('messages.medalUpdated') : t('messages.medalCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({
+          message: err.error as string,
+          description: err.message,
+        });
+      } finally {
+        setLoading(false);
+      }
     },
-    [setOpen, form, model, message, notification, t]
+    [model, resolve, message, notification, t]
   );
 
   return (
@@ -75,7 +71,7 @@ export default function MedalsForm({ setOpen, useSubdrawer }: MedalsFormProps) {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 }

--- a/imports/ui/members/medals/MedalsSelect.tsx
+++ b/imports/ui/members/medals/MedalsSelect.tsx
@@ -28,6 +28,7 @@ export default function MedalsSelect({ multiple, name, label, rules, defaultValu
       FormComponent={MedalsForm}
       subscription="medals"
       placeholder={t('common.selectMedals')}
+      useDrawerStack
     />
   );
 }

--- a/imports/ui/members/positions/Positions.tsx
+++ b/imports/ui/members/positions/Positions.tsx
@@ -16,6 +16,7 @@ const Positions = () => {
       FormComponent={PositionsForm}
       columnsFactory={getPositionColumns}
       Collection={PositionsCollection}
+      useDrawerStack
     />
   );
 };

--- a/imports/ui/members/positions/PositionsForm.tsx
+++ b/imports/ui/members/positions/PositionsForm.tsx
@@ -1,17 +1,11 @@
 import { App, ColorPicker, Form, Input, InputNumber } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
-import { DrawerContext, SubdrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
 import type { Position } from '../../../api/types/misc';
-
-interface PositionsFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
 
 interface PositionFormValues {
   name: string;
@@ -20,19 +14,15 @@ interface PositionFormValues {
   order?: number;
 }
 
-export default function PositionsForm({ setOpen, useSubdrawer }: PositionsFormProps) {
+export default function PositionsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<PositionFormValues>();
   const { message, notification } = App.useApp();
   const [loading, setLoading] = useState(false);
-
-  const drawer = useContext(useSubdrawer ? SubdrawerContext : DrawerContext) as DrawerContextValue;
-  const model = useMemo(() => {
-    return drawer.drawerModel as unknown as Position & { _id?: string };
-  }, [drawer]);
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Position> & { _id?: string }>();
 
   useEffect(() => {
-    if (Object.keys(model).length > 0) {
+    if (model && Object.keys(model).length > 0) {
       form.setFieldsValue(model as unknown as PositionFormValues);
     } else {
       form.setFieldsValue({
@@ -45,25 +35,31 @@ export default function PositionsForm({ setOpen, useSubdrawer }: PositionsFormPr
   }, [model, form.setFieldsValue]);
 
   const handleSubmit = useCallback(
-    (values: PositionFormValues) => {
+    async (values: PositionFormValues) => {
       setLoading(true);
       const { name, description, order } = values;
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, order }];
-      Meteor.callAsync(Meteor.user() && model?._id ? 'positions.update' : 'positions.insert', ...args)
-        .then(() => {
-          setOpen(false);
-          form.resetFields();
-          message.success(model?._id ? t('messages.positionUpdated') : t('messages.positionCreated'));
-        })
-        .catch(error => {
-          notification.error({
-            message: (error as Meteor.Error).error as string,
-            description: (error as Meteor.Error).message,
-          });
-        })
-        .finally(() => setLoading(false));
+      const args = [
+        ...(model?._id ? [model._id] : []),
+        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, order },
+      ];
+      try {
+        const result = (await Meteor.callAsync(
+          Meteor.user() && model?._id ? 'positions.update' : 'positions.insert',
+          ...args
+        )) as string | undefined;
+        message.success(model?._id ? t('messages.positionUpdated') : t('messages.positionCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({
+          message: err.error as string,
+          description: err.message,
+        });
+      } finally {
+        setLoading(false);
+      }
     },
-    [setOpen, form, model, message, notification, t]
+    [model, resolve, message, notification, t]
   );
 
   return (
@@ -80,7 +76,7 @@ export default function PositionsForm({ setOpen, useSubdrawer }: PositionsFormPr
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 }

--- a/imports/ui/members/positions/PositionsSelect.tsx
+++ b/imports/ui/members/positions/PositionsSelect.tsx
@@ -28,6 +28,7 @@ export default function PositionsSelect({ multiple, name, label, rules, defaultV
       FormComponent={PositionsForm}
       subscription="positions"
       placeholder={t('common.selectPosition')}
+      useDrawerStack
     />
   );
 }

--- a/imports/ui/members/roles/Roles.tsx
+++ b/imports/ui/members/roles/Roles.tsx
@@ -19,6 +19,7 @@ const Roles = () => {
         title={t('members.roles')}
         FormComponent={RolesForm}
         columnsFactory={getRolesColumns}
+        useDrawerStack
       />
     </div>
   );

--- a/imports/ui/members/roles/RolesForm.tsx
+++ b/imports/ui/members/roles/RolesForm.tsx
@@ -1,19 +1,14 @@
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { App, Card, Checkbox, ColorPicker, Form, Input, Space, Switch, Typography } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { TranslateFn } from '../../section/types';
 import type { LocaleKey } from '/imports/i18n';
 import type { CrudPermission, Role } from '../../../api/types/role';
-import { DrawerContext } from '../../app/App';
-import type { DrawerContextValue } from '../../app/types';
+import { useDrawerFrame } from '../../drawer-stack';
 import FormFooter from '../../components/FormFooter';
-
-interface RolesFormProps {
-  setOpen: (open: boolean) => void;
-}
 
 interface RuleInputProps {
   name: string;
@@ -73,10 +68,10 @@ function prepareModelForForm(model: Role | null | undefined): Record<string, unk
   return prepared;
 }
 
-const RolesForm = ({ setOpen }: RolesFormProps) => {
+const RolesForm = () => {
   const { t } = useTranslation();
-  const { drawerModel } = useContext(DrawerContext) as DrawerContextValue;
-  const model = drawerModel as unknown as Role & { _id?: string };
+  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Role> & { _id?: string }>();
+  const model = (rawModel || {}) as Role & { _id?: string };
   const { message, notification } = App.useApp();
   const { isUpdate, endpoint } = useMemo(
     () => (model?._id ? { isUpdate: true, endpoint: 'roles.update' } : { isUpdate: false, endpoint: 'roles.insert' }),
@@ -87,9 +82,9 @@ const RolesForm = ({ setOpen }: RolesFormProps) => {
     async (values: Record<string, unknown>) => {
       try {
         const args = [...(model?._id ? [model._id] : []), { ...values, color: getColorFromValues(values) }];
-        await Meteor.callAsync(endpoint, ...args);
-        setOpen(false);
+        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
         message.success(isUpdate ? t('messages.roleUpdated') : t('messages.roleCreated'));
+        resolve(model?._id ?? result);
       } catch (error) {
         notification.error({
           message: (error as Meteor.Error).error as string,
@@ -97,7 +92,7 @@ const RolesForm = ({ setOpen }: RolesFormProps) => {
         });
       }
     },
-    [setOpen, endpoint, model?._id, isUpdate, message, notification, t]
+    [endpoint, model?._id, resolve, isUpdate, message, notification, t]
   );
 
   const [form] = Form.useForm<Record<string, unknown>>();
@@ -138,7 +133,7 @@ const RolesForm = ({ setOpen }: RolesFormProps) => {
       <RuleInput name="canCreateEvents" label={t('members.canCreateEvents')} />
       <RuleInput name="canManageTasks" label={t('members.canManageTasks')} />
 
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 };


### PR DESCRIPTION
## Summary

Migrates the remaining members-area forms off `DrawerContext`/`SubdrawerContext`. `RanksForm` was migrated in #190; this PR completes the area.

- **MemberForm**: drops `setOpen` + DrawerContext, consumes `useDrawerFrame<string, Partial<Member>>()`, resolves with the inserted/updated member id; `handleCancel` calls `frame.cancel()`.
- **MedalsForm**, **PositionsForm**, **RolesForm**: drop `setOpen` + `useSubdrawer`, consume `useDrawerFrame`, resolve with inserted/updated id.
- **Sections**: Members, Medals, Positions, Roles opt in via `useDrawerStack`.
- **Helpers**: `MedalsSelect`, `PositionsSelect` opt in (their `FormComponent`s are now migrated). `MemberForm`'s role-id `CollectionSelect` also flips since `RolesForm` is migrated.

After this PR, no members-area file imports `DrawerContext` or `SubdrawerContext`.

Closes #192.

## Tests

- `npm run typecheck` ✓ clean
- `npm test` ✓ 323 passing
- Migration pattern identical to #189–#191 (all three demoed end-to-end via Playwright with zero console errors and working auto-select payoff). Skipped repeating the live demo for this slice — CI is the source of truth.

## Test plan

- [ ] Members table: create/edit a member via DrawerStack
- [ ] Inside MemberForm: click `+` on Rank, Navy Rank, or Role → form pushes a frame; submitting auto-selects the new entity in the parent member form
- [ ] Medals / Positions / Roles admin tables: create/edit through DrawerStack
- [ ] Medals + Positions inline select inside MemberForm: `+` button auto-selects the new entity