### PR TITLE
Replace deprecated Modal destroyOnClose with destroyOnHidden

### DIFF
--- a/imports/ui/events/EventDetailPopover.tsx
+++ b/imports/ui/events/EventDetailPopover.tsx
@@ -77,7 +77,7 @@ export default function EventDetailPopover({ event, open, setOpen, onEdit }: Eve
           </Button>
         </Space>
       }
-      destroyOnClose
+      destroyOnHidden
     >
       {loading ? (
         <Row justify="center" style={{ padding: 24 }}>


### PR DESCRIPTION
## What

`EventDetailPopover`'s `Modal` used `destroyOnClose`, which antd has deprecated in favor of `destroyOnHidden` — it logged `[antd: Modal] \`destroyOnClose\` is deprecated. Please use \`destroyOnHidden\` instead.` (surfaced during a full app verification run, on the events view).

This was the **last** remaining `destroyOnClose` in the codebase; `Palette` and `DrawerStackProvider` already use `destroyOnHidden`. Same behavior, just the non-deprecated prop name.

## Testing

- `npm run typecheck` — 0 errors
- `npm test` (mocha) — 364 passing
- `npm run e2e` — 105 passed, 3 skipped, 1 flaky (passed on retry), 0 failed
- `grep destroyOnClose` — 0 remaining