### PR TITLE
feat(ui): pin drawer form footers to the bottom of the drawer

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -40,6 +40,13 @@ h6 {
   width: 100%;
 }
 
+/* The drawer-stack always renders a footer slot, but only forms with a
+   FormFooter portal buttons into it. Collapse the footer (border + padding)
+   when the slot is empty so viewers and footer-less forms show no empty bar. */
+.ant-drawer-footer:has(> .frame-footer-slot:empty) {
+  display: none;
+}
+
 html {
   /* dvh tracks the *visible* viewport; plain vh is the large viewport that
      ignores the mobile address bar, which pushed the app's scroll container

--- a/e2e/pages/base.page.ts
+++ b/e2e/pages/base.page.ts
@@ -101,8 +101,12 @@ export class BasePage {
    * Click submit button in form (handles Submit, Save, etc.)
    */
   async submitForm(): Promise<void> {
-    // Try different common submit button patterns
-    const submitBtn = this.page.locator('button[type="submit"], .ant-drawer button:has-text("Save"), .ant-drawer button:has-text("Submit")').first();
+    // Click the visible action button in the Drawer's footer slot. Scope to
+    // .ant-drawer-footer (not a bare button[type="submit"]) because forms now
+    // also carry a hidden off-screen submit button inside the body to preserve
+    // Enter-to-submit — a bare selector would match that hidden button first
+    // and hang on Playwright's actionability checks.
+    const submitBtn = this.page.locator('.ant-drawer-footer button:has-text("Save"), .ant-drawer-footer button:has-text("Submit")').first();
     await submitBtn.click();
   }
 

--- a/imports/ui/components/FormFooter.tsx
+++ b/imports/ui/components/FormFooter.tsx
@@ -1,6 +1,7 @@
 import { Button, Col, Row } from 'antd';
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
+import { DrawerFooter } from '../drawer-stack';
 
 interface FormFooterProps {
   setOpen?: (open: boolean) => void;
@@ -11,22 +12,38 @@ interface FormFooterProps {
 
 const FormFooter = ({ setOpen, onCancel, cancelText, submitText }: FormFooterProps) => {
   const { t } = useTranslation();
+  // Anchor stays in the form's DOM so we can reach the owning <form> for submit.
+  const anchorRef = useRef<HTMLSpanElement>(null);
 
   const handleCancel = onCancel ?? (() => setOpen?.(false));
 
+  // DrawerFooter portals the buttons into the Drawer footer slot, outside the
+  // <form> element, so this button can't use htmlType="submit". With no form
+  // instance to hand, walk up from the in-form anchor and call requestSubmit(),
+  // firing antd validation and onFinish. (Enter-to-submit is handled separately
+  // by DrawerFooter's hidden in-form submit button.)
+  const handleSubmit = useCallback(() => {
+    anchorRef.current?.closest('form')?.requestSubmit();
+  }, []);
+
   return (
-    <Row gutter={[16, 16]} align="middle" justify="end">
-      <Col>
-        <Button onClick={handleCancel} danger>
-          {cancelText || t('common.cancel')}
-        </Button>
-      </Col>
-      <Col>
-        <Button type="primary" htmlType="submit">
-          {submitText || t('common.submit')}
-        </Button>
-      </Col>
-    </Row>
+    <>
+      <span ref={anchorRef} aria-hidden style={{ display: 'none' }} />
+      <DrawerFooter>
+        <Row gutter={[16, 16]} align="middle" justify="end">
+          <Col>
+            <Button onClick={handleCancel} danger>
+              {cancelText || t('common.cancel')}
+            </Button>
+          </Col>
+          <Col>
+            <Button type="primary" onClick={handleSubmit}>
+              {submitText || t('common.submit')}
+            </Button>
+          </Col>
+        </Row>
+      </DrawerFooter>
+    </>
   );
 };
 

--- a/imports/ui/drawer-stack/DrawerFooter.tsx
+++ b/imports/ui/drawer-stack/DrawerFooter.tsx
@@ -1,0 +1,47 @@
+import React, { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import useDrawerFrame from './useDrawerFrame';
+
+interface DrawerFooterProps {
+  children: ReactNode;
+}
+
+/**
+ * Pins footer content (action buttons) to the bottom of the current Drawer by
+ * portaling it into the frame's footer slot, while the body scrolls.
+ *
+ * Because a portal preserves the React tree (only the DOM target moves), the
+ * children remain React descendants of the surrounding <Form> — so antd's
+ * disabled context (e.g. `disabled={loading}`) still reaches buttons rendered
+ * here. The footer DOM lives outside the <form> element, though, so a submit
+ * button can't use htmlType="submit"; call `form.submit()` (or, for the generic
+ * FormFooter, `form.requestSubmit()`) from an onClick handler instead.
+ *
+ * DrawerFooter itself renders inside the <Form> (only its children are
+ * portaled), so it emits one hidden submit button at its own location. That
+ * restores the form's default button — without it, native Enter-to-submit would
+ * be lost once the visible submit button moved out of the form element. It is
+ * positioned off-screen rather than `display: none`, since some browsers skip
+ * `display: none` buttons during implicit (Enter-key) submission.
+ */
+const hiddenSubmitStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  border: 0,
+  overflow: 'hidden',
+  opacity: 0,
+  pointerEvents: 'none',
+};
+
+export default function DrawerFooter({ children }: DrawerFooterProps) {
+  const { footerContainer } = useDrawerFrame();
+  return (
+    <>
+      <button type="submit" tabIndex={-1} aria-hidden style={hiddenSubmitStyle} />
+      {footerContainer ? createPortal(children, footerContainer) : null}
+    </>
+  );
+}

--- a/imports/ui/drawer-stack/DrawerStackProvider.tsx
+++ b/imports/ui/drawer-stack/DrawerStackProvider.tsx
@@ -1,5 +1,5 @@
 import { Drawer } from 'antd';
-import React, { createContext, ReactNode, useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import React, { createContext, ReactNode, useCallback, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { getDrawerWidth } from '../../config';
 import useViewportSize from '../hooks/useViewportSize';
 import { createDrawerStackStore, type DrawerStackStore } from './drawerStackStore';
@@ -71,6 +71,10 @@ interface FrameDrawerProps {
 
 function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
   const { width } = useViewportSize();
+  // The Drawer footer slot DOM node. FormFooter portals its action buttons here
+  // so they pin to the bottom of the drawer while the body scrolls. State (not a
+  // ref) so the context value updates once the slot mounts and consumers re-render.
+  const [footerEl, setFooterEl] = useState<HTMLDivElement | null>(null);
   const handleClose = useCallback(() => {
     void store.tryClose(frame.id);
   }, [store, frame.id]);
@@ -81,8 +85,9 @@ function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
       resolve: value => store.resolveFrame(frame.id, value),
       cancel: () => store.cancelFrame(frame.id),
       confirmCloseRef: frame.confirmCloseRef,
+      footerContainer: footerEl,
     }),
-    [store, frame.id, frame.model, frame.confirmCloseRef]
+    [store, frame.id, frame.model, frame.confirmCloseRef, footerEl]
   );
 
   const Component = frame.Component;
@@ -96,6 +101,9 @@ function FrameDrawer({ frame, isTop, store, children }: FrameDrawerProps) {
       extra={frame.extra}
       maskClosable={isTop}
       destroyOnHidden
+      // Always render a footer slot; it collapses to nothing (see main.css) for
+      // frames whose component never portals anything into it (e.g. viewers).
+      footer={<div ref={setFooterEl} className="frame-footer-slot" />}
     >
       <FrameContext.Provider value={frameApi}>
         <Component />

--- a/imports/ui/drawer-stack/index.ts
+++ b/imports/ui/drawer-stack/index.ts
@@ -2,5 +2,6 @@ export { default as DrawerStackProvider } from './DrawerStackProvider';
 export { default as useDrawerStack } from './useDrawerStack';
 export { default as useDrawerFrame } from './useDrawerFrame';
 export { default as useConfirmClose } from './useConfirmClose';
+export { default as DrawerFooter } from './DrawerFooter';
 export type { DrawerStackApi, PushFrameOptions, ConfirmClosePredicate } from './types';
 export type { DrawerFrame } from './useDrawerFrame';

--- a/imports/ui/drawer-stack/types.ts
+++ b/imports/ui/drawer-stack/types.ts
@@ -27,6 +27,10 @@ export interface FrameContextValue {
   resolve: (value: unknown) => void;
   cancel: () => void;
   confirmCloseRef: ConfirmCloseRef;
+  // DOM node of this frame's Drawer footer slot, into which FormFooter portals
+  // its action buttons so they pin to the bottom of the drawer. Null until the
+  // Drawer mounts the slot.
+  footerContainer: HTMLElement | null;
 }
 
 export interface DrawerStackApi {

--- a/imports/ui/drawer-stack/useDrawerFrame.ts
+++ b/imports/ui/drawer-stack/useDrawerFrame.ts
@@ -5,6 +5,7 @@ export interface DrawerFrame<R, M> {
   model: M;
   resolve: (value: R | undefined) => void;
   cancel: () => void;
+  footerContainer: HTMLElement | null;
 }
 
 export default function useDrawerFrame<R = unknown, M = unknown>(): DrawerFrame<R, M> {
@@ -16,5 +17,6 @@ export default function useDrawerFrame<R = unknown, M = unknown>(): DrawerFrame<
     model: frame.model as M,
     resolve: value => frame.resolve(value),
     cancel: frame.cancel,
+    footerContainer: frame.footerContainer,
   };
 }

--- a/imports/ui/events/EventForm.tsx
+++ b/imports/ui/events/EventForm.tsx
@@ -13,7 +13,7 @@ import type { EventDoc, BriefingTemplate } from '../../api/types';
 import type { CollectionDoc } from '../components/CollectionSelect';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
-import { useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
 import CollectionSelect from '../components/CollectionSelect';
 import MembersSelect from '../members/MembersSelect';
 import RichTextEditor from '../components/RichTextEditor';
@@ -154,20 +154,22 @@ const EventForm = () => {
       <Form.Item name="description" label={t('common.description')} rules={[{ type: 'string' }]}>
         <RichTextEditor placeholder={t('forms.placeholders.enterDescription')} />
       </Form.Item>
-      <Row gutter={[16, 16]} justify="end" align="middle">
-        {model?._id && (
+      <DrawerFooter>
+        <Row gutter={[16, 16]} justify="end" align="middle">
+          {model?._id && (
+            <Col>
+              <Button type="primary" onClick={handleDelete} icon={<DeleteOutlined />} danger>
+                {t('common.delete')}
+              </Button>
+            </Col>
+          )}
           <Col>
-            <Button type="primary" onClick={handleDelete} icon={<DeleteOutlined />} danger>
-              {t('common.delete')}
+            <Button type="primary" onClick={() => form.submit()} icon={<SaveOutlined />}>
+              {t('common.save')}
             </Button>
           </Col>
-        )}
-        <Col>
-          <Button type="primary" htmlType="submit" icon={<SaveOutlined />}>
-            {t('common.save')}
-          </Button>
-        </Col>
-      </Row>
+        </Row>
+      </DrawerFooter>
     </Form>
   );
 };

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -137,6 +137,11 @@ export default function MemberForm() {
 
   const handleSubmit = useCallback(
     async (values: MemberFormValues) => {
+      // Guard the submit itself, not just the footer button. The button's
+      // `disabled` blocks clicks, but Enter-to-submit fires through the form's
+      // hidden submit button — which bypasses `disableSubmit` (name or id
+      // already in use / rules not accepted) unless we re-check here.
+      if (loading || disableSubmit) return;
       setLoading(true);
       const payload = {
         ...values,
@@ -164,7 +169,7 @@ export default function MemberForm() {
         setLoading(false);
       }
     },
-    [model?._id, resolve, message, notification, t]
+    [model?._id, resolve, message, notification, t, loading, disableSubmit]
   );
 
   const handleValuesChange = useCallback(

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -9,7 +9,7 @@ import RanksCollection from '../../api/collections/ranks.collection';
 import RolesCollection from '../../api/collections/roles.collection';
 import type { Member } from '../../api/types/member';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import { getDateFromValues } from '../events/EventForm';
 import ProfilePictureInput from '../profile-picture-input/ProfilePictureInput';
@@ -309,18 +309,20 @@ export default function MemberForm() {
       <Form.Item name={['profile', 'hasCustomArmour']} label={t('forms.labels.hasCustomArmour')} valuePropName="checked" rules={[{ type: 'boolean' }]}>
         <Switch />
       </Form.Item>
-      <Row gutter={[16, 16]} align="middle" justify="end">
-        <Col>
-          <Button onClick={handleCancel} danger>
-            {t('common.cancel')}
-          </Button>
-        </Col>
-        <Col>
-          <Button type="primary" htmlType="submit" loading={loading} disabled={disableSubmit}>
-            {t('common.submit')}
-          </Button>
-        </Col>
-      </Row>
+      <DrawerFooter>
+        <Row gutter={[16, 16]} align="middle" justify="end">
+          <Col>
+            <Button onClick={handleCancel} danger>
+              {t('common.cancel')}
+            </Button>
+          </Col>
+          <Col>
+            <Button type="primary" onClick={() => form.submit()} loading={loading} disabled={disableSubmit}>
+              {t('common.submit')}
+            </Button>
+          </Col>
+        </Row>
+      </DrawerFooter>
     </Form>
   );
 }

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -96,6 +96,11 @@ export default function RegistrationForm() {
 
   const handleSubmit = useCallback(
     async (values: RegistrationFormValues) => {
+      // Guard the submit itself, not just the footer button. The button's
+      // `disabled` blocks clicks, but Enter-to-submit fires through the form's
+      // hidden submit button — which bypasses `disableSubmit` (rules not
+      // accepted / name or id already in use) unless we re-check here.
+      if (loading || disableSubmit) return;
       setLoading(true);
       const { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description } = values;
       const args = [
@@ -119,7 +124,7 @@ export default function RegistrationForm() {
         setLoading(false);
       }
     },
-    [resolve, model, message, notification, t],
+    [resolve, model, message, notification, t, loading, disableSubmit],
   );
 
   const handleValuesChange = useCallback(

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import DiscoveryTypesCollection from '../../api/collections/discoveryTypes.collection';
 import type { Registration } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import DiscoveryTypeForm from './discovery-types/DiscoveryTypesForm';
 
@@ -214,20 +214,22 @@ export default function RegistrationForm() {
           <Input.TextArea autoSize placeholder={t('forms.placeholders.enterDescription')} />
         </Form.Item>
       )}
-      <Row gutter={[16, 16]} align="middle" justify="end">
-        <Col>
-          <Button onClick={cancel} danger>
-            {t('common.cancel')}
-          </Button>
-        </Col>
-        <Col>
-          <Tooltip title={disableSubmit ? t('forms.tooltips.pleaseReadAndAcceptRules') : ''}>
-            <Button type="primary" htmlType="submit" loading={loading} disabled={disableSubmit}>
-              {t('common.submit')}
+      <DrawerFooter>
+        <Row gutter={[16, 16]} align="middle" justify="end">
+          <Col>
+            <Button onClick={cancel} danger>
+              {t('common.cancel')}
             </Button>
-          </Tooltip>
-        </Col>
-      </Row>
+          </Col>
+          <Col>
+            <Tooltip title={disableSubmit ? t('forms.tooltips.pleaseReadAndAcceptRules') : ''}>
+              <Button type="primary" onClick={() => form.submit()} loading={loading} disabled={disableSubmit}>
+                {t('common.submit')}
+              </Button>
+            </Tooltip>
+          </Col>
+        </Row>
+      </DrawerFooter>
     </Form>
   );
 }

--- a/tests/client/hooks/drawerStackHooks.test.tsx
+++ b/tests/client/hooks/drawerStackHooks.test.tsx
@@ -83,6 +83,7 @@ if (Meteor.isClient) {
         resolve: () => {},
         cancel: () => {},
         confirmCloseRef: { current: null },
+        footerContainer: null,
       };
       const result = await renderHook(useDrawerFrame, children => (
         <FrameContext.Provider value={fakeFrame}>{children}</FrameContext.Provider>
@@ -110,6 +111,7 @@ if (Meteor.isClient) {
         resolve: () => {},
         cancel: () => {},
         confirmCloseRef: ref,
+        footerContainer: null,
       };
       const predicate = () => false;
       await renderHook(() => useConfirmClose(predicate), children => (


### PR DESCRIPTION
## What

Form action buttons in drawers now render in the antd **`Drawer` native footer slot** — pinned to the bottom of the drawer while the body scrolls — instead of sitting inline at the end of the scrolling form content.

Applies to **every** drawer form: the 15 `FormFooter` forms and the 3 that roll their own footer (`EventForm`, `MemberForm`, `RegistrationForm`). Viewers (LogViewer, etc.) and footer-less forms show no footer bar.

| Before | After |
|--------|-------|
| Buttons scroll away at the end of the form | Buttons pinned at the drawer bottom, body scrolls under them |

## How

- **`DrawerStackProvider`** renders a `footer={<div className="frame-footer-slot" ref … />}` per frame and exposes that DOM node via `FrameContext` as `footerContainer`.
- New **`DrawerFooter`** component portals its children into the slot. Because a portal preserves the React tree (not the DOM tree), the buttons stay React descendants of `<Form>` and still receive antd's `disabled` context (`disabled={loading}`) — no double-submit regression, no per-form wiring.
- **`client/main.css`**: `.ant-drawer-footer:has(> .frame-footer-slot:empty){display:none}` collapses the bar when nothing is portaled in.
- `FormFooter` + the 3 custom forms route through `DrawerFooter`. Since the footer DOM lives outside `<form>`, submit goes through `form.submit()` (forms with an instance) or `requestSubmit()` (generic `FormFooter`).
- **Enter-to-submit preserved**: removing the in-form `htmlType="submit"` button would have disabled native implicit submission. `DrawerFooter` renders one hidden, off-screen in-form `<button type="submit">` to restore it.

## Verification

`npm run typecheck` clean. Manually verified against the running app with Playwright:

- **Squads / Event (long forms):** real `.ant-drawer-footer`, body scrolls under it, footer stays put on scroll; create succeeds; validation blocks + keeps the drawer open.
- **EventForm:** Delete + Save pinned; `form.submit()` drives validation.
- **MemberForm / RegistrationForm:** Cancel + Submit pinned, no stray in-body submit button.
- **Nested drawers:** each frame gets its own independent footer.
- **LogViewer (viewer):** empty slot → footer collapsed, no empty bar.
- **Enter-to-submit:** Enter in a field fires submission/validation again (regression caught in review and fixed).

> Note: the empty-footer collapse uses the CSS `:has()` selector; in browsers without `:has()` support, viewers would show an empty footer bar (cosmetic-only degradation).