### PR TITLE
Stack login buttons on mobile

### DIFF
--- a/imports/ui/login/Login.tsx
+++ b/imports/ui/login/Login.tsx
@@ -48,10 +48,10 @@ export default function Login() {
           <Input.Password placeholder={t('auth.enterPassword')} autoComplete="current-password" />
         </Form.Item>
         <Row gutter={[16, 16]} align="middle">
-          <Col span={12}>
+          <Col xs={24} md={12}>
             <Button onClick={handleRegister}>{t('auth.register')}</Button>
           </Col>
-          <Col span={12}>
+          <Col xs={24} md={12}>
             <Button type="primary" htmlType="submit">
               {t('auth.login')}
             </Button>


### PR DESCRIPTION
Closes #226.

## What this does

Makes the `Register | Login` button row stack on mobile.

## Scope correction

The four components named in #226 (`MemberForm`, `RegistrationForm`, `CollectionSelect`, `EventDetailPopover`) turned out to **already be mobile-responsive** — vertical forms with full-width (`span={24}`) fields, `Descriptions column={1}`, or `<Col flex="auto">`. An app-wide search for genuine fixed multi-column spans (`span` < 24) found exactly one: the login button row. Details in the [issue comment](https://github.com/sentinel-web/community-manager/issues/226#issuecomment-4529556974).

## Change

- **`Login.tsx`** — button row `span={12}` → `xs={24} md={12}`: stacks full-width below 768px, side-by-side above. (The existing `.login form button { width: 100% }` rule makes them fill the column in both states.)

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 358 passing
- `npm run e2e` — 106 passed, 3 skipped, 0 failed