### PR TITLE
Scope ORBAT chart scroll to horizontal axis

### DIFF
--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -134,7 +134,10 @@ export default function Orbat() {
         title={<Typography.Title level={3}>{t('orbat.title')}</Typography.Title>}
         extra={<OrbatViewSelector viewType={viewType} handleChange={setViewType} t={t} />}
       >
-        <div style={{ overflow: 'auto' }}>
+        {/* Horizontal-only scroll: a wide org tree pans sideways within the card
+            rather than pushing a page-level scrollbar, while vertical growth flows
+            into the page's content scroll instead of a nested vertical scrollbar. */}
+        <div style={{ overflowX: 'auto' }}>
           {options?.length === 0 && <Empty />}
           {options.map(option => {
             return (


### PR DESCRIPTION
Closes #228.

## Finding

The audit (finding #6) said the ORBAT chart had "no scroll container." On inspection it **already wraps the tree in an overflow container**, and verification at mobile widths showed **no clipping and no page-level horizontal scrollbar** (`docHorizOverflow: 0`). `react-organizational-chart` shrink-to-fits, so with realistic data the tree fits the viewport; a larger hierarchy would overflow into — and scroll within — that container.

Per discussion on the issue, scope here is the **minimal polish**, not a node min-width rework.

## Change

- **`Orbat.tsx`** — wrapper `overflow: auto` → `overflowX: 'auto'`: makes the intent explicit (a wide tree pans horizontally within the card) and guards against a nested vertical scrollbar if the wrapper's height is ever constrained. Vertical growth flows into the page's content scroll.

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 364 passing
- `npm run e2e` — 106 passed, 3 skipped, 0 failed
- Manual: ORBAT at 360/375px renders fully, no clipping, no page-level horizontal scrollbar.

## Note

The deeper "large org squishes nodes instead of scrolling at a readable size" concern (shrink-to-fit has no min node width) is left as-is by design — flagged for a potential future follow-up if needed.