### PR TITLE
chore: refresh docs and standardize on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install npm dependencies
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       # Meteor install is ~200 MB and takes 1-2 min. Cache the entire user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repository.
 
 ## Development Commands
 
@@ -25,11 +25,13 @@ client/main.tsx         # Client entry point
 server/main.ts          # Server setup, permissions, validation, test data
 server/apis/            # API implementations (members, events, backup, logs, etc.) — *.server.ts
 server/crud.lib.ts      # Generic CRUD method/publish generator
+server/collection-registry.ts  # Per-collection permission/FK/audit metadata (COLLECTION_REGISTRY)
+server/mutation-pipeline.ts    # Shared server-mutation lifecycle (runMutation: auth→perm→validate→body→audit)
 server/config.ts        # Server settings with Meteor.settings overrides
 imports/api/collections/  # MongoDB collection definitions (*.collection.ts)
 imports/api/types/      # Shared TS interfaces mirroring server return shapes
 imports/ui/             # React components organized by feature (.tsx)
-imports/i18n/           # Localization — LanguageContext.tsx, locales/
+imports/i18n/           # Localization — LanguageContext.tsx, translations.ts
 imports/helpers/        # Utility functions (.ts)
 imports/config.ts       # UI constants (breakpoints, layout ratios)
 imports/types/          # Ambient module declarations (.d.ts)
