### PR TITLE
Fix TableHeader extra layout (Tasks filter button)

### DIFF
--- a/imports/ui/table/header/TableHeader.tsx
+++ b/imports/ui/table/header/TableHeader.tsx
@@ -6,6 +6,8 @@ interface TableHeaderProps {
   handleChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   value?: string;
   handleCreate?: () => void;
+  /** Rendered between the search field and the create button inside the antd
+   *  Row — must be `<Col>`(s) so it gets the gutter spacing and wrap behavior. */
   extra?: ReactNode;
   canCreate?: boolean;
 }

--- a/imports/ui/tasks/Tasks.tsx
+++ b/imports/ui/tasks/Tasks.tsx
@@ -1,4 +1,4 @@
-import { Button } from 'antd';
+import { Button, Col } from 'antd';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Mongo } from 'meteor/mongo';
@@ -53,7 +53,11 @@ export default function Tasks() {
         FormComponent={TaskForm}
         columnsFactory={getTaskColumns}
         customView={filter?.type === 'kanban' ? KanbanBoard : false}
-        headerExtra={<Button onClick={openFilterDrawer}>{t('tasks.filter')}</Button>}
+        headerExtra={
+          <Col>
+            <Button onClick={openFilterDrawer}>{t('tasks.filter')}</Button>
+          </Col>
+        }
         filterFactory={filterFactory}
       />
     </div>


### PR DESCRIPTION
Closes #229.

## Root cause

`TableHeader` renders `extra` as a child of its antd `Row`, expecting `<Col>`(s). Members and Events comply, but **Tasks passed a bare `<Button>`** — a non-`Col` child of a `Row` misses the gutter padding and flex-grid behavior, so the filter button had no spacing and crowded its neighbours (the audit's "button may crowd" symptom).

## Changes

- **`Tasks.tsx`** — wrap the filter button in `<Col>` (consistent with Members/Events).
- **`TableHeader.tsx`** — document that `extra` must be `Col`(s), so this doesn't recur.

## Verification

Measured the Tasks header geometry:
- **Desktop (1400px):** filter button now has the proper 16px gutter gap from the search field (was flush/0 before); search + filter + create all on one row.
- **Mobile (375px):** search on row 1, filter + create wrap to row 2 — no overlap.

The other `TableHeader` call sites already wrapped `extra` in `<Col>`, so only the Tasks page is affected. (Minor: this *does* nudge the Tasks desktop header — it adds the previously-missing 16px gutter around the filter button, i.e. corrects the spacing rather than leaving it crowded.)

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 364 passing
- `npm run e2e` — 106 passed, 3 skipped, 0 failed