### PR TITLE
fix: stop Meteor HMR reload from flaking auth e2e tests

### DIFF
--- a/.meteorignore
+++ b/.meteorignore
@@ -1,4 +1,3 @@
-# Playwright E2E test output
-e2e/playwright-report/
-e2e/test-results/
-e2e/.auth/
+# Playwright E2E (test specs, page objects, fixtures, transient artifacts)
+# Excluded entirely so Playwright file activity does not trigger Meteor HMR mid-test
+e2e/

--- a/imports/ui/app/App.tsx
+++ b/imports/ui/app/App.tsx
@@ -23,7 +23,6 @@ interface AppSettings {
 }
 
 export default function App() {
-  const { message, notification } = AntdApp.useApp();
   const { communityColor } = useSettings() as unknown as AppSettings;
   const [theme, setTheme] = useState<ThemeMode>(getPreferedTheme);
   const [navigationValue, setNavigationValue] = useState<string>(getNavigationValue);
@@ -65,7 +64,7 @@ export default function App() {
                 algorithm: theme === 'dark' ? AntdTheme.darkAlgorithm : AntdTheme.defaultAlgorithm,
               }}
             >
-              <AntdApp className="app" message={{ ...message, maxCount: 1 }} notification={{ ...notification, maxCount: 3 }}>
+              <AntdApp className="app" message={{ maxCount: 1 }} notification={{ maxCount: 3 }}>
                 <DrawerStackProvider>
                   <Layout>
                     <Layout.Header>


### PR DESCRIPTION
## Summary

Fixes the flaky auth e2e tests (`should show error for invalid credentials`, `should show error for non-existent user`, `should logout successfully`). The single functional fix is in `.meteorignore`; the `App.tsx` change is an unrelated cleanup (details below).

> **Note:** an earlier version of this PR claimed the `App.tsx` `useApp()` spread corrupted AntdApp's notification holder. That was wrong — see "Correction" below. The real cause was a Meteor HMR-triggered page reload.

### The fix — `.meteorignore`

`.meteorignore` only excluded `e2e/playwright-report/`, `e2e/test-results/`, `e2e/.auth/`. Playwright's other writes under `e2e/` stayed visible to Meteor's file watcher, so mid-test it triggered an HMR push that fell back to `forceBrowserReload` (from `packages/reload.js`) — a full page reload that wiped form state and any just-rendered notification. Excluding `e2e/` wholesale stops it.

### Cleanup — `App.tsx` (not a fix)

`App.tsx` called `AntdApp.useApp()` outside the `<AntdApp>` provider (returning the static fallback) and spread the result into the `message`/`notification` **config props**. That's an antd anti-pattern and emits a dev console warning, but it is **functionally harmless** — antd reads only known config keys (`maxCount`, …) and ignores the spread-in method keys. Replaced with plain config objects.

## Correction (why the framing changed)

Original analysis credited both changes as the fix. Isolating them disproved that: with `App.tsx` **reverted to the spread** but `.meteorignore` fixed, the auth error tests pass **40/40**. So the spread was never the cause — the HMR reload was. The early "notification never rendered" evidence was a reload killing the toast, misattributed to the config. Keeping the `App.tsx` tidy-up because it's a genuine (if minor) improvement, but it carries no behavioral weight.

## Testing

- Auth spec × 20 parallel repeats, `--retries=0`: **100/100**
- `App.tsx` spread reverted + `.meteorignore` fix only, auth error × 20: **40/40** (proves `.meteorignore` is the fix)
- Full e2e suite: **105 passed, 3 skipped, 0 flaky**
- `npm run typecheck`: clean