@@ -43,82 +45,45 @@ The codebase is **fully TypeScript** with `strict: true`. No `.jsx` or untyped `
 **Permission System**
 - Two-tier RBAC: boolean modules (dashboard, orbat, logs, settings) and CRUD modules (members, events, tasks, etc.)
 - Permission check: `checkPermission(userId, module, operation)` in `server/main.ts`
+- Per-collection permission/FK/audit metadata lives in `COLLECTION_REGISTRY` (`server/collection-registry.ts`), a `Record<CrudCollectionName, CollectionRegistryEntry>`: `module`, optional `fallback` (e.g. `canCreateEvents`), `allowsAnonymous`, `redact`, `foreignKeys`, `displayField`
 - Role caching with 1-minute TTL for performance
 - Admin users have `roles: true` for full access
 
+**Server-Mutation Lifecycle** (`server/mutation-pipeline.ts`)
+- `runMutation(ctx, descriptor, args, body)` owns the standard mutation lifecycle: auth → permission → validate → body → audit. Both the CRUD factory and custom methods route through it, so there is exactly one implementation
+- Pre-body failures emit a `<collection>.<op>.denied` audit entry before throwing; body errors propagate untouched (a `Meteor.Error('Code', …)` reaches the caller intact)
+
 **CRUD Generation** (`server/crud.lib.ts`)
-- `createCollectionMethods(collectionName)` - generates standard methods: `.read`, `.insert`, `.update`, `.delete`, `.count`, `.options`
-- `createCollectionPublish(collectionName)` - generates reactive publications (requires authentication)
+- `createCollectionMethods(collectionName)` - generates standard methods: `.read`, `.insert`, `.update`, `.delete`, `.count`, `.options` (each wrapped by `runMutation`)
+- `createCollectionPublish(collectionName)` - generates reactive publications (authenticated unless the registry sets `allowsAnonymous.read`)
 - All operations include permission checks and audit logging
 
-**Configuration** (`server/config.ts`, `imports/config.ts`)
-- Server settings (rate limits, cache TTL) configurable via `Meteor.settings` or `settings.json`
-- UI constants (breakpoints, layout ratios) in `imports/config.ts`
-- See `settings.example.json` for available overrides
+**Configuration**
+- Server settings (rate limits, cache TTL) in `server/config.ts`, overridable via `Meteor.settings`/`settings.json` (see `settings.example.json`); UI constants (breakpoints, layout ratios) in `imports/config.ts`
 
 **State Management**
-- React Context: NavigationContext, ThemeContext, DrawerContext, SubdrawerContext, LanguageContext, PaletteContext, TourContext
+- React Context: NavigationContext, ThemeContext, LanguageContext, PaletteContext, TourContext
+- Nested entity editing uses the **DrawerStack** module (`imports/ui/drawer-stack/`), which replaced the old `DrawerContext`/`SubdrawerContext` pair — see the Drawer Pattern section
 - Meteor hooks: `useTracker()`, `useFind()`, `useSubscribe()` for reactive data
 - Pathname-based routing without router library (reads `window.location.pathname`)
 
-**Localization (i18n)**
-- Custom lightweight i18n system in `imports/i18n/`
-- Supported languages: English (en), German (de), French (fr)
-- All translations in `imports/i18n/translations.ts` as a single typed `TranslationSet` (one entry per line, alphabetically sorted by dotted key; excluded from prettier so the dense per-line layout stays diff-friendly)
-- Use `useTranslation()` hook to get `t()` function
-- Use `useLanguage()` hook for full context (language, setLanguage, t, locales)
-- Language persisted in localStorage, auto-detects browser language
-- LanguageSelector component in header for switching languages
+**Localization (i18n)** (`imports/i18n/`)
+- Languages en/de/fr. All translations in `translations.ts` as one typed `TranslationSet` (one entry per line, sorted by dotted key, prettier-excluded). See `CONTEXT.md` → LocaleSet
+- `useTranslation()` for `t()`; `useLanguage()` for full context. Language persisted to localStorage + browser-autodetected; `LanguageSelector` in header
 
 **Validation** (server/main.ts)
 - `validateString()`, `validateNumber()`, `validateBoolean()`, `validateDate()`
 - `validateArray()`, `validateArrayOfStrings()`, `validateObject()`, `validateUserId()`
 
+**Rich Text**
+- Only two surfaces are rich text: the briefing-template `content` and the event `description`. Every other `description` field stays plain text
+- Stored as sanitized HTML and sanitized twice — server write path (`sanitize-html`) and client render just before DOM injection (DOMPurify) — against one shared allow-list in `imports/api/htmlSanitizer/sanitizePolicy.ts`. See `CONTEXT.md` → BriefingTemplate.
+
 ### Collections
 
-Members (Meteor.users), Events, Attendances, Tasks, TaskStatus, Squads, Ranks, Specializations, Medals, EventTypes, Positions, Registrations, DiscoveryTypes, Roles, ProfilePictures, Settings, Logs, Questionnaires, QuestionnaireResponses
+Members (Meteor.users), Events, Attendances, Tasks, TaskStatus, Squads, Ranks, Specializations, Medals, EventTypes, Positions, Registrations, DiscoveryTypes, Roles, ProfilePictures, Settings, Logs, Questionnaires, QuestionnaireResponses, BriefingTemplates
 
-### Collection Schemas
-
-**Members** (Meteor.users)
-- `username`, `password`, `profile: { name, id (1000-9999), roleId, squadId, rankId, navyRankId, specializationIds[], medalIds[], profilePictureId, discordTag, steamProfileLink, description, entryDate, exitDate, staticAttendancePoints, staticInactivityPoints, hasCustomArmour }`
-
-**Events**
-- `name, start, end, eventType, hosts[], attendees[], isPrivate, color, preset, description`
-
-**Tasks**
-- `name, status (taskStatusId), participants[], priority ('low'|'medium'|'high'), link, description, parent (taskId)`
-
-**Squads**
-- `name, color, image (base64), parentSquadId, shortRangeFrequency, longRangeFrequency, description`
-
-**Ranks**
-- `name, type ('player'|'zeus'), color, previousRankId, nextRankId, description`
-
-**Specializations**
-- `name, color, linkToFile, instructors[], requiredSpecializations[], requiredRankId, description`
-
-**Medals, EventTypes, TaskStatus, DiscoveryTypes**
-- `name, color, description`
-
-**Roles**
-- `name, color, description` + boolean permissions (`dashboard, orbat, logs, settings`) + CRUD permissions (`members, events, tasks, squads, ranks, specializations, medals, eventTypes, positions, taskStatus, registrations, discoveryTypes, roles, questionnaires`)
-
-**Registrations**
-- `name, id (1000-9999), age (min 16), discoveryType, rulesReadAndAccepted, description`
-
-**Questionnaires**
-- `name, description, status ('draft'|'active'|'closed'), allowAnonymous, interval ('once'|'daily'|'weekly'|'monthly'|'unlimited'), questions[], createdAt, updatedAt`
-- `questions[]: { text, type ('text'|'textarea'|'number'|'select'|'multiselect'|'rating'), required, options[] }`
-
-**QuestionnaireResponses**
-- `questionnaireId, respondentId (null if anonymous), answers[], ignored, submittedAt, createdAt`
-- `answers[]: { questionIndex, questionText, questionType, value }`
-
-**Attendances** - `{ [eventId]: { [memberId]: points } }`
-**ProfilePictures** - `{ value (base64) }`
-**Settings** - Key-value store
-**Logs** - `{ action, data, createdAt }`
+Field-level schemas for every collection: [`docs/collections.md`](docs/collections.md).
 
 ### UI Components
 
@@ -140,45 +105,24 @@ Members (Meteor.users), Events, Attendances, Tasks, TaskStatus, Squads, Ranks, S
 - `orbat/` - Organization chart
 - `palette/` - Cmd+K command palette (fuzzy ranking, recents, global UI controls)
 - `tour/` - First-run guided tour
+- `drawer-stack/` - Nested-drawer editing module (see Drawer Pattern)
+- `briefing-templates/` - Rich-text briefing templates loaded into event descriptions
 - `dashboard/`, `questionnaires/`, `registration/`, `members/`, `squads/`, `specializations/`, `logs/`, `settings/`, `backup/`
 - Chrome: `app/`, `header/`, `footer/`, `navigation/`, `login/`, `theme/`, `title/`, `logo/`, `profile-picture-input/`, `suspense/`, `section/`, `table/`, `components/`
 
 ## Deployment
 
-**Docker with Traefik** (production)
-```bash
-# Required environment variables
-ROOT_URL=https://yourdomain.com
-DOMAIN=yourdomain.com
-MONGO_URL=mongodb://mongo:27017/community-manager  # default
-
-# Optional Traefik settings
-TRAEFIK_ENTRYPOINT=websecure                       # default
-TRAEFIK_CERTRESOLVER=letsencrypt                   # default
-
-# Build and run
-docker compose up -d
-```
-
-- Multi-stage Dockerfile: builds Meteor app, runs on Node 20
-- Requires external `traefik` network (assumes Traefik reverse proxy)
-- MongoDB 7 with health checks and persistent volume
+Docker + Traefik (production), Node 22, MongoDB 7. Full env vars and compose notes: [`docs/deployment.md`](docs/deployment.md).
 
 ## Key Dependencies
 
-- **react-beautiful-dnd** - Drag-and-drop for Kanban task board
-- **react-big-calendar** + **rrule** - Calendar views with recurring event support
-- **react-organizational-chart** - Orbat tree visualization
-- **fuse.js** - Fuzzy ranking for the command palette (union of static + entity items)
-- **jszip** - Backup file generation
+`react-beautiful-dnd` (Kanban DnD), `react-big-calendar` + `rrule` (recurring-event calendar), `react-organizational-chart` (ORBAT tree), `fuse.js` (command-palette fuzzy ranking), `jszip` (backup files).
 
 ## Coding Guidelines
 
 **Priority Order:** Security → Performance → Usability → Developer Experience
 
-When making tradeoffs, follow this hierarchy. Never compromise security for convenience, and prefer performant solutions over easier-to-write ones.
-
-**Follow modern design patterns and best practices.** Write clean, maintainable code using established patterns (DRY, KISS, YAGNI, SOLID, separation of concerns). Prefer composition over inheritance, keep functions focused and testable, and avoid premature optimization while still writing efficient code.
+Follow this hierarchy when making tradeoffs — never compromise security for convenience. Otherwise write clean, maintainable code (DRY, KISS, YAGNI, SOLID, composition over inheritance, focused/testable functions) without premature optimization.
 
 ### Server-Side
 
@@ -192,14 +136,15 @@ When making tradeoffs, follow this hierarchy. Never compromise security for conv
 
 **Server File Conventions**
 - One API per file: each `server/apis/<feature>.server.ts` contains only methods/publications matching its name (e.g. `squads.*` lives in `squads.server.ts`, not scattered across files)
-- Alphabetical ordering: arrays/maps/switch cases in `server/main.ts` and `server/crud.lib.ts` (e.g. `collectionNames`, `COLLECTION_TO_MODULE`, the `getCollection()` switch) are kept in alphabetical order — preserve this when adding entries
+- Alphabetical ordering: arrays/maps/switch cases (e.g. `collectionNames`, `COLLECTION_REGISTRY` in `server/collection-registry.ts`, the `getCollection()` switch in `server/crud.lib.ts`) are kept in alphabetical order — preserve this when adding entries
 - New `server/apis/*.server.ts` files must be imported in `server/main.ts` for their methods/publications to register
 
 **Adding New Collections**
 1. Create collection file in `imports/api/collections/` (e.g. `foo.collection.ts`)
-2. Add to `getCollection()` switch in `server/crud.lib.ts`
-3. Call `createCollectionMethods()` and `createCollectionPublish()` in `server/crud.lib.ts`
-4. Add permission module mapping in `COLLECTION_TO_MODULE` in `server/main.ts`
+2. Add the name to the `CrudCollectionName` union in `imports/api/types/` (this forces a `COLLECTION_REGISTRY` entry — omitting it is a compile error)
+3. Add to `getCollection()` switch in `server/crud.lib.ts`
+4. Call `createCollectionMethods()` and `createCollectionPublish()` in `server/crud.lib.ts`
+5. Add the registry entry (at least `{ module }`) in `COLLECTION_REGISTRY` (`server/collection-registry.ts`)
 
 ### Client-Side
 
@@ -209,7 +154,7 @@ When making tradeoffs, follow this hierarchy. Never compromise security for conv
 - Destructure props with defaults in the signature: `function Component({ title = '', items = [] }: ComponentProps)`
 - Use `useCallback` for event handlers, `useMemo` for computed values
 - Narrow `useCallback`/`useMemo` deps to specific fields (e.g. `[questionnaire?._id, questionnaire?.createdAt]`), not whole objects
-- Drawer model double-cast: `drawer.drawerModel as unknown as ConcreteType` for read; `setDrawerModel(x as unknown as Record<string, unknown>)` for write
+- Drawer forms read their model from the frame: `const { model } = useDrawerFrame<R, M>()` (see Drawer Pattern); openers pass it via `push({ model, ... })`
 - Section generic: `<Section<EntityType> Collection={EntityCollection} columnsFactory={getEntityColumns} ... />`
 - Section column factory: `const getEntityColumns: ColumnsFactory<Entity> = (handleEdit, handleDelete, permissions, t) => [...]`
 - For nullable string fields at antd DOM boundaries (Tag, Picker), convert with `?? undefined` *only* at the DOM site — never on a server-write path
@@ -244,9 +189,11 @@ try {
 - Get notification/message from `App.useApp()` hook (never the static antd singleton — won't render inside drawer context)
 - For nullable wire-format fields, mirror server's `string | null` exactly; only convert at the antd DOM boundary with `?? undefined`
 
-**Drawer Pattern**
-- Access via `useContext(DrawerContext)` or `useContext(SubdrawerContext)`
-- Set model, title, component, then open: `drawer.setDrawerOpen(true)`
+**Drawer Pattern** (`imports/ui/drawer-stack/` — replaced `DrawerContext`/`SubdrawerContext`; there is no depth-aware code anymore)
+- **Openers** (`Section`, `CollectionSelect`, `Palette`) use `const { push } = useDrawerStack()`, then `const result = await push<R, M>({ title, Component, model, extra? })`. The promise resolves with whatever the form passes to `resolve`, or `undefined` if cancelled — so `CollectionSelect` can open a create-form inline and auto-select the returned doc
+- **Forms** use `const { model, resolve, cancel } = useDrawerFrame<R, M>()` — they resolve the nearest frame and never know their depth (no `useSubdrawer` prop, no `setOpen`)
+- **Unsaved-state guards** use `useConfirmClose(predicate)` — the predicate (returning `boolean | Promise<boolean>`) runs only on user-initiated close (X/mask); `resolve`/`cancel` from inside the form skip it
+- See `CONTEXT.md` → DrawerStack for the full contract
 
 ### Testing
 
@@ -262,95 +209,42 @@ try {
 
 ## Development Workflow
 
-1. **GitHub Issue** - Start from a GitHub issue describing the feature/bug
-2. **Create Implementation Plan** - Analyze requirements and design approach
-3. **Ask Questions** - Clarify ambiguities with stakeholders
-4. **Refine Plan** - Update plan based on feedback
-5. **Document Plan in Issue** - Add implementation details to the GitHub issue
-6. **Create Branch** - Create feature branch from issue (e.g., `feature/issue-123-description`)
-7. **Implement Changes** - Write code following coding guidelines
-8. **Run Tests** - Execute `npm test` and verify all pass
-9. **Fix Issues** - Address any failing tests or bugs
-10. **Run Code Review** - Self-review or request peer review
-11. **Fix Review Issues** - Address feedback from review
-12. **Validate Against CLAUDE.md** - Ensure code follows documented patterns; update CLAUDE.md if new patterns emerge
-13. **Create Pull Request** - Include summary of changes and steps for testing/reproduction
+Issue → plan → branch → implement → test → review → PR. Full step list: [`docs/agents/workflow.md`](docs/agents/workflow.md).
 
 ## Claude Code Skills
 
-Custom skills in `.claude/skills/` automate common development tasks:
-
-**Workflow Skills**
-| Skill | Purpose |
-|-------|---------|
-| `/issue` | Fetch and analyze a GitHub issue to start work |
-| `/plan` | Create or refine an implementation plan |
-| `/branch` | Create a properly named branch from the current issue |
-| `/commit` | Create a commit with clean, descriptive message |
-| `/pr` | Create a pull request with summary and testing steps |
-| `/review` | Run code review against coding guidelines |
-| `/validate` | Validate code against CLAUDE.md patterns |
-| `/test` | Run tests, analyze failures, suggest fixes |
-
-**Scaffolding Skills**
-| Skill | Purpose |
-|-------|---------|
-| `/collection` | Scaffold a new MongoDB collection with all registrations |
-| `/component` | Scaffold a React component following project patterns |
-| `/form` | Scaffold an Ant Design form with drawer integration |
-| `/section` | Scaffold a full Section page (collection, form, columns, page) |
-
-**Debugging Skills**
-| Skill | Purpose |
-|-------|---------|
-| `/logs` | Check recent audit logs for debugging |
-| `/permissions` | Show permission structure for a module |
+Custom skills in `.claude/skills/` automate common tasks (available skills are also surfaced each session):
+- **Workflow:** `/issue`, `/plan`, `/branch`, `/commit`, `/pr`, `/review`, `/validate`, `/test`
+- **Scaffolding:** `/collection`, `/component`, `/form`, `/section`
+- **Debugging:** `/logs`, `/permissions`
 
 ## Common Gotchas
 
+Non-obvious traps only; the coding rules above aren't repeated here.
+
 **Server-Side**
-- Forgetting to add collection to `getCollection()` switch in `server/crud.lib.ts`
-- Using sync methods (`find`, `insert`) instead of async (`findAsync`, `insertAsync`)
-- Using generic `Error` instead of `Meteor.Error(code, message)`
-- Missing permission module mapping in `COLLECTION_TO_MODULE`
-- Forgetting `createLog()` for audit trail on custom methods
-- Not checking `this.userId` before operations
+- Forgetting to add a collection to the `getCollection()` switch (`crud.lib.ts`) or its `COLLECTION_REGISTRY` entry — the latter is a compile error via `Record<CrudCollectionName, _>`
+- Using sync collection methods (`find`, `insert`) instead of async (`findAsync`, `insertAsync`)
 
 **Client-Side**
-- Missing dependency array in `useFind()`, `useCallback()`, `useMemo()`
-- Widened `useCallback`/`useMemo` deps to whole objects instead of narrow fields (causes spurious re-runs)
-- Forgetting `useSubscribe()` before `useFind()` (data won't load)
-- Not using `App.useApp()` for notifications (won't render in drawer context)
-- Forgetting to narrow `Meteor.callAsync` return type (defaults to `unknown` under strict)
+- Forgetting `useSubscribe()` before `useFind()` (data won't load), or a missing dependency array in `useFind`/`useCallback`/`useMemo`
 - Using `?.` on `member.profile.X` access — masks crashes; use `!` non-null assertion to preserve original behavior
-- Switching `<Tag color={X || 'transparent'}>` to `?? undefined` — removes the visual fallback for nullable colors
 - Using `useEffect` for derived state instead of `useMemo`
 
 **Forms**
-- Forgetting `initialValues={model}` (edit mode won't populate)
 - Missing `valuePropName="checked"` for Switch/Checkbox Form.Items
 - Not handling both create (no `_id`) and update (has `_id`) in `handleFinish`
 
 **Permissions**
-- Adding new CRUD module but forgetting to add to `CRUD_MODULES` array
-- Not passing `permissionModule` prop to Section when collection name differs
+- Not passing `permissionModule` prop to Section when collection name differs from the permission module
 
 ## Code Style
 
 - Prettier: 2-space indent, single quotes, trailing commas (es5), 150 char width, `arrowParens: "avoid"`
 - TypeScript: `strict: true` (no implicit any, strict null checks, unknown catch variables, etc.)
-- TypeScript interfaces above each component for props validation
 
 ## Agent skills
 
-### Issue tracker
-
-Issues live in GitHub Issues at `sentinel-web/community-manager`, accessed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Five canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context repo: `CONTEXT.md` and `docs/adr/` at the repo root (will be created lazily by `/grill-with-docs`). See `docs/agents/domain.md`.
+- **Issue tracker** — GitHub Issues at `sentinel-web/community-manager` via the `gh` CLI. See `docs/agents/issue-tracker.md`
+- **Triage labels** — five canonical: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`
+- **Domain docs** — single-context repo: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/grill-with-docs`). See `docs/agents/domain.md`

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN meteor build --server-only --directory /built-app
 
 # ---------- Production stage ----------
-FROM node:20-slim AS production
+FROM node:22-slim AS production
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends tini curl ca-certificates \

--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ A web application for managing ArmA III communities. Built with Meteor.js, React
 
 **Key Features:**
 - Event management with calendar and attendance tracking
+- Rich-text briefing templates for events
 - Member management with ranks, squads, and specializations
+- Member registration and application flow
 - Task management with Kanban board
 - Organization chart (ORBAT) visualization
+- Questionnaires with anonymous responses
+- Audit logging and database backup/restore
 - Role-based access control (RBAC)
 - Multi-language support (English, German, French)
 
 ## Requirements
 
-- [Node.js 20.x](https://nodejs.org/en) (matches the version CI runs)
+- [Node.js 22.x](https://nodejs.org/en) (matches Meteor's bundled Node and the version CI runs)
 - [Meteor.js 3.4+](https://docs.meteor.com/about/install.html)
 - A text editor — we use [VS Code](https://code.visualstudio.com/download) with ESLint and Prettier so contributions match project style
 - MongoDB itself is **not** required for development — Meteor bundles it. Install [MongoDB Compass](https://www.mongodb.com/try/download/compass) only if you want to inspect the database.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -1,0 +1,19 @@
+# Development Workflow
+
+The end-to-end flow for taking a change from issue to merged PR. Most steps map
+to a Claude Code skill in `.claude/skills/` (e.g. `/issue`, `/plan`, `/branch`,
+`/test`, `/review`, `/validate`, `/pr`).
+
+1. **GitHub Issue** - Start from a GitHub issue describing the feature/bug
+2. **Create Implementation Plan** - Analyze requirements and design approach
+3. **Ask Questions** - Clarify ambiguities with stakeholders
+4. **Refine Plan** - Update plan based on feedback
+5. **Document Plan in Issue** - Add implementation details to the GitHub issue
+6. **Create Branch** - Create feature branch from issue (e.g., `feature/issue-123-description`)
+7. **Implement Changes** - Write code following coding guidelines
+8. **Run Tests** - Execute `npm test` and verify all pass
+9. **Fix Issues** - Address any failing tests or bugs
+10. **Run Code Review** - Self-review or request peer review
+11. **Fix Review Issues** - Address feedback from review
+12. **Validate Against CLAUDE.md** - Ensure code follows documented patterns; update CLAUDE.md if new patterns emerge
+13. **Create Pull Request** - Include summary of changes and steps for testing/reproduction

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,55 @@
+# Collection Schemas
+
+Field-level reference for every MongoDB collection. The source of truth is the
+`*.collection.ts` files in `imports/api/collections/`; this doc is a quick map.
+Per-collection permission/FK/audit metadata lives in `COLLECTION_REGISTRY`
+(`server/collection-registry.ts`).
+
+## Collections
+
+Members (Meteor.users), Events, Attendances, Tasks, TaskStatus, Squads, Ranks, Specializations, Medals, EventTypes, Positions, Registrations, DiscoveryTypes, Roles, ProfilePictures, Settings, Logs, Questionnaires, QuestionnaireResponses, BriefingTemplates
+
+## Schemas
+
+**Members** (Meteor.users)
+- `username`, `password`, `profile: { name, id (1000-9999), roleId, squadId, rankId, navyRankId, specializationIds[], medalIds[], profilePictureId, discordTag, steamProfileLink, description, entryDate, exitDate, staticAttendancePoints, staticInactivityPoints, hasCustomArmour }`
+
+**Events**
+- `name, start, end, eventType, hosts[], attendees[], isPrivate, color, preset, description` (`description` is rich text — sanitized HTML, see the Rich Text pattern in `CLAUDE.md`)
+
+**BriefingTemplates**
+- `name, color, content, description` — `content` is the rich-text briefing body (sanitized HTML) loaded into an event's `description` as a one-way snapshot; `description` is a short plain-text note. Rides on the `briefingTemplates` permission module. See `CONTEXT.md` → BriefingTemplate.
+
+**Tasks**
+- `name, status (taskStatusId), participants[], priority ('low'|'medium'|'high'), link, description, parent (taskId)`
+
+**Squads**
+- `name, color, image (base64), parentSquadId, shortRangeFrequency, longRangeFrequency, description`
+
+**Ranks**
+- `name, type ('player'|'zeus'), color, previousRankId, nextRankId, description`
+
+**Specializations**
+- `name, color, linkToFile, instructors[], requiredSpecializations[], requiredRankId, description`
+
+**Medals, EventTypes, TaskStatus, DiscoveryTypes**
+- `name, color, description`
+
+**Roles**
+- `name, color, description` + boolean permissions (`dashboard, orbat, logs, settings`) + CRUD permissions (`members, events, tasks, squads, ranks, specializations, medals, eventTypes, positions, taskStatus, registrations, discoveryTypes, roles, questionnaires`)
+
+**Registrations**
+- `name, id (1000-9999), age (min 16), discoveryType, rulesReadAndAccepted, description`
+
+**Questionnaires**
+- `name, description, status ('draft'|'active'|'closed'), allowAnonymous, interval ('once'|'daily'|'weekly'|'monthly'|'unlimited'), questions[], createdAt, updatedAt`
+- `questions[]: { text, type ('text'|'textarea'|'number'|'select'|'multiselect'|'rating'), required, options[] }`
+
+**QuestionnaireResponses**
+- `questionnaireId, respondentId (null if anonymous), answers[], ignored, submittedAt, createdAt`
+- `answers[]: { questionIndex, questionText, questionType, value }`
+
+**Attendances** - `{ [eventId]: { [memberId]: points } }`
+**ProfilePictures** - `{ value (base64) }`
+**Settings** - Key-value store
+**Logs** - `{ action, data, createdAt }`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,23 @@
+# Deployment
+
+**Docker with Traefik** (production)
+
+```bash
+# Required environment variables
+ROOT_URL=https://yourdomain.com
+DOMAIN=yourdomain.com
+MONGO_URL=mongodb://mongo:27017/community-manager  # default
+
+# Optional Traefik settings
+TRAEFIK_ENTRYPOINT=websecure                       # default
+TRAEFIK_CERTRESOLVER=letsencrypt                   # default
+
+# Build and run
+docker compose up -d
+```
+
+- Multi-stage Dockerfile: builds Meteor app, runs on Node 22
+- Requires external `traefik` network (assumes Traefik reverse proxy)
+- MongoDB 7 with health checks and persistent volume
+
+See `docker-compose.yml` for the full configuration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "community-manager",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "start": "meteor run",
     "test": "meteor test --once --driver-package meteortesting:mocha",

--- a/setup.ps1
+++ b/setup.ps1
@@ -3,6 +3,10 @@
 
 $ErrorActionPreference = "Stop"
 
+# Node major the project targets. Keep in sync with Meteor's bundled Node
+# (`meteor node -v`), the Dockerfile, CI, and setup.sh's NodeSource pin.
+$NodeVersion = "22"
+
 function Write-Header {
     Write-Host ""
     Write-Host "========================================" -ForegroundColor Blue
@@ -43,29 +47,54 @@ function Test-Administrator {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-function Install-NodeJS {
-    Write-Step "Installing Node.js..."
+function Update-SessionPath {
+    # Pull the freshly-written Machine + User PATH into the current session so a
+    # just-installed tool (nvm, the nvm Node symlink) resolves without a restart.
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+}
 
-    if (Test-Command "winget") {
-        Write-Info "Using winget..."
-        winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements
-    }
-    elseif (Test-Command "choco") {
-        Write-Info "Using Chocolatey..."
-        choco install nodejs-lts -y
+function Install-NodeWithNvm {
+    Write-Step "Setting up Node.js $NodeVersion via nvm-windows..."
+
+    # nvm-windows manages the active Node via a symlink; a non-nvm Node already on
+    # PATH can shadow it, so existing standalone installs should be removed first.
+    Write-Info "If a non-nvm Node.js is installed, uninstall it first so nvm can manage the active version."
+
+    if (-not (Test-Command "nvm")) {
+        Write-Info "nvm-windows not found. Installing it..."
+        if (Test-Command "winget") {
+            winget install CoreyButler.NVMforWindows --accept-package-agreements --accept-source-agreements
+        }
+        elseif (Test-Command "choco") {
+            choco install nvm -y
+        }
+        else {
+            Write-Error "No package manager found (winget or chocolatey) to install nvm-windows."
+            Write-Info "Install it manually: https://github.com/coreybutler/nvm-windows/releases"
+            Write-Info "Then re-run this script."
+            exit 1
+        }
+        Update-SessionPath
     }
     else {
-        Write-Error "No package manager found (winget or chocolatey)."
-        Write-Info "Please install Node.js manually from: https://nodejs.org/en/download/"
-        Write-Info "Or install winget: https://aka.ms/getwinget"
-        Write-Info "Or install Chocolatey: https://chocolatey.org/install"
-        exit 1
+        Write-Success "nvm-windows is already installed."
     }
 
-    # Refresh environment variables
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    # `nvm install 22` grabs the latest 22.x patch — floating within the major,
+    # mirroring the NodeSource `setup_22.x` line used in setup.sh.
+    Write-Info "Installing and activating Node.js $NodeVersion..."
+    nvm install $NodeVersion
+    nvm use $NodeVersion
+    Update-SessionPath
 
-    Write-Success "Node.js installed successfully!"
+    if (Test-Command "node") {
+        Write-Success "Node.js $(node --version) active via nvm-windows."
+    }
+    else {
+        Write-Info "Node was installed via nvm but isn't on PATH for this session yet."
+        Write-Info "Open a new terminal (or run 'nvm use $NodeVersion') and re-run this script."
+        exit 1
+    }
 }
 
 function Install-Meteor {
@@ -97,14 +126,21 @@ function Main {
         Write-Info "Some installations may require elevated permissions."
     }
 
-    # Check and install Node.js
-    Write-Step "Checking for Node.js..."
+    # Check Node.js — the project needs Node $NodeVersion.x (matches Meteor's bundled Node)
+    Write-Step "Checking Node.js..."
+    $nodeOk = $false
     if (Test-Command "node") {
         $nodeVersion = node --version
-        Write-Success "Node.js is already installed: $nodeVersion"
+        if ($nodeVersion -match "^v$NodeVersion\.") {
+            Write-Success "Node.js $nodeVersion is active (matches required major $NodeVersion)."
+            $nodeOk = $true
+        }
+        else {
+            Write-Info "Node.js $nodeVersion is active, but the project needs Node $NodeVersion.x."
+        }
     }
-    else {
-        Install-NodeJS
+    if (-not $nodeOk) {
+        Install-NodeWithNvm
     }
 
     # Check npm

--- a/setup.sh
+++ b/setup.sh
@@ -58,15 +58,15 @@ install_node() {
         linux)
             if command_exists apt-get; then
                 print_info "Using apt package manager..."
-                curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+                curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
                 sudo apt-get install -y nodejs
             elif command_exists dnf; then
                 print_info "Using dnf package manager..."
-                curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+                curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo bash -
                 sudo dnf install -y nodejs
             elif command_exists yum; then
                 print_info "Using yum package manager..."
-                curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+                curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo bash -
                 sudo yum install -y nodejs
             elif command_exists pacman; then
                 print_info "Using pacman package manager..."


### PR DESCRIPTION
## Summary

Two-part maintenance pass, surfaced while auditing whether the docs and setup files were up to date.

### Documentation refresh
- **README** — added missing features to the highlights list: member registration, questionnaires, rich-text briefing templates, audit logging, backup/restore.
- **CLAUDE.md** — corrected drift from the `drawer-stack`, `collection-registry`, and `mutation-pipeline` refactors (it still described the deleted `DrawerContext`/`SubdrawerContext` and `COLLECTION_TO_MODULE`). Trimmed **376 → 250 lines** by extracting reference blocks into `docs/` and deduping the Common Gotchas against the coding guidelines they restated.
- Extracted **Collection Schemas**, **Deployment**, and **Development Workflow** into `docs/collections.md`, `docs/deployment.md`, and `docs/agents/workflow.md`, referenced from CLAUDE.md.

### Node 22 alignment
Meteor 3.4.1 bundles **Node 22.22.1** (`meteor node -v`), but the project was pinned to **Node 20** everywhere — including a build-vs-runtime mismatch in the Docker image (built on Meteor's Node 22, run on `node:20-slim`).

- `setup.sh` — NodeSource `setup_20.x` → `setup_22.x`
- `setup.ps1` — install Node 22 via **nvm-windows** (`nvm install 22`) instead of latest LTS (which now resolves to Node 24, not 22)
- `Dockerfile` — `node:20-slim` → `node:22-slim` (production stage)
- `.github/workflows/ci.yml` — `node-version: '20'` → `'22'` (both jobs)
- README / deployment docs — Node 20.x → 22.x
- `package.json` — added advisory `engines.node: "22.x"` as a mismatch tripwire

## Testing
- No code changes — docs, CI config, Dockerfile, setup scripts, and `package.json` metadata only.
- CI on this PR is the real validation of the Node 20 → 22 bump (typecheck + mocha + e2e now run on Node 22).