### PR TITLE
docs: document that client mocha tests don't run in CI (#205)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,22 @@ Source of truth is `imports/i18n/translations.ts` — a flat `Record<DottedKey, 
 
 The previous design (three hand-synchronized `locales/{en,de,fr}.json` files + a `getTranslation` walker that returned the key string on miss) had no way to express any of these invariants. The deepening removes the JSON files entirely; the locale set lives once, in TypeScript.
 
+### DrawerStack
+
+The single deep module (`imports/ui/drawer-stack/`) that owns the side-panel UI for nested entity editing. Replaces the two parallel `DrawerContext` / `SubdrawerContext` providers and the hand-rolled depth heuristic (`useSubdrawer` boolean prop, `const usedDrawer = !drawer.drawerOpen ? drawer : subdrawer`) that previously sprawled across `Section`, `CollectionSelect`, and every nested form (`RanksForm`, `SquadsForm`, `SpecializationForm`, …).
+
+Internally the module holds an ordered array of **frames**. Each `InternalFrame` carries `{ id, title, Component, model, extra, confirmCloseRef, resolveFn, settled }`; the slice handed to a form through `FrameContext` is `{ model, resolve, cancel, confirmCloseRef }`. The renderer reflects the array as a recursively nested chain of antd `<Drawer>` elements — depth is unbounded, no caller is depth-aware.
+
+The seam is three hooks:
+
+- **`useDrawerStack()`** — used by openers (`Section`, `CollectionSelect`, `Palette`). Exposes `push<R, M>(options): Promise<R | undefined>`, where `options` is `{ title, Component, model, extra? }`. Every push returns a promise that resolves with the value the form passes to its frame's `resolve`, or `undefined` if the user cancels. This is the new leverage: a `CollectionSelect` inside a `SquadsForm` can `await editor.push(...)` to create a new `Rank` inline and receive the inserted doc back, auto-selecting it — eliminating the "create, close, re-find" dance.
+- **`useDrawerFrame<R, M>()`** — used by forms. Returns `{ model, resolve, cancel }`, resolving the topologically-nearest frame, so a form has no idea (and no need to know) what depth it's rendered at. Replaces both `useContext(useSubdrawer ? SubdrawerContext : DrawerContext)` and the `setOpen` / `useSubdrawer` props on every form.
+- **`useConfirmClose(predicate)`** — used by forms with unsaved-state guards. Writes the predicate into the nearest frame's `confirmCloseRef.current` on every render; the predicate returns `boolean | Promise<boolean>`.
+
+Close semantics: when the user dismisses the top frame (antd `onClose` from X-click or mask-click), the stack invokes the predicate stored in that frame's `confirmCloseRef` first; it may return `false` (or a `Promise<boolean>`) to abort the close. User-initiated close is the only path that runs the predicate — code-initiated `resolve(value)` / `cancel()` from inside a form is authoritative and skips the prompt. Programmatic close of a non-top frame cascades down: any frames stacked above also resolve with `undefined`, matching the modal-dialog convention.
+
+The depth pattern that previously required a `useSubdrawer: boolean` prop drilled through every nested form, plus an `if (drawer.drawerOpen) use subdrawer else use drawer` branch at each open site, is now structurally impossible — there is no second context to choose between, and frames don't expose their depth on the seam.
+
 ## Doctrines
 
 ### Rule of three

