### PR TITLE
Default EventCalendar to agenda view on mobile

### DIFF
--- a/imports/types/react-big-calendar.d.ts
+++ b/imports/types/react-big-calendar.d.ts
@@ -63,6 +63,10 @@ declare module 'react-big-calendar' {
     onSelectEvent?: (event: CalendarEvent, e: React.SyntheticEvent) => void;
     eventPropGetter?: (event: CalendarEvent) => { style?: CSSProperties; className?: string };
     onRangeChange?: (range: Date[] | DateRange, view?: View) => void;
+    view?: View;
+    onView?: (view: View) => void;
+    defaultView?: View;
+    views?: View[];
     resizable?: boolean;
     selectable?: boolean;
     style?: CSSProperties;

--- a/imports/ui/events/EventCalendar.tsx
+++ b/imports/ui/events/EventCalendar.tsx
@@ -10,6 +10,7 @@ import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import EventTypesCollection from '../../api/collections/eventTypes.collection';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
+import { BREAKPOINTS } from '../../config';
 import { useLanguage } from '../../i18n/LanguageContext';
 import type { EventDoc } from '../../api/types/event';
 import { useDrawerStack } from '../drawer-stack';
@@ -112,7 +113,12 @@ const EventCalendar = ({ datasource, setFilter }: EventCalendarProps) => {
     [t]
   );
 
-  const [currentView, setCurrentView] = useState<View>('month');
+  // Default to the agenda list below the mobile breakpoint — react-big-calendar's
+  // month grid is unreadable on a phone. Read once at mount; the user can switch
+  // views afterwards via the (controlled) toolbar.
+  const [currentView, setCurrentView] = useState<View>(() =>
+    typeof window !== 'undefined' && window.innerWidth < BREAKPOINTS.MOBILE ? 'agenda' : 'month'
+  );
 
   const handleRangeChange = useCallback(
     (value: Date[] | DateRange, view?: View) => {
@@ -168,6 +174,8 @@ const EventCalendar = ({ datasource, setFilter }: EventCalendarProps) => {
           onSelectEvent={onSelectEvent}
           eventPropGetter={eventPropGetter}
           onRangeChange={handleRangeChange}
+          view={currentView}
+          onView={setCurrentView}
           resizable
           selectable
         />


### PR DESCRIPTION
Closes #227.

## What this does

`react-big-calendar`'s month grid is unreadable on a phone (the audit's finding #6). Default the calendar to the **agenda** list below the `MOBILE` (768px) breakpoint, while desktop keeps month and the view switcher stays fully usable.

## Changes

- **`EventCalendar.tsx`** — make the view **controlled** (`view` + `onView`) with a viewport-aware initial value (`window.innerWidth < BREAKPOINTS.MOBILE ? 'agenda' : 'month'`, read once at mount). The user can switch views afterwards via the toolbar.
- **`react-big-calendar.d.ts`** — add `view` / `onView` / `defaultView` / `views` to the hand-written `CalendarProps` (this project ships its own ambient types; there's no `@types/react-big-calendar`).

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 364 passing
- `npm run e2e` — 105 passed, 3 skipped, 1 flaky (passed on retry), 0 failed
- Manual: at 375px the calendar opens in Agenda (readable Date/Time/Event list, toolbar wraps to two rows) and switching to Month works; at 1400px it opens in Month.

## Note

The non-reactive `height: window.innerHeight * 0.75` on the calendar wrapper is left as-is (out of scope); it could adopt the `useViewportSize` hook from #224 in a future pass.