### PR TITLE
Full-width ProfileModal on mobile

### DIFF
--- a/imports/config.ts
+++ b/imports/config.ts
@@ -13,7 +13,9 @@ export function getDrawerWidth(windowWidth: number): number {
 }
 
 export function getModalWidth(windowWidth: number): number {
-  return windowWidth * LAYOUT.MODAL_WIDTH_RATIO;
+  // Full viewport width below the mobile breakpoint (a 75%-wide centered modal
+  // is cramped on a phone); the configured ratio on larger screens.
+  return windowWidth < BREAKPOINTS.MOBILE ? windowWidth : windowWidth * LAYOUT.MODAL_WIDTH_RATIO;
 }
 
 export function isDeviceUnsupported(windowWidth: number): boolean {

--- a/tests/client/config.test.ts
+++ b/tests/client/config.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { BREAKPOINTS, LAYOUT, getDrawerWidth, getModalWidth, isDeviceUnsupported } from '../../imports/config';
+
+describe('getModalWidth', () => {
+  it('returns full viewport width below the mobile breakpoint', () => {
+    assert.strictEqual(getModalWidth(375), 375);
+    assert.strictEqual(getModalWidth(BREAKPOINTS.MOBILE - 1), BREAKPOINTS.MOBILE - 1);
+  });
+
+  it('returns the configured ratio at and above the mobile breakpoint', () => {
+    assert.strictEqual(getModalWidth(BREAKPOINTS.MOBILE), BREAKPOINTS.MOBILE * LAYOUT.MODAL_WIDTH_RATIO);
+    assert.strictEqual(getModalWidth(1024), 1024 * LAYOUT.MODAL_WIDTH_RATIO);
+  });
+});
+
+describe('getDrawerWidth', () => {
+  it('returns full viewport width below the mobile breakpoint', () => {
+    assert.strictEqual(getDrawerWidth(375), 375);
+  });
+
+  it('returns the configured ratio at and above the mobile breakpoint', () => {
+    assert.strictEqual(getDrawerWidth(1024), 1024 * LAYOUT.DRAWER_WIDTH_RATIO);
+  });
+});
+
+describe('isDeviceUnsupported', () => {
+  it('flags widths below the minimum supported width', () => {
+    assert.strictEqual(isDeviceUnsupported(BREAKPOINTS.MIN_SUPPORTED_WIDTH - 1), true);
+  });
+
+  it('accepts widths at or above the minimum supported width', () => {
+    assert.strictEqual(isDeviceUnsupported(BREAKPOINTS.MIN_SUPPORTED_WIDTH), false);
+    assert.strictEqual(isDeviceUnsupported(1024), false);
+  });
+});

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,3 +1,4 @@
+import './client/config.test';
 import './client/hooks/drawerStackHooks.test';
 import './client/hooks/drawerStackStore.test';
 import './helpers/colors/getLegibleTextColor.test';


### PR DESCRIPTION
Closes #225.

## What this does

`getModalWidth()` returned 75% of viewport width at every size, so the profile modal was a cramped centered box on phones. Make it full viewport width below the `MOBILE` (768px) breakpoint — mirroring `getDrawerWidth` — while desktop keeps the configured 75% ratio.

## Changes

- **`imports/config.ts`** — `getModalWidth` is now mobile-aware: full width below 768px, `MODAL_WIDTH_RATIO` at/above.
- **`tests/client/config.test.ts`** (new) — unit tests for `getModalWidth`, `getDrawerWidth`, and `isDeviceUnsupported` (previously untested).

`ProfileModal` (the only `getModalWidth` consumer) needs no change — it already passes the value to the antd `Modal` width.

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 364 passing (6 new)
- `npm run e2e` — 105 passed, 3 skipped, 1 flaky (passed on retry), 0 failed

## Notes

Independent of #224 (which makes the *width value* reactive) — this changes the width *math*. They touch different files and compose: once both land, the profile modal is full-width on mobile **and** updates that on rotation.