### PR TITLE
feat(ui): add the MethodCall seam (useMethod)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,24 @@ Close semantics: when the user dismisses the top frame (antd `onClose` from X-cl
 
 The depth pattern that previously required a `useSubdrawer: boolean` prop drilled through every nested form, plus an `if (drawer.drawerOpen) use subdrawer else use drawer` branch at each open site, is now structurally impossible — there is no second context to choose between, and frames don't expose their depth on the seam.
 
+### MethodCall
+
+The single deep module (`imports/ui/hooks/useMethod.ts`) that owns the client side of invoking a Meteor method. Meteor's untyped `Meteor.callAsync` is wrapped exactly once so that error narrowing, failure-notification policy, success feedback, and in-flight `loading` state live behind one hook instead of being re-derived at every call site. It is the client-side counterpart to [[MutationWithAudit]]: that owns the server mutation lifecycle, this owns the client call.
+
+The seam is one hook:
+
+- **`useMethod<T>(name, opts?)`** — binds a method name (computed names like `isUpdate ? 'squads.update' : 'squads.insert'` are fine) and returns `{ call, loading, error, data }`.
+  - `call(...args)` invokes the method and resolves to a discriminated `Result<T> = { ok: true; data: T } | { ok: false; error: Meteor.Error }`. It does **not** throw for a server-side `Meteor.Error`; callers branch on `res.ok`. The discriminated shape (not a bare `T | undefined`) keeps void methods unambiguous — a `remove` that resolves to nothing is still `{ ok: true }`, distinct from a handled failure.
+  - On failure the hook narrows `unknown → Meteor.Error` once and fires `notification.error` (the persistent-panel channel) — unless `opts.notify === false`, the opt-out used by the field-availability validators (`members.validateName`, `registrations.validateId`, …) that fold a failure into a form-field state rather than a popup.
+  - On success it fires `message.success` (the toast channel) when `opts.success` is set — a string, or a `(data) => string` for create-vs-update message divergence. Reads omit `success`.
+  - `loading` / `error` / `data` are reactive (for button-disable and inline rendering); the same values are also carried by the `Result` that `call` returns, for use inside handlers.
+
+Channel convention is baked in: success → `message` (toast), failure → `notification` (panel). The hook calls `App.useApp()` internally, satisfying the provider-order rule (message/notification must resolve inside a descendant of `<App>`) — which is *why* the seam is a hook and not a free function.
+
+Internally the seam has a private core: `runMethodCall(invoke, policy, feedback)` (`imports/ui/hooks/runMethodCall.ts`) holds all the policy — narrowing, notify/success decisions, the discriminated outcome — with no React and no antd. `useMethod` is the thin adapter that wires React `loading`/`error`/`data` state and `App.useApp()` feedback onto it. That internal seam is what makes the policy testable in the server test context (`tests/server/runMethodCall.test.ts`, DOM-free), with the hook's React wiring covered by a browser-only smoke test (`tests/client/hooks/useMethod.test.tsx`) — the same split the [[DrawerStack]] uses (pure `drawerStackStore` + browser hook test).
+
+What the previous design could not express, now structural: the `error as Meteor.Error` cast (forced into every `catch` by `strict`) lives in one place; changing notification policy, adding telemetry, or adding retry is one edit instead of touching ~69 call sites; and the accidental error-extraction drift (`error.reason || error.message` at one site, a missing `as string` cast at two others) cannot recur because there is exactly one extraction — `{ message: error.error, description: error.reason || error.message }`, preferring the clean reason and dropping the `[<code>]` suffix Meteor appends to `.message`. The bespoke success *strings* stay at the call sites where they belong, so the hook is not a pass-through. The per-form create-vs-update branching of *name* and *message* is deliberately **not** absorbed here — that is the job of a future `useEntityForm` lifecycle built on top of this seam.
+
 ## Doctrines
 
 ### Rule of three

--- a/imports/ui/hooks/runMethodCall.ts
+++ b/imports/ui/hooks/runMethodCall.ts
@@ -1,0 +1,56 @@
+import type { Meteor } from 'meteor/meteor';
+
+/**
+ * Pure policy core of the MethodCall seam (see CONTEXT.md → MethodCall).
+ *
+ * Owns the decisions — error narrowing, when to notify, when to show success,
+ * and the discriminated outcome — with no React and no antd, so it is fully
+ * testable without a DOM. The `useMethod` hook is a thin adapter that wires
+ * React state and `App.useApp()` feedback onto this function.
+ */
+
+/**
+ * Discriminated outcome. Never a bare `T | undefined`, so a method that
+ * legitimately resolves to nothing (e.g. a `*.remove`) is an unambiguous
+ * `{ ok: true }` rather than indistinguishable from a failure.
+ */
+export type MethodResult<T> = { ok: true; data: T } | { ok: false; error: Meteor.Error };
+
+export interface MethodCallPolicy<T> {
+  /** Success toast text — a string, or a function of the result (for
+   *  create-vs-update message divergence). Omit for reads / silent calls. */
+  success?: string | ((data: T) => string);
+  /** When true (default), a failure invokes `feedback.notifyError`. Set false
+   *  for callers that fold failures into their own state (field validators). */
+  notify?: boolean;
+}
+
+/** Side-effect sink. The hook maps these onto antd's contextual message/notification. */
+export interface MethodCallFeedback {
+  notifySuccess: (content: string) => void;
+  notifyError: (content: { message: string; description: string }) => void;
+}
+
+export async function runMethodCall<T>(
+  invoke: () => Promise<unknown>,
+  policy: MethodCallPolicy<T>,
+  feedback: MethodCallFeedback
+): Promise<MethodResult<T>> {
+  const { success, notify = true } = policy;
+  try {
+    const data = (await invoke()) as T;
+    if (success !== undefined) {
+      feedback.notifySuccess(typeof success === 'function' ? success(data) : success);
+    }
+    return { ok: true, data };
+  } catch (caught) {
+    // The single place the unsafe Meteor.Error narrowing lives.
+    const error = caught as Meteor.Error;
+    if (notify) {
+      // Prefer the clean reason; fall back to the full message (which Meteor
+      // formats as "<reason> [<code>]") for errors that carry no reason.
+      feedback.notifyError({ message: error.error as string, description: error.reason || error.message });
+    }
+    return { ok: false, error };
+  }
+}

--- a/imports/ui/hooks/useMethod.ts
+++ b/imports/ui/hooks/useMethod.ts
@@ -1,0 +1,57 @@
+import { useCallback, useState } from 'react';
+import { Meteor } from 'meteor/meteor';
+import { App } from 'antd';
+import { runMethodCall, type MethodCallPolicy, type MethodResult } from './runMethodCall';
+
+/**
+ * The MethodCall seam — see CONTEXT.md → MethodCall.
+ *
+ * The single client-side adapter over Meteor's untyped `Meteor.callAsync`. It
+ * wires React `loading`/`error`/`data` state and antd's contextual feedback
+ * onto the pure `runMethodCall` policy core, so the `unknown → Meteor.Error`
+ * narrowing, the notify/success policy, and the discriminated result are not
+ * re-derived at the call site. The client-side counterpart to MutationWithAudit.
+ */
+
+export type { MethodResult } from './runMethodCall';
+export type UseMethodOptions<T> = MethodCallPolicy<T>;
+
+export interface UseMethod<T> {
+  call: (...args: unknown[]) => Promise<MethodResult<T>>;
+  loading: boolean;
+  error: Meteor.Error | null;
+  data: T | null;
+}
+
+export default function useMethod<T = unknown>(name: string, options: UseMethodOptions<T> = {}): UseMethod<T> {
+  // useApp() resolves the contextual message/notification instances — required
+  // so feedback renders inside drawers/modals (the static antd singletons do not).
+  const { message, notification } = App.useApp();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Meteor.Error | null>(null);
+  const [data, setData] = useState<T | null>(null);
+
+  const { success, notify } = options;
+
+  const call = useCallback(
+    async (...args: unknown[]): Promise<MethodResult<T>> => {
+      setLoading(true);
+      setError(null);
+      const result = await runMethodCall<T>(
+        () => Meteor.callAsync(name, ...args),
+        { success, notify },
+        {
+          notifySuccess: content => message.success(content),
+          notifyError: content => notification.error(content),
+        }
+      );
+      if (result.ok) setData(result.data);
+      else setError(result.error);
+      setLoading(false);
+      return result;
+    },
+    [name, success, notify, message, notification]
+  );
+
+  return { call, loading, error, data };
+}

--- a/tests/client/hooks/useMethod.test.tsx
+++ b/tests/client/hooks/useMethod.test.tsx
@@ -1,0 +1,173 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+
+// React-wiring smoke test for the MethodCall seam: proves the hook resolves
+// antd feedback via App.useApp() and reflects loading/error/data as state. The
+// exhaustive policy coverage lives in tests/server/runMethodCall.test.ts (pure,
+// DOM-free). This file only runs in the Meteor client test context (a browser).
+if (Meteor.isClient) {
+  const ReactDOMClient = require('react-dom/client') as typeof import('react-dom/client');
+  const { act } = require('react-dom/test-utils') as { act: (cb: () => void | Promise<void>) => Promise<void> };
+  const { App } = require('antd') as typeof import('antd');
+
+  type AntdApp = typeof import('antd').App;
+  type CapturedApi = ReturnType<AntdApp['useApp']>;
+
+  type UseMethodHook = typeof import('/imports/ui/hooks/useMethod').default;
+  type UseMethod<T> = import('/imports/ui/hooks/useMethod').UseMethod<T>;
+  type MethodResult<T> = import('/imports/ui/hooks/useMethod').MethodResult<T>;
+  const useMethod = (require('/imports/ui/hooks/useMethod') as { default: UseMethodHook }).default;
+
+  function makeSpy() {
+    const calls: unknown[][] = [];
+    const fn = (...args: unknown[]): unknown => {
+      calls.push(args);
+      return undefined;
+    };
+    return { fn, calls };
+  }
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(res => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  const realCallAsync = Meteor.callAsync.bind(Meteor);
+  function stubCallAsync(impl: (name: string, ...args: unknown[]) => Promise<unknown>) {
+    (Meteor as unknown as { callAsync: typeof Meteor.callAsync }).callAsync = impl as typeof Meteor.callAsync;
+  }
+  afterEach(() => {
+    (Meteor as unknown as { callAsync: typeof Meteor.callAsync }).callAsync = realCallAsync;
+  });
+
+  // Mount the hook under a real antd <App>, capturing the same message/
+  // notification instances the hook receives (antd memoizes the context value,
+  // so the sibling capturer and the hook share one object reference).
+  async function mountUseMethod<T>(name: string, options?: import('/imports/ui/hooks/useMethod').UseMethodOptions<T>) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const captured: { current: UseMethod<T> | null } = { current: null };
+    let api: CapturedApi | null = null;
+
+    function ApiCapture() {
+      api = App.useApp();
+      return null;
+    }
+    function Probe() {
+      captured.current = useMethod<T>(name, options);
+      return null;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(async () => {
+      root.render(
+        <App>
+          <ApiCapture />
+          <Probe />
+        </App>
+      );
+    });
+
+    return {
+      get current() {
+        return captured.current!;
+      },
+      get api() {
+        return api!;
+      },
+      unmount: async () => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      },
+    };
+  }
+
+  describe('useMethod — React wiring of the MethodCall seam', () => {
+    it('exposes { call, loading:false, error:null, data:null } initially', async () => {
+      stubCallAsync(async () => undefined);
+      const hook = await mountUseMethod('x.read');
+      assert.strictEqual(typeof hook.current.call, 'function');
+      assert.strictEqual(hook.current.loading, false);
+      assert.strictEqual(hook.current.error, null);
+      assert.strictEqual(hook.current.data, null);
+      await hook.unmount();
+    });
+
+    it('reflects success as reactive data and fires the contextual message.success', async () => {
+      stubCallAsync(async () => 'new-id');
+      const hook = await mountUseMethod<string>('squads.insert', { success: 'Saved' });
+      const successSpy = makeSpy();
+      hook.api.message.success = successSpy.fn as typeof hook.api.message.success;
+      let result: MethodResult<string> | undefined;
+      await act(async () => {
+        result = await hook.current.call({ name: 'Alpha' });
+      });
+      assert.deepStrictEqual(result, { ok: true, data: 'new-id' });
+      assert.strictEqual(hook.current.data, 'new-id');
+      assert.strictEqual(hook.current.error, null);
+      assert.deepStrictEqual(successSpy.calls, [['Saved']]);
+      await hook.unmount();
+    });
+
+    it('reflects a Meteor.Error as reactive error and fires the contextual notification.error', async () => {
+      const thrown = new Meteor.Error('forbidden', 'Not allowed');
+      stubCallAsync(async () => {
+        throw thrown;
+      });
+      const hook = await mountUseMethod('squads.update');
+      const errorSpy = makeSpy();
+      hook.api.notification.error = errorSpy.fn as typeof hook.api.notification.error;
+      let result: MethodResult<unknown> | undefined;
+      await act(async () => {
+        result = await hook.current.call('id', {});
+      });
+      assert.ok(result && result.ok === false);
+      assert.strictEqual(hook.current.error, thrown);
+      assert.deepStrictEqual(errorSpy.calls, [[{ message: 'forbidden', description: 'Not allowed' }]]);
+      await hook.unmount();
+    });
+
+    it('stays silent when notify:false but still reflects the error in state', async () => {
+      const thrown = new Meteor.Error('taken', 'Name taken');
+      stubCallAsync(async () => {
+        throw thrown;
+      });
+      const hook = await mountUseMethod('members.validateName', { notify: false });
+      const errorSpy = makeSpy();
+      hook.api.notification.error = errorSpy.fn as typeof hook.api.notification.error;
+      await act(async () => {
+        await hook.current.call('Bob', false);
+      });
+      assert.strictEqual(errorSpy.calls.length, 0);
+      assert.strictEqual(hook.current.error, thrown);
+      await hook.unmount();
+    });
+
+    it('toggles loading true during the call and false after it settles', async () => {
+      const pending = deferred<string>();
+      stubCallAsync(() => pending.promise);
+      const hook = await mountUseMethod<string>('squads.insert');
+
+      let callPromise: Promise<MethodResult<string>> | undefined;
+      await act(async () => {
+        callPromise = hook.current.call({});
+      });
+      // The call is in flight (callAsync unresolved) — loading must be true.
+      assert.strictEqual(hook.current.loading, true);
+
+      await act(async () => {
+        pending.resolve('id');
+        await callPromise;
+      });
+      assert.strictEqual(hook.current.loading, false);
+      assert.strictEqual(hook.current.data, 'id');
+      await hook.unmount();
+    });
+  });
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,6 +1,7 @@
 import './client/config.test';
 import './client/hooks/drawerStackHooks.test';
 import './client/hooks/drawerStackStore.test';
+import './client/hooks/useMethod.test';
 import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
 import './helpers/colors/hexToRgb.test';
@@ -21,6 +22,7 @@ import './server/paletteScoring.test';
 import './server/paletteSearch.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
+import './server/runMethodCall.test';
 import './server/settingsMethods.test';
 import './server/shouldConfirmTemplateOverwrite.test';
 import './server/specializationsMethods.test';

--- a/tests/server/runMethodCall.test.ts
+++ b/tests/server/runMethodCall.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import { runMethodCall, type MethodCallFeedback } from '/imports/ui/hooks/runMethodCall';
+
+// Pure policy core of the MethodCall seam — no React, no DOM, so it runs in the
+// server test context (unlike the browser-only useMethod hook wiring test).
+
+function makeSpy() {
+  const calls: unknown[][] = [];
+  const fn = (...args: unknown[]): void => {
+    calls.push(args);
+  };
+  return { fn, calls };
+}
+
+function makeFeedback() {
+  const success = makeSpy();
+  const error = makeSpy();
+  const feedback: MethodCallFeedback = {
+    notifySuccess: content => success.fn(content),
+    notifyError: content => error.fn(content),
+  };
+  return { feedback, success, error };
+}
+
+describe('runMethodCall — the MethodCall policy core', () => {
+  it('resolves { ok:true, data } on success', async () => {
+    const { feedback } = makeFeedback();
+    const result = await runMethodCall<string>(async () => 'new-id', {}, feedback);
+    assert.deepStrictEqual(result, { ok: true, data: 'new-id' });
+  });
+
+  it('treats a method resolving to undefined as ok (void method, not a failure)', async () => {
+    const { feedback } = makeFeedback();
+    const result = await runMethodCall(async () => undefined, {}, feedback);
+    // The discriminated shape is the whole point: void success !== failure.
+    assert.deepStrictEqual(result, { ok: true, data: undefined });
+  });
+
+  it('notifies success with a static string', async () => {
+    const { feedback, success } = makeFeedback();
+    await runMethodCall(async () => 'id', { success: 'Saved' }, feedback);
+    assert.deepStrictEqual(success.calls, [['Saved']]);
+  });
+
+  it('notifies success with a (data)=>string function of the result', async () => {
+    const { feedback, success } = makeFeedback();
+    await runMethodCall<string>(async () => 'created-id', { success: data => `made ${data}` }, feedback);
+    assert.deepStrictEqual(success.calls, [['made created-id']]);
+  });
+
+  it('does not notify success when no success option is given (reads)', async () => {
+    const { feedback, success } = makeFeedback();
+    await runMethodCall(async () => [{ value: 'a' }], {}, feedback);
+    assert.strictEqual(success.calls.length, 0);
+  });
+
+  it('resolves { ok:false, error } WITHOUT throwing on a Meteor.Error', async () => {
+    const { feedback } = makeFeedback();
+    const thrown = new Meteor.Error('forbidden', 'Not allowed');
+    const result = await runMethodCall(
+      async () => {
+        throw thrown;
+      },
+      {},
+      feedback
+    );
+    assert.ok(result.ok === false);
+    assert.strictEqual(result.error, thrown);
+  });
+
+  it('notifies error with err.error as message and the clean err.reason as description', async () => {
+    const { feedback, error } = makeFeedback();
+    const thrown = new Meteor.Error('forbidden', 'Not allowed');
+    await runMethodCall(
+      async () => {
+        throw thrown;
+      },
+      {},
+      feedback
+    );
+    // One canonical extraction: message = err.error (the code); description =
+    // the clean reason, dropping the "[<code>]" suffix Meteor appends to .message.
+    assert.deepStrictEqual(error.calls, [[{ message: 'forbidden', description: 'Not allowed' }]]);
+  });
+
+  it('falls back to err.message for the description when the error carries no reason', async () => {
+    const { feedback, error } = makeFeedback();
+    const thrown = new Meteor.Error('boom');
+    await runMethodCall(
+      async () => {
+        throw thrown;
+      },
+      {},
+      feedback
+    );
+    assert.deepStrictEqual(error.calls, [[{ message: 'boom', description: thrown.message }]]);
+  });
+
+  it('stays silent when notify:false, but still returns { ok:false, error }', async () => {
+    const { feedback, error } = makeFeedback();
+    const thrown = new Meteor.Error('taken', 'Name taken');
+    const result = await runMethodCall(
+      async () => {
+        throw thrown;
+      },
+      { notify: false },
+      feedback
+    );
+    assert.strictEqual(error.calls.length, 0);
+    assert.ok(result.ok === false);
+    assert.strictEqual(result.error, thrown);
+  });
+
+  it('does not notify success on failure, nor error on success', async () => {
+    const ok = makeFeedback();
+    await runMethodCall(async () => 'id', { success: 'Saved' }, ok.feedback);
+    assert.strictEqual(ok.error.calls.length, 0);
+
+    const bad = makeFeedback();
+    await runMethodCall(
+      async () => {
+        throw new Meteor.Error('x', 'y');
+      },
+      { success: 'Saved' },
+      bad.feedback
+    );
+    assert.strictEqual(bad.success.calls.length, 0);
+  });
+});


### PR DESCRIPTION
## What

Adds the **MethodCall** seam — the client-side counterpart to the server `MutationWithAudit` pipeline. Meteor's untyped `Meteor.callAsync` is wrapped exactly once so that error narrowing, failure-notification policy, success feedback, and in-flight `loading` state live behind one hook instead of being re-derived at each of ~69 call sites.

See `CONTEXT.md → MethodCall` for the full contract.

## Shape

- **`runMethodCall(invoke, policy, feedback)`** (`imports/ui/hooks/runMethodCall.ts`) — the pure policy core. Holds the discriminated `MethodResult<T> = { ok: true; data: T } | { ok: false; error: Meteor.Error }`, the notify/success decisions, and the single error extraction. No React, no antd, so it is fully testable without a DOM.
- **`useMethod<T>(name, opts?)`** (`imports/ui/hooks/useMethod.ts`) — the thin React adapter. Wires `loading`/`error`/`data` state and resolves contextual `message`/`notification` via `App.useApp()` (which is *why* the seam is a hook, not a free function — the provider-order rule).

Conventions baked in: success → `message.success` (toast) when `opts.success` is set; failure → `notification.error` (panel) unless `opts.notify === false`. One canonical extraction — `{ message: error.error, description: error.reason || error.message }` — preferring the clean reason and dropping the `[<code>]` suffix Meteor appends to `.message`.

## Tests

Mirrors the DrawerStack store/hook split:
- `tests/server/runMethodCall.test.ts` — 10 tests covering the policy core, server-runnable (so they execute under `npm test`, which has no browser driver).
- `tests/client/hooks/useMethod.test.tsx` — 5 browser-only React-wiring smoke tests.

## Scope

This lands the seam on its own. Migrating the existing call sites is tracked separately:

- Epic: #241
- Unblocks #242 (read sites), #243 (mutation sites), #244 (validator sites) — all gated on this merging to `main`.

## Verification

- `npm run typecheck` — clean
- `npm test` — 374 passing, 0 failing
