### PR TITLE
Reactive viewport size (useViewportSize hook)

### DIFF
--- a/imports/ui/drawer-stack/DrawerStackProvider.tsx
+++ b/imports/ui/drawer-stack/DrawerStackProvider.tsx
@@ -1,6 +1,7 @@
 import { Drawer } from 'antd';
 import React, { createContext, ReactNode, useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 import { getDrawerWidth } from '../../config';
+import useViewportSize from '../hooks/useViewportSize';
 import { createDrawerStackStore, type DrawerStackStore } from './drawerStackStore';
 import type { DrawerStackApi, FrameContextValue, InternalFrame, PushFrameOptions } from './types';
 
@@ -69,6 +70,7 @@ interface FrameDrawerProps {
 }
 
 function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
+  const { width } = useViewportSize();
   const handleClose = useCallback(() => {
     void store.tryClose(frame.id);
   }, [store, frame.id]);
@@ -87,7 +89,7 @@ function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
 
   return (
     <Drawer
-      width={getDrawerWidth(window.innerWidth)}
+      width={getDrawerWidth(width)}
       open={true}
       onClose={handleClose}
       title={frame.title}

--- a/imports/ui/hooks/useViewportSize.ts
+++ b/imports/ui/hooks/useViewportSize.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+function readViewport(): ViewportSize {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0 };
+  }
+  return { width: window.innerWidth, height: window.innerHeight };
+}
+
+/**
+ * Reactive viewport size. Updates on `resize` and `orientationchange` (debounced
+ * to avoid thrashing during a continuous drag), so width-dependent UI — the
+ * unsupported-device gate, drawer width, modal width — recomputes on resize and
+ * rotation instead of being frozen at the value read on first render.
+ */
+export default function useViewportSize(debounceMs = 150): ViewportSize {
+  const [size, setSize] = useState<ViewportSize>(readViewport);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const handleChange = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setSize(readViewport()), debounceMs);
+    };
+    // Sync once on mount in case the viewport changed before listeners attached.
+    setSize(readViewport());
+    window.addEventListener('resize', handleChange);
+    window.addEventListener('orientationchange', handleChange);
+    return () => {
+      if (timer) clearTimeout(timer);
+      window.removeEventListener('resize', handleChange);
+      window.removeEventListener('orientationchange', handleChange);
+    };
+  }, [debounceMs]);
+
+  return size;
+}

--- a/imports/ui/main/Main.tsx
+++ b/imports/ui/main/Main.tsx
@@ -5,6 +5,7 @@ import React, { lazy, useMemo } from 'react';
 import RolesCollection from '../../api/collections/roles.collection';
 import type { Role, CrudPermission } from '../../api/types';
 import { isDeviceUnsupported } from '../../config';
+import useViewportSize from '../hooks/useViewportSize';
 import Login from '../login/Login';
 import useNavigation from '../navigation/navigation.hook';
 import Suspense from '../suspense/Suspense';
@@ -56,6 +57,7 @@ const MyQuestionnaires = lazy(() => import('../questionnaires/MyQuestionnaires')
 
 export default function Main() {
   const { navigationValue } = useNavigation();
+  const { width } = useViewportSize();
   const { loggedIn, user } = useTracker(() => {
     return {
       loggedIn: !!Meteor.userId(),
@@ -73,7 +75,7 @@ export default function Main() {
     return checkAccess(role, navigationValue);
   }, [roles, navigationValue]);
 
-  if (isDeviceUnsupported(window.innerWidth)) {
+  if (isDeviceUnsupported(width)) {
     return (
       <section className="container">
         <Result status="500" title="406 - Not supported" subTitle="Sorry, this device is not supported." />

--- a/imports/ui/members/ProfileModal.tsx
+++ b/imports/ui/members/ProfileModal.tsx
@@ -2,6 +2,7 @@ import { Modal } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import { getModalWidth } from '../../config';
+import useViewportSize from '../hooks/useViewportSize';
 import { ProfileStats } from '../dashboard/Dashboard';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
@@ -13,12 +14,13 @@ interface ProfileModalProps {
 export default function ProfileModal({ showProfile = false, toggleProfile = () => {} }: ProfileModalProps) {
   const [profileStats, setProfileStats] = useState<Record<string, unknown> | null>(null);
   const { t } = useTranslation();
+  const { width } = useViewportSize();
   useEffect(() => {
     Meteor.callAsync('members.profileStats').then((data: Record<string, unknown>) => setProfileStats(data));
   }, []);
 
   return (
-    <Modal title={t('modals.profile')} open={showProfile} onCancel={toggleProfile} width={getModalWidth(window.innerWidth)} footer={null} centered>
+    <Modal title={t('modals.profile')} open={showProfile} onCancel={toggleProfile} width={getModalWidth(width)} footer={null} centered>
       {profileStats && <ProfileStats profileStats={profileStats} />}
     </Modal>
   );


### PR DESCRIPTION
Closes #224.

## What this does

Adds a `useViewportSize` hook and routes the viewport-width-dependent UI through it, so they recompute on resize/rotation instead of being frozen at the value read on first render.

## Changes

- **`imports/ui/hooks/useViewportSize.ts`** — returns live `{ width, height }`, updates on `resize` + `orientationchange` (debounced 150ms), cleans up its listeners, SSR-safe.
- **`Main`** — device gate (`isDeviceUnsupported`) consumes the hook.
- **`DrawerStackProvider`** — drawer width (`getDrawerWidth`) consumes the hook.
- **`ProfileModal`** — modal width (`getModalWidth`) consumes the hook.

No more direct `window.innerWidth` reads on these paths (only the hook reads it).

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 358 passing
- `npm run e2e` — 106 passed, 3 skipped, 0 failed
- Manual: opened the Members create drawer at 1400px (width 462 = 33%), resized to 375px without reload → drawer became full-width (375). Confirmed reactive.

## Notes

Branched from `main` (independent of the open responsive PR #223; touches different lines). `getDrawerWidth`/`getModalWidth`/`isDeviceUnsupported` in `imports/config.ts` stay pure (numeric width in) — the hook just supplies a reactive width.