### PR TITLE
feat(drawer-stack): squads + specialization sweep (#193)

### DIFF
--- a/imports/ui/specializations/SpecializationForm.tsx
+++ b/imports/ui/specializations/SpecializationForm.tsx
@@ -1,10 +1,9 @@
 import { App, Col, ColorPicker, Form, Input, Row } from 'antd';
 import type { Rule } from 'antd/es/form';
 import { Meteor } from 'meteor/meteor';
-import React, { ComponentType, useCallback, useContext, useMemo } from 'react';
+import React, { ComponentType, useCallback, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import type { DrawerContextValue } from '../app/types';
-import { DrawerContext, SubdrawerContext } from '../app/App';
+import { useDrawerFrame } from '../drawer-stack';
 import FormFooter from '../components/FormFooter';
 import MembersSelect from '../members/MembersSelect';
 import RanksSelect from '../members/ranks/RanksSelect';
@@ -15,7 +14,6 @@ import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 
 export { getColorFromValues };
 
-/** Shared props that MembersSelect and RanksSelect accept (still .jsx, typed via cast) */
 interface SelectFieldProps {
   multiple?: boolean;
   name?: string;
@@ -38,40 +36,34 @@ interface SpecializationFormValues {
   description?: string;
 }
 
-interface SpecializationFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
-
-const SpecializationForm = ({ setOpen, useSubdrawer }: SpecializationFormProps) => {
+const SpecializationForm = () => {
   const { t } = useTranslation();
-  const drawer = useContext(DrawerContext) as DrawerContextValue;
-  const subdrawer = useContext(SubdrawerContext) as DrawerContextValue;
+  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Specialization> & { _id?: string }>();
   const { message, notification } = App.useApp();
 
   const { model, endpoint } = useMemo(() => {
-    const newModel = ((useSubdrawer ? subdrawer.drawerModel : drawer.drawerModel) || {}) as unknown as Specialization;
+    const newModel = (rawModel || {}) as unknown as Specialization;
     return { model: newModel, endpoint: newModel?._id ? 'specializations.update' : 'specializations.insert' };
-  }, [drawer, subdrawer, useSubdrawer]);
+  }, [rawModel]);
 
   const handleFinish = useCallback(
     async (values: SpecializationFormValues) => {
       const color = getColorFromValues(values);
       values.color = color;
       const args = [...(model?._id ? [model._id] : []), values];
-      Meteor.callAsync(endpoint, ...args)
-        .then(() => {
-          message.success(model?._id ? t('messages.specializationUpdated') : t('messages.specializationCreated'));
-          setOpen(false);
-        })
-        .catch((error: Meteor.Error) => {
-          notification.error({
-            message: error.error as string,
-            description: error.message,
-          });
+      try {
+        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
+        message.success(model?._id ? t('messages.specializationUpdated') : t('messages.specializationCreated'));
+        resolve(model?._id ?? result);
+      } catch (error) {
+        const err = error as Meteor.Error;
+        notification.error({
+          message: err.error as string,
+          description: err.message,
         });
+      }
     },
-    [setOpen, notification, message, model?._id, endpoint, t]
+    [resolve, notification, message, model?._id, endpoint, t]
   );
 
   const [form] = Form.useForm<SpecializationFormValues>();
@@ -105,7 +97,7 @@ const SpecializationForm = ({ setOpen, useSubdrawer }: SpecializationFormProps) 
       <Form.Item name="description" label={t('common.description')} rules={[{ required: false, type: 'string' }]}>
         <Input.TextArea autoSize placeholder={t('forms.placeholders.enterDescription')} />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 };

--- a/imports/ui/specializations/Specializations.tsx
+++ b/imports/ui/specializations/Specializations.tsx
@@ -20,6 +20,7 @@ export default function Specializations() {
         FormComponent={SpecializationForm}
         columnsFactory={getSpecializationColumns}
         filterFactory={string => ({ name: { $regex: string, $options: 'i' } })}
+        useDrawerStack
       />
     </div>
   );

--- a/imports/ui/specializations/SpecializationsSelect.tsx
+++ b/imports/ui/specializations/SpecializationsSelect.tsx
@@ -31,6 +31,7 @@ export default function SpecializationsSelect({ multiple, name, label, rules, de
       subscription="specializations"
       placeholder={t('common.selectSpecializations')}
       extra={<></>}
+      useDrawerStack
     />
   );
 }

--- a/imports/ui/squads/Squads.tsx
+++ b/imports/ui/squads/Squads.tsx
@@ -28,6 +28,7 @@ export default function Squads() {
         FormComponent={SquadsForm}
         columnsFactory={getSquadsColumns}
         expandable={expandable}
+        useDrawerStack
       />
     </div>
   );

--- a/imports/ui/squads/SquadsForm.tsx
+++ b/imports/ui/squads/SquadsForm.tsx
@@ -1,20 +1,14 @@
 import { App, Col, ColorPicker, Form, Input, Row, Switch, Upload } from 'antd';
 import type { RcFile } from 'antd/es/upload';
 import { Meteor } from 'meteor/meteor';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import type { Squad } from '../../api/types/squad';
-import type { DrawerContextValue } from '../app/types';
-import { DrawerContext, SubdrawerContext } from '../app/App';
+import { useDrawerFrame } from '../drawer-stack';
 import FormFooter from '../components/FormFooter';
 import { turnBase64ToImage, turnImageFileToBase64 } from '../profile-picture-input/ProfilePictureInput';
 import { getColorFromValues } from '../specializations/SpecializationForm';
 import SquadsSelect from './SquadsSelect';
-
-interface SquadsFormProps {
-  setOpen: (open: boolean) => void;
-  useSubdrawer?: boolean;
-}
 
 interface SquadsFormValues {
   name?: string;
@@ -27,17 +21,12 @@ interface SquadsFormValues {
   excludeFromOrbat?: boolean;
 }
 
-const SquadsForm = ({ setOpen, useSubdrawer = false }: SquadsFormProps) => {
+const SquadsForm = () => {
   const { t } = useTranslation();
   const { message, notification } = App.useApp();
-  const drawer = useContext(DrawerContext) as DrawerContextValue;
-  const subdrawer = useContext(SubdrawerContext) as DrawerContextValue;
+  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Squad> & { _id?: string }>();
 
-  const model = useMemo(() => {
-    return useSubdrawer ? subdrawer.drawerModel || {} : drawer.drawerModel || {};
-  }, [drawer, subdrawer, useSubdrawer]);
-
-  const squad = model as unknown as Squad;
+  const squad = (model || {}) as unknown as Squad;
 
   const [file, setFile] = useState<RcFile | null>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -45,7 +34,7 @@ const SquadsForm = ({ setOpen, useSubdrawer = false }: SquadsFormProps) => {
   useEffect(() => {
     if (!squad.image) return;
     setImageSrc(squad.image);
-  }, [model]);
+  }, [squad.image]);
 
   const handleCustomRequest = async () => {
     try {
@@ -67,21 +56,24 @@ const SquadsForm = ({ setOpen, useSubdrawer = false }: SquadsFormProps) => {
     const image = imageSrc;
     values.image = image;
     const args = [...(squad?._id ? [squad._id] : []), values];
-    Meteor.callAsync(Meteor.user() && squad?._id ? 'squads.update' : 'squads.insert', ...args)
-      .then(() => {
-        setOpen(false);
-        message.success(squad?._id ? t('messages.squadUpdated') : t('messages.squadCreated'));
-      })
-      .catch(error => {
-        notification.error({
-          message: error.error,
-          description: error.message,
-        });
+    try {
+      const result = (await Meteor.callAsync(
+        Meteor.user() && squad?._id ? 'squads.update' : 'squads.insert',
+        ...args
+      )) as string | undefined;
+      message.success(squad?._id ? t('messages.squadUpdated') : t('messages.squadCreated'));
+      resolve(squad?._id ?? result);
+    } catch (error) {
+      const err = error as Meteor.Error;
+      notification.error({
+        message: err.error as string,
+        description: err.message,
       });
+    }
   };
 
   return (
-    <Form layout="vertical" initialValues={model} onFinish={handleFinish}>
+    <Form layout="vertical" initialValues={squad} onFinish={handleFinish}>
       <Form.Item label={t('squads.logo')} name="image" rules={[{ required: false }]}>
         <Upload.Dragger
           fileList={file ? [file] : []}
@@ -118,7 +110,7 @@ const SquadsForm = ({ setOpen, useSubdrawer = false }: SquadsFormProps) => {
       <Form.Item label={t('squads.excludeFromOrbat')} name="excludeFromOrbat" valuePropName="checked">
         <Switch />
       </Form.Item>
-      <FormFooter setOpen={setOpen} />
+      <FormFooter onCancel={cancel} />
     </Form>
   );
 };

--- a/imports/ui/squads/SquadsSelect.tsx
+++ b/imports/ui/squads/SquadsSelect.tsx
@@ -37,6 +37,7 @@ export default function SquadsSelect({ multiple, name, label, rules, defaultValu
       subscription="squads"
       placeholder={t('common.selectSquad')}
       extra={<></>}
+      useDrawerStack
     />
   );
 }


### PR DESCRIPTION
## Summary

Migrates `SquadsForm` and `SpecializationForm` off `DrawerContext`/`SubdrawerContext`.

- **SquadsForm**: drops `setOpen` + `useSubdrawer`, consumes `useDrawerFrame<string, Partial<Squad>>()`, resolves with the inserted/updated id.
- **SpecializationForm**: same pattern with `Partial<Specialization>`.
- **Sections**: Squads, Specializations opt in via `useDrawerStack`.
- **Helpers**: `SquadsSelect`, `SpecializationsSelect` opt in (their `FormComponent`s are now migrated).

After this PR, no squads-area or specializations-area file imports `DrawerContext` or `SubdrawerContext`.

Closes #193.

## Tests

- `npm run typecheck` ✓ clean
- `npm test` ✓ 323 passing
- Migration pattern identical to #189–#192 (all four demoed end-to-end on Playwright with zero console errors).

## Test plan

- [ ] Squads admin table: create/edit through DrawerStack
- [ ] SquadsForm: click `+` on Parent Squad → SquadsForm pushed at depth 2; submit auto-selects in parent (recursive nesting)
- [ ] Specializations admin table: create/edit through DrawerStack
- [ ] SpecializationForm: click `+` on Required Specializations (recursive) or Required Rank → frame pushes; submit auto-selects
- [ ] Members area `MemberForm`'s SquadsSelect: `+` button auto-selects the new squad