### PR TITLE
fix(tasks): show all tasks when status/participant filter is empty

### DIFF
--- a/imports/ui/tasks/KanbanBoard.tsx
+++ b/imports/ui/tasks/KanbanBoard.tsx
@@ -2,9 +2,10 @@ import { CommentOutlined } from '@ant-design/icons';
 import { Badge, Button, Card, Col, Empty, Grid, Row, Typography } from 'antd';
 import dayjs from 'dayjs';
 import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useFind, useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React, { useMemo } from 'react';
 import { DragDropContext, Draggable, Droppable, type DropResult } from 'react-beautiful-dnd';
+import TaskStatusCollection from '../../api/collections/taskStatus.collection';
 import type { Task } from '../../api/types/task';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { RowClickEvent } from '../section/types';
@@ -27,7 +28,14 @@ export default function KanbanBoard({ datasource, handleEdit, handleDelete }: Ka
     Meteor.callAsync('tasks.update', draggableId, { status: destination.droppableId });
   };
 
-  const options = useTracker(() => (Meteor.user()?.profile?.taskFilter?.status as string[] | undefined) || [], []);
+  const selectedStatuses = useTracker(() => (Meteor.user()?.profile?.taskFilter?.status as string[] | undefined) || [], []);
+  useSubscribe('taskStatus', {});
+  const allStatuses = useFind(() => TaskStatusCollection.find({}), []);
+  // No status filter selected → show every task-status as a column instead of nothing.
+  const options = useMemo(
+    () => (selectedStatuses.length ? selectedStatuses : allStatuses.map(status => status._id as string)),
+    [selectedStatuses, allStatuses]
+  );
 
   const columns = useMemo(() => {
     const result: Record<string, Task[]> = datasource?.reduce<Record<string, Task[]>>((acc, task) => {

--- a/imports/ui/tasks/Tasks.tsx
+++ b/imports/ui/tasks/Tasks.tsx
@@ -35,9 +35,8 @@ export default function Tasks() {
 
   const filterFactory = useCallback(
     (string: string): Mongo.Selector<Task> => {
-      const newFilter: Mongo.Selector<Task> = {
-        status: { $in: filter?.status || [] },
-      };
+      const newFilter: Mongo.Selector<Task> = {};
+      if (filter?.status?.length) (newFilter as Record<string, unknown>).status = { $in: filter.status };
       if (string) (newFilter as Record<string, unknown>).name = { $regex: string, $options: 'i' };
       if (filter?.participants?.length) (newFilter as Record<string, unknown>).participants = { $in: filter.participants };
       return newFilter;


### PR DESCRIPTION
Closes #208

## Summary

When no statuses and no participants were selected in the task filter, the Tasks page showed **zero tasks** instead of all of them.

The table selector built the status clause unconditionally:

```ts
status: { $in: filter?.status || [] }
```

In MongoDB `{ $in: [] }` matches **nothing**, so an empty status filter excluded every document. Participants was already conditional — status now matches that pattern.

## Changes

- **`Tasks.tsx`** — build the selector additively; the `status` clause is only attached when at least one status is selected (mirroring participants). An empty filter now applies no constraint → all tasks shown.
- **`KanbanBoard.tsx`** — subscribe to `taskStatus` and fall back to **all** task-status columns when no status filter is set, instead of rendering an empty board.

## Testing

- `npm run typecheck` — clean
- `npm test` — 324 passing
- Manual verification with Playwright (table + Kanban, empty filter shows all)