### PR TITLE
fix(registration): allow anonymous reads of discovery types

### DIFF
--- a/e2e/tests/public-registration.spec.ts
+++ b/e2e/tests/public-registration.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../fixtures/auth.fixture';
+
+/**
+ * Regression guard for issue #207. The public registration form is reachable
+ * by unauthenticated visitors (the "Register" button on the login screen). Its
+ * "Discovery type" dropdown is backed by the `discoveryTypes` publication, which
+ * used to gate *all* reads on `this.userId` — leaving the dropdown empty for
+ * guests. `discoveryTypes` is now flagged `allowsAnonymous.read`, so guests can
+ * see the options.
+ */
+test.describe('Public registration form', () => {
+  const discoveryName = `E2E Discovery ${Date.now()}`;
+  let discoveryId: string;
+
+  // Seed a discovery type as admin; the test itself runs logged-out.
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await login(page);
+    discoveryId = await page.evaluate(
+      async (name: string) => (await window.Meteor.callAsync('discoveryTypes.insert', { name })) as string,
+      discoveryName
+    );
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (!discoveryId) return;
+    const page = await browser.newPage();
+    await login(page);
+    await page.evaluate(async (id: string) => {
+      await window.Meteor.callAsync('discoveryTypes.remove', id);
+    }, discoveryId);
+    await page.close();
+  });
+
+  test('anonymous visitor sees discovery type options', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('.login', { timeout: 15000 });
+
+    // Open the registration drawer without authenticating.
+    await page.click('button:has-text("Register")');
+    await expect(page.locator('.ant-drawer')).toBeVisible();
+    await expect(page.locator('.ant-drawer input[id="name"]')).toBeVisible();
+
+    // Discovery type is the only Select in the registration form. Open it and
+    // confirm the publication actually delivered options to the guest's client.
+    const discoverySelect = page.locator('.ant-drawer .ant-select').first();
+    await discoverySelect.click();
+
+    // The dropdown renders in a body-level portal, so options are matched globally.
+    await expect(page.locator('.ant-select-item-option').first()).toBeVisible();
+    await expect(page.locator(`.ant-select-item-option:has-text("${discoveryName}")`)).toBeVisible();
+  });
+});

--- a/server/collection-registry.ts
+++ b/server/collection-registry.ts
@@ -14,7 +14,10 @@ export interface ForeignKeyEdge {
 export interface CollectionRegistryEntry {
   readonly module: string;
   readonly fallback?: { readonly create?: string; readonly update?: string };
-  readonly allowsAnonymous?: { readonly insert?: boolean };
+  // `insert` opens the generic `.insert` method to unauthenticated callers
+  // (see mutation-pipeline.ts); `read` opens the generic publication to them
+  // (see crud.lib.ts). Both are opt-in per collection and default to gated.
+  readonly allowsAnonymous?: { readonly insert?: boolean; readonly read?: boolean };
   readonly redact?: { readonly insert?: readonly string[]; readonly update?: readonly string[] };
   // Outgoing foreign-key edges (this collection's references to other collections).
   // Inverted to incoming-edges at boot inside server/integrity.ts.
@@ -31,7 +34,9 @@ export interface CollectionRegistryEntry {
 // the same omission under loosened type checks.
 export const COLLECTION_REGISTRY: Record<CrudCollectionName, CollectionRegistryEntry> = {
   attendances: { module: 'events' },
-  discoveryTypes: { module: 'discoveryTypes' },
+  // Discovery types are surfaced on the public (pre-auth) registration form,
+  // so guests must be able to read them. The docs carry nothing sensitive.
+  discoveryTypes: { module: 'discoveryTypes', allowsAnonymous: { read: true } },
   events: {
     module: 'events',
     fallback: { create: 'canCreateEvents' },

--- a/server/crud.lib.ts
+++ b/server/crud.lib.ts
@@ -83,8 +83,9 @@ const MAX_PUBLISH_LIMIT = 1000;
 function createCollectionPublish(collection: CrudCollectionName): void {
   if (Meteor.isServer) {
     const Collection = getCollection(collection);
+    const allowsAnonymousRead = COLLECTION_REGISTRY[collection].allowsAnonymous?.read === true;
     Meteor.publish(collection, function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
-      if (!this.userId) return this.ready();
+      if (!this.userId && !allowsAnonymousRead) return this.ready();
       validateObject(filter, false);
       validateObject(options, false);
 

--- a/tests/server/permissions.test.ts
+++ b/tests/server/permissions.test.ts
@@ -178,9 +178,19 @@ describe('COLLECTION_REGISTRY', () => {
     assert.strictEqual(COLLECTION_REGISTRY.medals.fallback, undefined);
   });
 
-  it('declares allowsAnonymous only for registrations.insert', () => {
+  it('declares anonymous insert only for registrations', () => {
     assert.strictEqual(COLLECTION_REGISTRY.registrations.allowsAnonymous?.insert, true);
     assert.strictEqual(COLLECTION_REGISTRY.medals.allowsAnonymous, undefined);
+  });
+
+  it('declares anonymous read only for discoveryTypes (public registration form)', () => {
+    // The pre-auth registration form reads discoveryTypes; nothing else should
+    // be publicly readable via the generic publication.
+    assert.strictEqual(COLLECTION_REGISTRY.discoveryTypes.allowsAnonymous?.read, true);
+    for (const [name, entry] of Object.entries(COLLECTION_REGISTRY)) {
+      if (name === 'discoveryTypes') continue;
+      assert.notStrictEqual(entry.allowsAnonymous?.read, true, `${name} must not allow anonymous read`);
+    }
   });
 
   it('does not declare any CRUD-style module that overlaps with BOOLEAN_MODULES', () => {


### PR DESCRIPTION
## Summary

Fixes #207. On the **public registration form** (opened from the login screen's *Register* button, before authenticating), the **Discovery type** dropdown showed no options.

## Root cause

The generic CRUD publication in `server/crud.lib.ts` short-circuited every read for unauthenticated connections:

```ts
Meteor.publish(collection, function (filter, options) {
  if (!this.userId) return this.ready(); // guests get an empty cursor
  ...
});
```

Registration *inserts* already work anonymously via `COLLECTION_REGISTRY.registrations.allowsAnonymous.insert`, but there was no equivalent on the read/publish side, so `useSubscribe('discoveryTypes')` in `RegistrationForm` delivered nothing to a guest's minimongo.

## Change

- Extend the registry's `allowsAnonymous` with an opt-in `read` flag.
- Set `allowsAnonymous: { read: true }` on `discoveryTypes` only.
- `createCollectionPublish` skips the `this.userId` gate solely for collections that declare the flag — every other publication stays authenticated.

`discoveryTypes` docs (`name`, `color`, `description`, `hasTextInput`) are meant to be shown on the public form and carry nothing sensitive.

## Testing

- `npm test` — 324 server tests pass, including a new registry conformance test asserting **only** `discoveryTypes` is anonymously readable.
- `npm run typecheck` — clean (root + `e2e/tsconfig.json`).
- New Playwright spec `e2e/tests/public-registration.spec.ts`: seeds a discovery type as admin, then **logs out** and confirms the registration drawer's dropdown is populated for a guest. Passed against the dev server.

## Risk

Low. Read access is opt-in per collection; no other collection's publication changes behavior.