### PR TITLE
fix(ui): reliable name/id availability checks in member & registration forms

### DIFF
--- a/e2e/tests/members.spec.ts
+++ b/e2e/tests/members.spec.ts
@@ -61,6 +61,23 @@ test.describe('Members', () => {
     await membersPage.expectValidationError();
   });
 
+  test('should flag a duplicate member name', async ({ page }) => {
+    // Derive a real in-use name rather than hardcoding demo data.
+    const usedNames = await page.evaluate(async () => (await window.Meteor.callAsync('members.getUsedNames')) as string[]);
+    const existingName = usedNames.find(Boolean);
+    expect(existingName, 'expected at least one existing member').toBeTruthy();
+
+    await membersPage.clickCreate();
+    await membersPage.fillFormField('profile_name', existingName as string);
+
+    // members.validateName runs async; the in-use alert should appear and submit
+    // should disable. This guards the regression where the check was dead code
+    // (wrong field paths + wrong collection) and where an available id clobbered
+    // the in-use-name result.
+    await expect(page.locator('.ant-drawer .ant-alert-error')).toBeVisible();
+    await expect(page.locator('.ant-drawer-footer button.ant-btn-primary')).toBeDisabled();
+  });
+
   test('should create and delete a member', async ({ page }) => {
     const testId = Math.floor(Math.random() * 8999) + 1000;
     const testUsername = `testuser_${testId}`;

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -67,7 +67,14 @@ export default function MemberForm() {
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
-  const [disableSubmit, setDisableSubmit] = useState(false);
+  // Independent availability signals derived into disableSubmit — see the same
+  // pattern in RegistrationForm. Previously a single disableSubmit was written
+  // by two async validations that clobbered each other; here they also never
+  // fired at all, because the checks below used the wrong (top-level) field
+  // paths and the registrations collection instead of members.
+  const [nameAvailable, setNameAvailable] = useState(true);
+  const [idAvailable, setIdAvailable] = useState(true);
+  const disableSubmit = useMemo(() => !nameAvailable || !idAvailable, [nameAvailable, idAvailable]);
   const [nameError, setNameError] = useState<ValidationStatus>(undefined);
   const [idError, setIdError] = useState<ValidationStatus>(undefined);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
@@ -110,12 +117,12 @@ export default function MemberForm() {
   }, [model, form.setFieldsValue]);
 
   const validateName = useCallback(() => {
-    const value = form.getFieldValue('name');
+    const value = form.getFieldValue(['profile', 'name']);
     setNameError('validating');
-    Meteor.callAsync('registrations.validateName', value, model?._id)
+    Meteor.callAsync('members.validateName', value, model?._id || false)
       .then((result: boolean) => {
         setNameError(result ? 'success' : 'error');
-        setDisableSubmit(!result);
+        setNameAvailable(result);
       })
       .catch(() => {
         setNameError('warning');
@@ -123,12 +130,12 @@ export default function MemberForm() {
   }, [form, model?._id]);
 
   const validateId = useCallback(() => {
-    const value = form.getFieldValue('id');
+    const value = form.getFieldValue(['profile', 'id']);
     setIdError('validating');
-    Meteor.callAsync('registrations.validateId', value, model?._id)
+    Meteor.callAsync('members.validateId', value, model?._id || false)
       .then((result: boolean) => {
         setIdError(result ? 'success' : 'error');
-        setDisableSubmit(!result);
+        setIdAvailable(result);
       })
       .catch(() => {
         setIdError('warning');
@@ -173,15 +180,14 @@ export default function MemberForm() {
   );
 
   const handleValuesChange = useCallback(
-    (changedValues: MemberFormValues, values: MemberFormValues) => {
-      if ('name' in values) {
+    (changedValues: MemberFormValues) => {
+      // name/id live under `profile`, so inspect the changed nested keys.
+      const changedProfile = (changedValues as { profile?: Record<string, unknown> }).profile;
+      if (changedProfile && 'name' in changedProfile) {
         validateName();
       }
-      if ('id' in values) {
+      if (changedProfile && 'id' in changedProfile) {
         validateId();
-      }
-      if ('rulesReadAndAccepted' in changedValues && 'rulesReadAndAccepted' in values) {
-        setDisableSubmit(!(values as Record<string, unknown>).rulesReadAndAccepted as boolean);
       }
     },
     [validateName, validateId]
@@ -192,7 +198,7 @@ export default function MemberForm() {
   }, [cancel]);
 
   useEffect(() => {
-    handleValuesChange({} as MemberFormValues, {} as MemberFormValues);
+    handleValuesChange({} as MemberFormValues);
   }, [model, handleValuesChange]);
 
   return (

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, App, Button, Col, Form, Input, InputNumber, Row, Switch, Tooltip } from 'antd';
+import { Alert, App, Button, Col, Form, Input, InputNumber, Row, Switch } from 'antd';
 import type { ValidateStatus } from 'antd/es/form/FormItem';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
@@ -29,7 +29,15 @@ export default function RegistrationForm() {
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
-  const [disableSubmit, setDisableSubmit] = useState(false);
+  // Track name/id availability as independent signals and derive disableSubmit
+  // from them. Folding both into one state let the two async validations
+  // clobber each other (last-writer-wins), so an in-use name could be masked by
+  // an available id. Rules acceptance is enforced via a field validator below,
+  // not here, so the button stays clickable on an empty form (to surface the
+  // required-field errors).
+  const [nameAvailable, setNameAvailable] = useState(true);
+  const [idAvailable, setIdAvailable] = useState(true);
+  const disableSubmit = useMemo(() => !nameAvailable || !idAvailable, [nameAvailable, idAvailable]);
   const [nameError, setNameError] = useState<ValidateStatus | undefined>(undefined);
   const [idError, setIdError] = useState<ValidateStatus | undefined>(undefined);
 
@@ -61,7 +69,7 @@ export default function RegistrationForm() {
     Meteor.callAsync('registrations.validateName', value, (model as Registration)?._id)
       .then((result: boolean) => {
         setNameError(result ? 'success' : 'error');
-        setDisableSubmit(!result);
+        setNameAvailable(result);
       })
       .catch(() => {
         setNameError('warning');
@@ -74,7 +82,7 @@ export default function RegistrationForm() {
     Meteor.callAsync('registrations.validateId', value, (model as Registration)?._id)
       .then((result: boolean) => {
         setIdError(result ? 'success' : 'error');
-        setDisableSubmit(!result);
+        setIdAvailable(result);
       })
       .catch(() => {
         setIdError('warning');
@@ -134,9 +142,6 @@ export default function RegistrationForm() {
       }
       if ('id' in values) {
         validateId();
-      }
-      if ('rulesReadAndAccepted' in changedValues && 'rulesReadAndAccepted' in values) {
-        setDisableSubmit(!values.rulesReadAndAccepted);
       }
       if ('discoveryType' in changedValues) {
         handleDiscoveryTypeChange();
@@ -211,7 +216,16 @@ export default function RegistrationForm() {
       <Form.Item name="discordTag" label={t('forms.labels.discordTag')} rules={[{ type: 'string' }]}>
         <Input placeholder={t('forms.placeholders.enterDiscordTag')} />
       </Form.Item>
-      <Form.Item name="rulesReadAndAccepted" label={t('forms.labels.rulesAccepted')} rules={[{ required: true, type: 'boolean' }]} required>
+      <Form.Item
+        name="rulesReadAndAccepted"
+        label={t('forms.labels.rulesAccepted')}
+        rules={[
+          {
+            validator: (_, value) => (value ? Promise.resolve() : Promise.reject(new Error(t('forms.tooltips.pleaseReadAndAcceptRules')))),
+          },
+        ]}
+        required
+      >
         <Switch />
       </Form.Item>
       {Meteor.user() && (
@@ -227,11 +241,9 @@ export default function RegistrationForm() {
             </Button>
           </Col>
           <Col>
-            <Tooltip title={disableSubmit ? t('forms.tooltips.pleaseReadAndAcceptRules') : ''}>
-              <Button type="primary" onClick={() => form.submit()} loading={loading} disabled={disableSubmit}>
-                {t('common.submit')}
-              </Button>
-            </Tooltip>
+            <Button type="primary" onClick={() => form.submit()} loading={loading} disabled={disableSubmit}>
+              {t('common.submit')}
+            </Button>
           </Col>
         </Row>
       </DrawerFooter>

--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -11,7 +11,7 @@ import RanksCollection from '../../imports/api/collections/ranks.collection';
 import RolesCollection from '../../imports/api/collections/roles.collection';
 import SpecializationsCollection from '../../imports/api/collections/specializations.collection';
 import SquadsCollection from '../../imports/api/collections/squads.collection';
-import { validateObject, validatePublish, validateString, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
+import { validateObject, validatePublish, validateString, validateNumber, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
 import { createLog } from './logs.server';
 import { runMutation, snapshotTouchedFields } from '../mutation-pipeline';
 import { COLLECTION_REGISTRY } from '../collection-registry';
@@ -256,6 +256,32 @@ if (Meteor.isServer) {
       const members = await MembersCollection.find({}, { fields: { 'profile.name': 1 } }).mapAsync(m => m.profile?.name);
 
       return members;
+    },
+    // Returns true when `name` is free among members (excluding the member being
+    // edited). An empty name is treated as available — the required-field rule
+    // handles emptiness; this only checks uniqueness.
+    'members.validateName': async function (name: string = '', excludeId: string | false = false): Promise<boolean> {
+      validateUserId(this.userId);
+      validateString(name, true);
+      if (!name) return true;
+
+      const filter: Record<string, unknown> = { 'profile.name': name };
+      if (excludeId) {
+        filter._id = { $ne: excludeId };
+      }
+      return !(await MembersCollection.findOneAsync(filter));
+    },
+    // Returns true when `id` is free among members (excluding the member being edited).
+    'members.validateId': async function (id: number = 0, excludeId: string | false = false): Promise<boolean> {
+      validateUserId(this.userId);
+      validateNumber(id, true);
+      if (!id) return true;
+
+      const filter: Record<string, unknown> = { 'profile.id': id };
+      if (excludeId) {
+        filter._id = { $ne: excludeId };
+      }
+      return !(await MembersCollection.findOneAsync(filter));
     },
     'members.all': async function () {
       if (!this.userId) {


### PR DESCRIPTION
Closes #239.

## Problem

`RegistrationForm` folded **two async availability checks** (name, id) **plus the rules toggle** into a single `disableSubmit` boolean. The async callbacks wrote that one state last-writer-wins, so they clobbered each other: typing an **in-use name** showed the "name already in use" alert, but the concurrent **id check returning available** reset `disableSubmit` back to `false` — leaving Submit wrongly enabled.

`MemberForm` carried the same code, but it **never ran at all**: `validateName`/`validateId` read top-level `'name'`/`'id'` (the fields live under `profile`), `handleValuesChange` gated on `'name' in values` (always false), there was no `rulesReadAndAccepted` field, and the checks called the **registrations** validators. So member name/id uniqueness was silently unvalidated.

## Changes

**RegistrationForm**
- Track `nameAvailable` / `idAvailable` as independent signals; derive `disableSubmit = !nameAvailable || !idAvailable` via `useMemo`. No check can overwrite another.
- Enforce rules acceptance with a **field validator** (rejects `false`) instead of gating the button. This blocks every submit path (click / Enter / programmatic) with an inline error, and keeps the button clickable on an empty form so required-field errors still surface. Removed the now-redundant submit tooltip.

**MemberForm**
- Wired correctly to the new server methods with `['profile','name']` / `['profile','id']` paths and the same non-racy derivation — restoring member name/id uniqueness pre-validation.

**Server**
- New `members.validateName` / `members.validateId` (check the members collection, exclude self on edit). Empty value is treated as available; the required-field rule handles emptiness.

**Tests**
- New e2e: `should flag a duplicate member name` (derives a real in-use name via `members.getUsedNames`, asserts the alert shows and Submit disables).

## Verification

`npm run typecheck` clean. Verified live with Playwright (against the running dev server):
- **MemberForm** (new behavior): typing an existing member name → "Name already in use" alert + Submit disabled (was dead code before).
- **Race fix** (both forms): an in-use name with an **available** id keeps Submit disabled — the available-id result no longer clobbers the in-use-name result.
- **Rules validator** (RegistrationForm): submitting with rules off → inline "Please read and accept the rules" error, drawer stays open, no insert.
- e2e: members + registrations specs pass (12/12, incl. the new test).

## Context

Follow-up to #238 (pinned drawer footers), whose review surfaced this pre-existing race. #238's submit guard only mirrored `disableSubmit`; this fixes the root cause.