--- a/TESTING.md
+++ b/TESTING.md
@@ -399,33 +399,51 @@ describe('checkPermission', () => {
 });
 ```
 
-### React Hooks (Client Tests)
+### React Hooks & Components (Client Tests)
 
-Test custom hooks with `@testing-library/react-hooks` (future):
+> ⚠️ **Client tests do not run in `npm test` or CI.** `meteor test --once` only
+> executes **server** tests; it ends with `RUNNING SERVER TESTS` and prints
+> `Load the app in a browser to run client tests, or set the
+> TEST_BROWSER_DRIVER environment variable.` We do not set that variable and no
+> headless browser is installed, so any test guarded by `if (Meteor.isClient)`
+> **never executes in CI** — it can only run in watch mode (`npm run test-app`)
+> with a browser open at `localhost:3000`.
+>
+> **Consequence:** never rely on a client-only test as a CI regression guard.
+> For logic that needs a DOM, mirror it with a **pure-logic server test** that
+> runs everywhere (see `drawerStackStore.test.ts`, which covers the same
+> behaviour as the DOM-rendering `drawerStackHooks.test.tsx` without a browser).
+> For real-browser behaviour that must be guarded in CI, use a Playwright e2e
+> test (`npm run e2e`) instead.
 
-```javascript
-// tests/client/hooks/useTranslation.test.js
-import { renderHook } from '@testing-library/react-hooks';
-import { useTranslation } from '/imports/i18n/LanguageContext.jsx';
+Client tests render real components into a DOM using `react-dom/client` + `act()`,
+gated on `Meteor.isClient` so the server run skips them. Use `require()` (not
+`import`) for the modules under test to avoid load-order issues:
 
-describe('useTranslation', () => {
-  it('returns translation function', () => {
-    const { result } = renderHook(() => useTranslation(), {
-      wrapper: LanguageProvider
-    });
+```tsx
+// tests/client/hooks/example.test.tsx
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
 
-    assert.strictEqual(typeof result.current.t, 'function');
+if (Meteor.isClient) {
+  const ReactDOMClient = require('react-dom/client') as typeof import('react-dom/client');
+  const { act } = require('react-dom/test-utils') as { act: (cb: () => void | Promise<void>) => Promise<void> };
+
+  it('renders into a real DOM node', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+    await act(async () => root.render(<SomeComponent />));
+    assert.ok(container.querySelector('.expected-selector'));
+    await act(async () => root.unmount());
+    container.remove();
   });
-
-  it('translates known keys', () => {
-    const { result } = renderHook(() => useTranslation(), {
-      wrapper: LanguageProvider
-    });
-
-    assert.strictEqual(result.current.t('common.save'), 'Save');
-  });
-});
+}
 ```
+
+See `tests/client/hooks/drawerStackHooks.test.tsx` for the full `renderHook`
+helper and provider-wrapping patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #205. Makes the invisible test-coverage gap explicit: `npm test` (`meteor test --once`) — the same command CI runs — executes **only server tests**. Without `TEST_BROWSER_DRIVER` and a headless browser, any `Meteor.isClient`-gated test silently never runs, so it cannot serve as a CI regression guard.

This is the recommended **Option 1** from the issue (document the constraint) rather than wiring up a redundant headless browser driver — Playwright (`npm run e2e`) already provides real-browser coverage in CI.

## Changes

- **TESTING.md**
  - Add a prominent ⚠️ callout in the client-tests section: client tests don't run in `npm test`/CI, name the exact terminal output and the missing `TEST_BROWSER_DRIVER`, and state they only run in watch mode (`npm run test-app`).
  - Prescribe the **pure-logic server-test mirror** pattern (`drawerStackStore.test.ts` mirrors the DOM-rendering `drawerStackHooks.test.tsx`) for DOM-dependent logic, and Playwright e2e for real-browser CI guards.
  - Replace the stale fictional `@testing-library/react-hooks` example with the real `react-dom/client` + `act()` pattern matching the actual test files.
- **CONTEXT.md** — document the DrawerStack deep module (the `#199`–`#203` refactor).

## Acceptance criteria

- [x] TESTING.md states `Meteor.isClient`-gated tests are not executed by `npm test`/CI.
- [x] It prescribes the pure-logic-mirror pattern for DOM-dependent logic.

## Verification

- `package.json` test script and `.github/workflows/ci.yml` both confirmed to run the server-only `meteor test --once` command; e2e runs as a separate Playwright job.
- Referenced test files (`drawerStackHooks.test.tsx`, `drawerStackStore.test.ts`) exist and match the documented pattern.

## Testing steps

Docs-only change — no runtime behaviour affected. Review the rendered TESTING.md / CONTEXT.md diffs.