### PR TITLE
chore: modernize tsconfig module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "react",
     "strict": true,
     "esModuleInterop": true,
@@ -12,11 +12,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "/*": ["./*"],
       "/imports/*": ["./imports/*"],
-      "meteor/*": [".meteor/local/types/packages.d.ts"]
+      "meteor/*": ["./.meteor/local/types/packages.d.ts"]
     },
     "types": ["node", "mocha"]
   },


### PR DESCRIPTION
## What

- Replace deprecated `moduleResolution: "node"` (alias for the legacy `node10` algorithm) with `"bundler"`.
- Drop the deprecated `baseUrl` option.
- Prefix the `meteor/*` path target with `./`, required once `baseUrl` is gone (non-relative path targets are otherwise rejected).

## Why

Newer TypeScript flags both `moduleResolution: "node"` and `baseUrl` as deprecation **errors** in the editor, and TS 7.0 removes the options entirely. The pinned `typescript@5.9.3` (CI) doesn't error yet, so this is proactive — a one-line diff now instead of a forced migration later.

These options only affect `tsc --noEmit` (CI typecheck) and the editor. Meteor 3 transpiles `.ts`/`.tsx` via SWC/Babel (syntax-only) and resolves modules through its own isobuild bundler, so it never reads `moduleResolution`, `baseUrl`, or `paths`. `"bundler"` is also the semantically honest mode for a bundled app.

## Verification

- `npm run typecheck` (TS 5.9.3) — passes, exit 0.
- Full `meteor build` (Meteor 3.4.1, production, `os.linux.x86_64`) — exit 0, valid bundle; only pre-existing bundle-size advisory warnings.
- IDE deprecation errors cleared.