### PR TITLE
refactor(ui): route read-only call sites through useMethod

### DIFF
--- a/imports/ui/dashboard/Dashboard.tsx
+++ b/imports/ui/dashboard/Dashboard.tsx
@@ -1,8 +1,8 @@
-import { App, Button, Card, Col, Collapse, Descriptions, Row, Statistic, Tag, Typography } from 'antd';
-import { Meteor } from 'meteor/meteor';
+import { Button, Card, Col, Collapse, Descriptions, Row, Statistic, Tag, Typography } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { LocaleKey } from '../../i18n';
+import useMethod from '../hooks/useMethod';
 import { useTourRef } from '../tour/TourContext';
 
 // Closed maps from server-data keys to LocaleKeys. `as const satisfies` preserves
@@ -71,23 +71,23 @@ interface DashboardStats {
 }
 
 export default function Dashboard() {
-  const { message } = App.useApp();
   const [stats, setStats] = useState<DashboardStats>({});
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
   const statsRef = useTourRef('dashboard-stats');
-  const fetchStats = useCallback(function () {
-    setLoading(true);
-    Meteor.callAsync('dashboard.stats')
-      .then((data: DashboardStats) => setStats(data))
-      .catch(() => {
-        message.error('Failed to load dashboard stats');
-      })
-      .finally(() => setLoading(false));
-  }, [message]);
+  const { call } = useMethod<DashboardStats>('dashboard.stats');
+  const fetchStats = useCallback(
+    function () {
+      setLoading(true);
+      call()
+        .then(res => res.ok && setStats(res.data))
+        .finally(() => setLoading(false));
+    },
+    [call]
+  );
   useEffect(() => {
     fetchStats();
-  }, []);
+  }, [fetchStats]);
 
   return (
     <div ref={statsRef}>
@@ -95,59 +95,59 @@ export default function Dashboard() {
         type="inner"
         loading={loading}
         title={
-        <Row justify="space-between" align="middle">
-          <Col>
-            <Typography.Title level={3}>{t('dashboard.title')}</Typography.Title>
-          </Col>
-          <Col>
-            <Button disabled={loading} onClick={fetchStats} type="primary">
-              {t('dashboard.refresh')}
-            </Button>
-          </Col>
-        </Row>
-      }
-    >
-      <Collapse
-        defaultActiveKey={['1', '2']}
-        items={[
-          {
-            key: '1',
-            label: t('dashboard.yourProfile'),
-            children: <ProfileStats profileStats={stats.profile} />,
-          },
-          {
-            key: '2',
-            label: t('dashboard.collectionStats'),
-            children: (
-              <Row gutter={[16, 16]}>
-                {Object.entries(stats).flatMap(([key, value]) => {
-                  if (key === 'profile') return [];
-                  const translateStatKey = (k: string): string => {
-                    const labelKey = STATS_LABEL_KEYS[k as keyof typeof STATS_LABEL_KEYS];
-                    return labelKey ? t(labelKey) : k;
-                  };
-                  if (typeof value === 'object') {
-                    return Object.keys(value as Record<string, number>).map(childKey => (
-                      <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
+          <Row justify="space-between" align="middle">
+            <Col>
+              <Typography.Title level={3}>{t('dashboard.title')}</Typography.Title>
+            </Col>
+            <Col>
+              <Button disabled={loading} onClick={fetchStats} type="primary">
+                {t('dashboard.refresh')}
+              </Button>
+            </Col>
+          </Row>
+        }
+      >
+        <Collapse
+          defaultActiveKey={['1', '2']}
+          items={[
+            {
+              key: '1',
+              label: t('dashboard.yourProfile'),
+              children: <ProfileStats profileStats={stats.profile} />,
+            },
+            {
+              key: '2',
+              label: t('dashboard.collectionStats'),
+              children: (
+                <Row gutter={[16, 16]}>
+                  {Object.entries(stats).flatMap(([key, value]) => {
+                    if (key === 'profile') return [];
+                    const translateStatKey = (k: string): string => {
+                      const labelKey = STATS_LABEL_KEYS[k as keyof typeof STATS_LABEL_KEYS];
+                      return labelKey ? t(labelKey) : k;
+                    };
+                    if (typeof value === 'object') {
+                      return Object.keys(value as Record<string, number>).map(childKey => (
+                        <Col xs={24} md={12} lg={8} xxl={6} key={childKey}>
+                          <Card variant="outlined">
+                            <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={(value as Record<string, number>)[childKey]} />
+                          </Card>
+                        </Col>
+                      ));
+                    }
+                    return [
+                      <Col xs={24} md={12} lg={8} xxl={6} key={key}>
                         <Card variant="outlined">
-                          <Statistic title={`${translateStatKey(key)}: ${childKey}`} value={(value as Record<string, number>)[childKey]} />
+                          <Statistic title={translateStatKey(key)} value={value as number} />
                         </Card>
-                      </Col>
-                    ));
-                  }
-                  return [
-                    <Col xs={24} md={12} lg={8} xxl={6} key={key}>
-                      <Card variant="outlined">
-                        <Statistic title={translateStatKey(key)} value={value as number} />
-                      </Card>
-                    </Col>,
-                  ];
-                })}
-              </Row>
-            ),
-          },
-        ]}
-      />
+                      </Col>,
+                    ];
+                  })}
+                </Row>
+              ),
+            },
+          ]}
+        />
       </Card>
     </div>
   );
@@ -167,7 +167,7 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
       const labelKey = PROFILE_LABEL_KEYS[key as keyof typeof PROFILE_LABEL_KEYS];
       return labelKey ? t(labelKey) : key;
     },
-    [t],
+    [t]
   );
 
   return (
@@ -194,9 +194,7 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
             lg: 3,
           }}
           items={Object.entries(profileStats ?? {}).flatMap(([key, value]) =>
-            oneThirdWidthKeys.includes(key)
-              ? [{ label: translateLabel(key), children: value as React.ReactNode }]
-              : []
+            oneThirdWidthKeys.includes(key) ? [{ label: translateLabel(key), children: value as React.ReactNode }] : []
           )}
           bordered
         />
@@ -216,7 +214,9 @@ export function ProfileStats({ profileStats }: ProfileStatsProps) {
                 ? (value as Specialization[]).map(spec =>
                     spec.linkToFile ? (
                       <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
-                        <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
+                        <Tag color="blue" style={{ cursor: 'pointer' }}>
+                          {spec.name}
+                        </Tag>
                       </a>
                     ) : (
                       <Tag key={spec.name}>{spec.name}</Tag>

--- a/imports/ui/events/EventAttendance.tsx
+++ b/imports/ui/events/EventAttendance.tsx
@@ -12,6 +12,7 @@ import RanksCollection from '../../api/collections/ranks.collection';
 import type { AttendanceStatus } from '../../api/types/shared';
 import type { EventDoc } from '../../api/types/event';
 import { useTranslation } from '../../i18n/LanguageContext';
+import useMethod from '../hooks/useMethod';
 import type { TranslateFn } from '../section/types';
 import TableContainer from '../table/body/TableContainer';
 import Table from '../table/Table';
@@ -77,23 +78,19 @@ interface AttendanceSelectProps {
 function AttendanceSelect({ value, eventId, memberId, setEditting }: AttendanceSelectProps) {
   const { t } = useTranslation();
   const { notification } = App.useApp();
-  const handleChange = (newValue: AttendanceStatus) => {
+  const { call: readAttendance } = useMethod<Array<{ _id: string }>>('attendances.read');
+  const handleChange = async (newValue: AttendanceStatus) => {
     if (value === newValue) return;
-    Meteor.callAsync('attendances.read', { eventId }, { limit: 1 })
-      .then(res => {
-        const attendanceRes = res as Array<{ _id: string }>;
-        const endpoint = attendanceRes.length ? 'attendances.update' : 'attendances.insert';
-        const args = attendanceRes.length
-          ? [attendanceRes[0]._id, { [memberId]: newValue }]
-          : [{ eventId, [memberId]: newValue }];
-        return Meteor.callAsync(endpoint, ...args);
-      })
-      .catch((error: Meteor.Error) => {
-        notification.error({
-          message: t('common.error'),
-          description: error.reason || error.message,
-        });
-      });
+    const res = await readAttendance({ eventId }, { limit: 1 });
+    if (!res.ok) return;
+    const endpoint = res.data.length ? 'attendances.update' : 'attendances.insert';
+    const args = res.data.length ? [res.data[0]._id, { [memberId]: newValue }] : [{ eventId, [memberId]: newValue }];
+    try {
+      await Meteor.callAsync(endpoint, ...args);
+    } catch (error) {
+      const err = error as Meteor.Error;
+      notification.error({ message: t('common.error'), description: err.reason || err.message });
+    }
   };
 
   const options = useMemo(
@@ -198,10 +195,7 @@ export default function EventAttendance({ datasource }: EventAttendanceProps) {
   const { t } = useTranslation();
   // Attendance grid needs all members and attendances for the selected events
   useSubscribe('attendances', { eventId: { $in: datasource.map(event => event._id) } }, { limit: 1000 });
-  const attendances = useFind(
-    () => AttendancesCollection.find({ eventId: { $in: datasource.map(event => event._id) as string[] } }),
-    [datasource]
-  );
+  const attendances = useFind(() => AttendancesCollection.find({ eventId: { $in: datasource.map(event => event._id) as string[] } }), [datasource]);
 
   // Get unique attendee IDs from datasource events to filter members subscription
   const attendeeIds = useMemo(() => {
@@ -214,7 +208,10 @@ export default function EventAttendance({ datasource }: EventAttendanceProps) {
   }, [datasource]);
   useSubscribe('members', attendeeIds.length ? { _id: { $in: attendeeIds } } : {}, {});
   const members = useFind(
-    () => MembersCollection.find(attendeeIds.length ? { _id: { $in: attendeeIds } } : {}, { sort: { 'profile.squadId': 1, 'profile.rankId': 1 } } as Mongo.Options<Meteor.User>),
+    () =>
+      MembersCollection.find(attendeeIds.length ? { _id: { $in: attendeeIds } } : {}, {
+        sort: { 'profile.squadId': 1, 'profile.rankId': 1 },
+      } as Mongo.Options<Meteor.User>),
     [attendeeIds]
   );
   useSubscribe('ranks', {}, {});
@@ -251,9 +248,7 @@ export default function EventAttendance({ datasource }: EventAttendanceProps) {
         memberId: member._id,
         ...datasource.reduce<Record<string, AttendanceStatus | null | undefined>>((acc, event) => {
           const attendanceDoc = attendances.find(a => a.eventId === event._id);
-          acc[event._id as string] = attendanceDoc
-            ? (attendanceDoc[member._id] as AttendanceStatus | undefined)
-            : undefined;
+          acc[event._id as string] = attendanceDoc ? (attendanceDoc[member._id] as AttendanceStatus | undefined) : undefined;
           return acc;
         }, {}),
       } as AttendanceRow;

--- a/imports/ui/events/EventDetailPopover.tsx
+++ b/imports/ui/events/EventDetailPopover.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { EventDoc } from '../../api/types/event';
 import RichTextView from '../components/RichTextView';
+import useMethod from '../hooks/useMethod';
 
 interface ResolvedMember {
   _id: string;
@@ -33,14 +34,15 @@ export default function EventDetailPopover({ event, open, setOpen, onEdit }: Eve
   const [loading, setLoading] = useState(false);
   const [rsvpLoading, setRsvpLoading] = useState(false);
   const currentUserId = useTracker(() => Meteor.userId(), []);
+  const { call: fetchDetail } = useMethod<EventDetail>('events.detail');
 
   useEffect(() => {
     if (!event?._id || !open) return;
     setLoading(true);
-    Meteor.callAsync('events.detail', event._id)
-      .then(data => setDetail(data as EventDetail))
+    fetchDetail(event._id)
+      .then(res => res.ok && setDetail(res.data))
       .finally(() => setLoading(false));
-  }, [event?._id, open]);
+  }, [event?._id, open, fetchDetail]);
 
   const handleRsvp = useCallback(() => {
     if (!event?._id) return;
@@ -69,9 +71,7 @@ export default function EventDetailPopover({ event, open, setOpen, onEdit }: Eve
       footer={
         <Space>
           <Button onClick={handleClose}>{t('common.cancel')}</Button>
-          {onEdit && (
-            <Button onClick={handleEdit}>{t('common.edit')}</Button>
-          )}
+          {onEdit && <Button onClick={handleEdit}>{t('common.edit')}</Button>}
           <Button type="primary" loading={rsvpLoading} onClick={handleRsvp} danger={isSignedUp}>
             {isSignedUp ? t('events.signOff') : t('events.signUp')}
           </Button>
@@ -96,15 +96,9 @@ export default function EventDetailPopover({ event, open, setOpen, onEdit }: Eve
               <Descriptions.Item label={t('events.startDate')}>
                 {detail.start ? dayjs(detail.start).format('YYYY-MM-DD HH:mm') : '-'}
               </Descriptions.Item>
-              <Descriptions.Item label={t('events.endDate')}>
-                {detail.end ? dayjs(detail.end).format('YYYY-MM-DD HH:mm') : '-'}
-              </Descriptions.Item>
-              <Descriptions.Item label={t('events.hosts')}>
-                {detail.resolvedHosts?.map(h => h.name).join(', ') || '-'}
-              </Descriptions.Item>
-              <Descriptions.Item label={t('events.attendeeCount')}>
-                {detail.resolvedAttendees?.length || 0}
-              </Descriptions.Item>
+              <Descriptions.Item label={t('events.endDate')}>{detail.end ? dayjs(detail.end).format('YYYY-MM-DD HH:mm') : '-'}</Descriptions.Item>
+              <Descriptions.Item label={t('events.hosts')}>{detail.resolvedHosts?.map(h => h.name).join(', ') || '-'}</Descriptions.Item>
+              <Descriptions.Item label={t('events.attendeeCount')}>{detail.resolvedAttendees?.length || 0}</Descriptions.Item>
               {detail.description && (
                 <Descriptions.Item label={t('common.description')}>
                   <RichTextView html={detail.description} />

--- a/imports/ui/events/EventForm.tsx
+++ b/imports/ui/events/EventForm.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
 import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
 import CollectionSelect from '../components/CollectionSelect';
+import useMethod from '../hooks/useMethod';
 import MembersSelect from '../members/MembersSelect';
 import RichTextEditor from '../components/RichTextEditor';
 import shouldConfirmTemplateOverwrite from '/imports/helpers/shouldConfirmTemplateOverwrite';
@@ -182,7 +183,7 @@ interface SquadQuickAddProps {
 const SquadQuickAdd = ({ form, t }: SquadQuickAddProps) => {
   const [selectedSquad, setSelectedSquad] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
-  const { notification } = App.useApp();
+  const { call: readMembers } = useMethod<Array<{ _id: string }>>('members.read');
   useSubscribe('squads', {}, {});
   const squads = useFind(() => SquadsCollection.find({}), []);
   const squadOptions = useMemo(() => squads.map(s => ({ label: s.name, value: s._id })), [squads]);
@@ -199,27 +200,17 @@ const SquadQuickAdd = ({ form, t }: SquadQuickAddProps) => {
   const handleAddSquad = useCallback(async () => {
     if (!selectedSquad) return;
     setLoading(true);
-    try {
-      const members = (await Meteor.callAsync('members.read', { 'profile.squadId': selectedSquad }, { fields: { _id: 1 } })) as Array<{
-        _id: string;
-      }>;
-      mergeAttendees(members.map(m => m._id));
-    } catch (error) {
-      notification.error({ message: (error as Meteor.Error).error, description: (error as Meteor.Error).message });
-    }
+    const res = await readMembers({ 'profile.squadId': selectedSquad }, { fields: { _id: 1 } });
+    if (res.ok) mergeAttendees(res.data.map(m => m._id));
     setLoading(false);
-  }, [selectedSquad, mergeAttendees, notification]);
+  }, [selectedSquad, mergeAttendees, readMembers]);
 
   const handleAddAll = useCallback(async () => {
     setLoading(true);
-    try {
-      const members = (await Meteor.callAsync('members.read', {}, { fields: { _id: 1 } })) as Array<{ _id: string }>;
-      mergeAttendees(members.map(m => m._id));
-    } catch (error) {
-      notification.error({ message: (error as Meteor.Error).error, description: (error as Meteor.Error).message });
-    }
+    const res = await readMembers({}, { fields: { _id: 1 } });
+    if (res.ok) mergeAttendees(res.data.map(m => m._id));
     setLoading(false);
-  }, [mergeAttendees, notification]);
+  }, [mergeAttendees, readMembers]);
 
   return (
     <Row gutter={[8, 8]} style={{ marginBottom: 16 }} align="middle">

--- a/imports/ui/footer/Footer.tsx
+++ b/imports/ui/footer/Footer.tsx
@@ -5,27 +5,29 @@ import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import React, { useEffect, useState } from 'react';
 import useUserMenu from '../components/useUserMenu';
+import useMethod from '../hooks/useMethod';
+
+interface ProfilePictureDoc {
+  value: string;
+}
 
 export default function Footer() {
   const breakpoints = Grid.useBreakpoint();
   const user = useTracker(() => Meteor.user(), []);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const { actionItems, handleAction, profileModal } = useUserMenu();
+  const { call: fetchProfilePicture } = useMethod<ProfilePictureDoc[]>('profilePictures.read');
 
   useEffect(() => {
     const profilePictureId = user?.profile?.profilePictureId;
     if (profilePictureId && typeof profilePictureId === 'string') {
-      Meteor.callAsync('profilePictures.read', { _id: profilePictureId })
-        .then(res => {
-          if (res?.[0]) {
-            setImageSrc(res[0].value);
-          }
-        })
-        .catch(() => {});
+      fetchProfilePicture({ _id: profilePictureId }).then(res => {
+        if (res.ok && res.data[0]) setImageSrc(res.data[0].value);
+      });
     } else {
       setImageSrc(null);
     }
-  }, [user?.profile?.profilePictureId]);
+  }, [user?.profile?.profilePictureId, fetchProfilePicture]);
 
   if (!user) {
     return <></>;

--- a/imports/ui/members/MemberProfile.tsx
+++ b/imports/ui/members/MemberProfile.tsx
@@ -3,6 +3,7 @@ import type { DefaultOptionType } from 'antd/es/select';
 import { Meteor } from 'meteor/meteor';
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
+import useMethod from '../hooks/useMethod';
 import { useTourRef } from '../tour/TourContext';
 
 // recharts ships ~100 KB into the initial bundle even though pie charts only
@@ -65,21 +66,22 @@ export default function MemberProfile({ memberId }: MemberProfileProps) {
 
   const isOwnProfile = useMemo(() => memberId === Meteor.userId(), [memberId]);
 
+  const { call: fetchProfileStats } = useMethod<ProfileStats>('members.profileStats');
+  const { call: fetchProfileAccess } = useMethod<ProfileAccess>('members.profileAccess');
+  const { call: fetchAttendanceBreakdown } = useMethod<AttendanceBreakdown>('members.attendanceBreakdown');
+  const { call: fetchSpecOptions } = useMethod<DefaultOptionType[]>('specializations.options');
+
   useEffect(() => {
     if (!memberId) return;
     setLoading(true);
-    Promise.all([
-      Meteor.callAsync('members.profileStats', memberId),
-      Meteor.callAsync('members.profileAccess', memberId),
-      Meteor.callAsync('members.attendanceBreakdown', memberId),
-    ])
+    Promise.all([fetchProfileStats(memberId), fetchProfileAccess(memberId), fetchAttendanceBreakdown(memberId)])
       .then(([stats, accessResult, breakdownResult]) => {
-        setProfileStats(stats as ProfileStats);
-        setAccess(accessResult as ProfileAccess);
-        setBreakdown(breakdownResult as AttendanceBreakdown);
+        if (stats.ok) setProfileStats(stats.data);
+        if (accessResult.ok) setAccess(accessResult.data);
+        if (breakdownResult.ok) setBreakdown(breakdownResult.data);
       })
       .finally(() => setLoading(false));
-  }, [memberId]);
+  }, [memberId, fetchProfileStats, fetchProfileAccess, fetchAttendanceBreakdown]);
 
   const handleRequestSpec = useCallback(async () => {
     if (!selectedSpec) return;
@@ -95,15 +97,11 @@ export default function MemberProfile({ memberId }: MemberProfileProps) {
   }, [selectedSpec, message, notification, t]);
 
   const openSpecModal = useCallback(async () => {
-    try {
-      const options = await Meteor.callAsync('specializations.options');
-      setSpecOptions(options as DefaultOptionType[]);
-      setSpecModalOpen(true);
-    } catch (error) {
-      const err = error as Meteor.Error;
-      notification.error({ message: err.error as string, description: err.message });
-    }
-  }, [notification]);
+    const res = await fetchSpecOptions();
+    if (!res.ok) return;
+    setSpecOptions(res.data);
+    setSpecModalOpen(true);
+  }, [fetchSpecOptions]);
 
   if (loading) {
     return (
@@ -119,187 +117,196 @@ export default function MemberProfile({ memberId }: MemberProfileProps) {
 
   return (
     <div ref={profileRef}>
-    <Row gutter={[16, 16]}>
-      {/* Header: Profile Picture + Basic Info */}
-      <Col xs={24} md={8}>
-        <Card variant="outlined">
-          <Row justify="center">
-            <Col>
-              {profileStats['profile picture'] && profileStats['profile picture'] !== '-' ? (
-                <img
-                  style={{ borderRadius: '50%', width: '100%', maxWidth: 200, maxHeight: 200 }}
-                  src={profileStats['profile picture']}
-                  alt={profileStats.name}
-                />
-              ) : (
-                <div
-                  style={{
-                    borderRadius: '50%',
-                    width: 200,
-                    height: 200,
-                    background: profileStats.rankColor || '#ccc',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 48,
-                    color: '#fff',
-                  }}
-                >
-                  {profileStats.name?.[0] || '?'}
-                </div>
-              )}
-            </Col>
-          </Row>
-          <Row justify="center" style={{ marginTop: 12 }}>
-            <Typography.Title level={4} style={{ margin: 0 }}>
-              {`${profileStats.rank}-${profileStats.id} "${profileStats.name}"`}
-            </Typography.Title>
-          </Row>
-        </Card>
-      </Col>
+      <Row gutter={[16, 16]}>
+        {/* Header: Profile Picture + Basic Info */}
+        <Col xs={24} md={8}>
+          <Card variant="outlined">
+            <Row justify="center">
+              <Col>
+                {profileStats['profile picture'] && profileStats['profile picture'] !== '-' ? (
+                  <img
+                    style={{ borderRadius: '50%', width: '100%', maxWidth: 200, maxHeight: 200 }}
+                    src={profileStats['profile picture']}
+                    alt={profileStats.name}
+                  />
+                ) : (
+                  <div
+                    style={{
+                      borderRadius: '50%',
+                      width: 200,
+                      height: 200,
+                      background: profileStats.rankColor || '#ccc',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 48,
+                      color: '#fff',
+                    }}
+                  >
+                    {profileStats.name?.[0] || '?'}
+                  </div>
+                )}
+              </Col>
+            </Row>
+            <Row justify="center" style={{ marginTop: 12 }}>
+              <Typography.Title level={4} style={{ margin: 0 }}>
+                {`${profileStats.rank}-${profileStats.id} "${profileStats.name}"`}
+              </Typography.Title>
+            </Row>
+          </Card>
+        </Col>
 
-      {/* Info Section */}
-      <Col xs={24} md={16}>
-        <Descriptions
-          layout="vertical"
-          size="small"
-          column={{ sm: 1, lg: 3 }}
-          bordered
-          items={[
-            { label: t('members.squad'), children: profileStats.squad },
-            { label: t('members.rank'), children: profileStats.rank },
-            { label: t('forms.labels.navyRank'), children: profileStats.navyRank },
-            { label: t('members.entryDate'), children: profileStats['entry date'] },
-            { label: t('columns.id'), children: profileStats.id },
-            { label: t('common.name'), children: profileStats.name },
-            { label: t('members.roles'), children: profileStats.role },
-            ...(profileStats.position && profileStats.position !== '-'
-              ? [{ label: t('members.position'), children: <Tag color={profileStats.positionColor}>{profileStats.position}</Tag> }]
-              : []),
-          ]}
-        />
-      </Col>
-
-      {/* Stats */}
-      <Col xs={24}>
-        <Card title={t('events.attendance')} variant="outlined" size="small">
-          <Row gutter={[16, 16]}>
-            <Col xs={12} md={6}>
-              <Statistic title={t('events.attendancePoints')} value={profileStats['attendance points']} />
-            </Col>
-            <Col xs={12} md={6}>
-              <Statistic title={t('events.inactivityPoints')} value={profileStats['inactivity points']} />
-            </Col>
-            {breakdown && (
-              <>
-                <Col xs={12} md={6}>
-                  <Statistic title={t('members.missionCount')} value={breakdown.missionCount} />
-                </Col>
-                <Col xs={24} md={12}>
-                  <Suspense fallback={<Spin size="small" />}>
-                    <AttendancePieChart data={breakdown.total} title={t('members.attendanceOverall')} />
-                  </Suspense>
-                </Col>
-                <Col xs={24} md={12}>
-                  <Suspense fallback={<Spin size="small" />}>
-                    <AttendancePieChart data={breakdown.quarterly} title={t('members.attendanceQuarterly')} />
-                  </Suspense>
-                </Col>
-              </>
-            )}
-          </Row>
-        </Card>
-      </Col>
-
-      {/* Qualifications */}
-      <Col xs={24}>
-        <Card
-          title={t('members.qualifications')}
-          variant="outlined"
-          size="small"
-          extra={isOwnProfile && <Button size="small" onClick={openSpecModal}>{t('members.requestSpecialization')}</Button>}
-        >
+        {/* Info Section */}
+        <Col xs={24} md={16}>
           <Descriptions
             layout="vertical"
             size="small"
-            column={1}
+            column={{ sm: 1, lg: 3 }}
             bordered
             items={[
-              {
-                label: t('members.specializations'),
-                children: Array.isArray(profileStats.specializations) && profileStats.specializations.length > 0
-                  ? profileStats.specializations.map(spec =>
-                      spec.linkToFile ? (
-                        <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
-                          <Tag color="blue" style={{ cursor: 'pointer' }}>{spec.name}</Tag>
-                        </a>
-                      ) : (
-                        <Tag key={spec.name}>{spec.name}</Tag>
-                      )
-                    )
-                  : '-',
-              },
-              { label: t('members.medals'), children: profileStats.medals || '-' },
+              { label: t('members.squad'), children: profileStats.squad },
+              { label: t('members.rank'), children: profileStats.rank },
+              { label: t('forms.labels.navyRank'), children: profileStats.navyRank },
+              { label: t('members.entryDate'), children: profileStats['entry date'] },
+              { label: t('columns.id'), children: profileStats.id },
+              { label: t('common.name'), children: profileStats.name },
+              { label: t('members.roles'), children: profileStats.role },
+              ...(profileStats.position && profileStats.position !== '-'
+                ? [{ label: t('members.position'), children: <Tag color={profileStats.positionColor}>{profileStats.position}</Tag> }]
+                : []),
             ]}
           />
-        </Card>
-      </Col>
+        </Col>
 
-      {/* Description */}
-      {profileStats.description && profileStats.description !== '-' && (
+        {/* Stats */}
         <Col xs={24}>
-          <Card title={t('common.description')} variant="outlined" size="small">
-            <Typography.Paragraph style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{profileStats.description}</Typography.Paragraph>
+          <Card title={t('events.attendance')} variant="outlined" size="small">
+            <Row gutter={[16, 16]}>
+              <Col xs={12} md={6}>
+                <Statistic title={t('events.attendancePoints')} value={profileStats['attendance points']} />
+              </Col>
+              <Col xs={12} md={6}>
+                <Statistic title={t('events.inactivityPoints')} value={profileStats['inactivity points']} />
+              </Col>
+              {breakdown && (
+                <>
+                  <Col xs={12} md={6}>
+                    <Statistic title={t('members.missionCount')} value={breakdown.missionCount} />
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Suspense fallback={<Spin size="small" />}>
+                      <AttendancePieChart data={breakdown.total} title={t('members.attendanceOverall')} />
+                    </Suspense>
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Suspense fallback={<Spin size="small" />}>
+                      <AttendancePieChart data={breakdown.quarterly} title={t('members.attendanceQuarterly')} />
+                    </Suspense>
+                  </Col>
+                </>
+              )}
+            </Row>
           </Card>
         </Col>
-      )}
 
-      {/* Contact Info (conditionally shown) */}
-      {access.canViewContact && (
+        {/* Qualifications */}
         <Col xs={24}>
-          <Card title={t('members.contactInfo')} variant="outlined" size="small">
+          <Card
+            title={t('members.qualifications')}
+            variant="outlined"
+            size="small"
+            extra={
+              isOwnProfile && (
+                <Button size="small" onClick={openSpecModal}>
+                  {t('members.requestSpecialization')}
+                </Button>
+              )
+            }
+          >
             <Descriptions
               layout="vertical"
               size="small"
-              column={{ sm: 1, lg: 2 }}
+              column={1}
               bordered
               items={[
                 {
-                  label: t('members.steamProfile'),
-                  children: profileStats.steamProfileLink ? (
-                    <a href={profileStats.steamProfileLink} target="_blank" rel="noopener noreferrer">
-                      {profileStats.steamProfileLink}
-                    </a>
-                  ) : (
-                    '-'
-                  ),
+                  label: t('members.specializations'),
+                  children:
+                    Array.isArray(profileStats.specializations) && profileStats.specializations.length > 0
+                      ? profileStats.specializations.map(spec =>
+                          spec.linkToFile ? (
+                            <a key={spec.name} href={spec.linkToFile} target="_blank" rel="noopener noreferrer">
+                              <Tag color="blue" style={{ cursor: 'pointer' }}>
+                                {spec.name}
+                              </Tag>
+                            </a>
+                          ) : (
+                            <Tag key={spec.name}>{spec.name}</Tag>
+                          )
+                        )
+                      : '-',
                 },
-                { label: t('members.discordTag'), children: profileStats.discordTag || '-' },
+                { label: t('members.medals'), children: profileStats.medals || '-' },
               ]}
             />
           </Card>
         </Col>
-      )}
 
-      {/* Request Specialization Modal */}
-      <Modal
-        title={t('members.requestSpecialization')}
-        open={specModalOpen}
-        onCancel={() => setSpecModalOpen(false)}
-        onOk={handleRequestSpec}
-        okButtonProps={{ disabled: !selectedSpec }}
-      >
-        <Select
-          style={{ width: '100%' }}
-          placeholder={t('common.selectSpecializations')}
-          options={specOptions}
-          value={selectedSpec}
-          onChange={setSelectedSpec}
-          optionFilterProp="label"
-          showSearch
-        />
-      </Modal>
-    </Row>
+        {/* Description */}
+        {profileStats.description && profileStats.description !== '-' && (
+          <Col xs={24}>
+            <Card title={t('common.description')} variant="outlined" size="small">
+              <Typography.Paragraph style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{profileStats.description}</Typography.Paragraph>
+            </Card>
+          </Col>
+        )}
+
+        {/* Contact Info (conditionally shown) */}
+        {access.canViewContact && (
+          <Col xs={24}>
+            <Card title={t('members.contactInfo')} variant="outlined" size="small">
+              <Descriptions
+                layout="vertical"
+                size="small"
+                column={{ sm: 1, lg: 2 }}
+                bordered
+                items={[
+                  {
+                    label: t('members.steamProfile'),
+                    children: profileStats.steamProfileLink ? (
+                      <a href={profileStats.steamProfileLink} target="_blank" rel="noopener noreferrer">
+                        {profileStats.steamProfileLink}
+                      </a>
+                    ) : (
+                      '-'
+                    ),
+                  },
+                  { label: t('members.discordTag'), children: profileStats.discordTag || '-' },
+                ]}
+              />
+            </Card>
+          </Col>
+        )}
+
+        {/* Request Specialization Modal */}
+        <Modal
+          title={t('members.requestSpecialization')}
+          open={specModalOpen}
+          onCancel={() => setSpecModalOpen(false)}
+          onOk={handleRequestSpec}
+          okButtonProps={{ disabled: !selectedSpec }}
+        >
+          <Select
+            style={{ width: '100%' }}
+            placeholder={t('common.selectSpecializations')}
+            options={specOptions}
+            value={selectedSpec}
+            onChange={setSelectedSpec}
+            optionFilterProp="label"
+            showSearch
+          />
+        </Modal>
+      </Row>
     </div>
   );
 }

--- a/imports/ui/members/MembersSelect.tsx
+++ b/imports/ui/members/MembersSelect.tsx
@@ -2,13 +2,13 @@ import { Form, Select } from 'antd';
 import type { Rule } from 'antd/es/form';
 import type { NamePath } from 'antd/es/form/interface';
 import type { DefaultOptionType } from 'antd/es/select';
-import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import React, { useEffect, useMemo, useState } from 'react';
 import MembersCollection from '../../api/collections/members.collection';
 import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import { useTranslation } from '../../i18n/LanguageContext';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
+import useMethod from '../hooks/useMethod';
 import MemberForm from './MemberForm';
 
 interface MembersSelectProps {
@@ -54,12 +54,11 @@ interface GroupedMembersSelectProps {
 
 function GroupedMembersSelect({ multiple, name, label, rules, defaultValue, t }: GroupedMembersSelectProps) {
   const [options, setOptions] = useState<DefaultOptionType[]>([]);
+  const { call } = useMethod<DefaultOptionType[]>('members.groupedOptions');
 
   useEffect(() => {
-    Meteor.callAsync('members.groupedOptions')
-      .then((data: DefaultOptionType[]) => setOptions(data))
-      .catch(() => {});
-  }, []);
+    call().then(res => res.ok && setOptions(res.data));
+  }, [call]);
 
   const isFormItem = useMemo(() => name && label && rules, [name, label, rules]);
 

--- a/imports/ui/members/ProfileModal.tsx
+++ b/imports/ui/members/ProfileModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import { getModalWidth } from '../../config';
+import useMethod from '../hooks/useMethod';
 import useViewportSize from '../hooks/useViewportSize';
 import { ProfileStats } from '../dashboard/Dashboard';
 import { useTranslation } from '/imports/i18n/LanguageContext';
@@ -15,13 +15,10 @@ export default function ProfileModal({ showProfile = false, toggleProfile = () =
   const [profileStats, setProfileStats] = useState<Record<string, unknown> | null>(null);
   const { t } = useTranslation();
   const { width } = useViewportSize();
+  const { call } = useMethod<Record<string, unknown>>('members.profileStats');
   useEffect(() => {
-    // Guard the rejection: profileStats requires auth, so a logged-out mount
-    // would otherwise surface an uncaught Unauthorized (dev-overlay) error.
-    Meteor.callAsync('members.profileStats')
-      .then((data: Record<string, unknown>) => setProfileStats(data))
-      .catch(() => setProfileStats(null));
-  }, []);
+    call().then(res => setProfileStats(res.ok ? res.data : null));
+  }, [call]);
 
   return (
     <Modal title={t('modals.profile')} open={showProfile} onCancel={toggleProfile} width={getModalWidth(width)} footer={null} centered>

--- a/imports/ui/members/ranks/RankTag.tsx
+++ b/imports/ui/members/ranks/RankTag.tsx
@@ -1,7 +1,7 @@
 import { Tag, Tooltip } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { Rank } from '../../../api/types/rank';
+import useMethod from '../../hooks/useMethod';
 
 interface RankTagProps {
   rankId?: string;
@@ -9,19 +9,20 @@ interface RankTagProps {
 
 export default function RankTag({ rankId }: RankTagProps) {
   const [match, setMatch] = useState<Rank | null>(null);
+  const { call } = useMethod<Rank[]>('ranks.read');
   useEffect(() => {
     if (!rankId) {
       setMatch(null);
       return;
     }
     let cancelled = false;
-    Meteor.callAsync('ranks.read', { _id: rankId }, { limit: 1 }).then(res => {
-      if (!cancelled) setMatch((res as Rank[])[0]);
+    call({ _id: rankId }, { limit: 1 }).then(res => {
+      if (!cancelled && res.ok) setMatch(res.data[0]);
     });
     return () => {
       cancelled = true;
     };
-  }, [rankId]);
+  }, [rankId, call]);
 
   if (!rankId) return <Tag>-</Tag>;
   if (!match) return <Tag>Not found</Tag>;

--- a/imports/ui/orbat/Orbat.tsx
+++ b/imports/ui/orbat/Orbat.tsx
@@ -1,11 +1,11 @@
-import { App, Card, Descriptions, Empty, Popover, Select, Space, Typography } from 'antd';
-import { Meteor } from 'meteor/meteor';
+import { Card, Descriptions, Empty, Popover, Select, Space, Typography } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Tree, TreeNode } from 'react-organizational-chart';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { LanguageContextValue } from '../../i18n/LanguageContext';
 import type { Squad } from '/imports/api/types';
+import useMethod from '../hooks/useMethod';
 import { turnBase64ToImage } from '../profile-picture-input/ProfilePictureInput';
 import useTheme from '../theme/theme.hook';
 import { useTourRef } from '../tour/TourContext';
@@ -27,7 +27,6 @@ interface OrbatPopoverItem {
 }
 
 export default function Orbat() {
-  const { message } = App.useApp();
   const [ready, setReady] = useState(true);
   const [squads, setSquads] = useState<Squad[]>([]);
   const [options, setOptions] = useState<OrbatNode[]>([]);
@@ -35,19 +34,15 @@ export default function Orbat() {
   const { t } = useTranslation();
   const { theme } = useTheme();
   const chartRef = useTourRef('orbat-chart');
+  const { call: fetchSquads } = useMethod<Squad[]>('orbat.squads');
 
   useEffect(() => {
     setReady(false);
-    Meteor.callAsync('orbat.squads')
-      .then((squads: Squad[]) => {
-        setSquads(squads);
-        setReady(true);
-      })
-      .catch(() => {
-        message.error('Failed to load ORBAT data');
-        setReady(true);
-      });
-  }, [message]);
+    fetchSquads().then(res => {
+      if (res.ok) setSquads(res.data);
+      setReady(true);
+    });
+  }, [fetchSquads]);
 
   const findParentRecursive = useCallback((options: OrbatNode[], parentId: string | undefined): OrbatNode | null => {
     if (!parentId) return null;
@@ -66,7 +61,7 @@ export default function Orbat() {
     const children: Squad[] = [];
     // Build a single Set of squad IDs that appear as someone's parent — turns
     // the inner "does anything reference me?" lookup from O(n²) into O(n).
-    const referencedParentIds = new Set(squads.flatMap(s => s.parentSquadId ? [s.parentSquadId] : []));
+    const referencedParentIds = new Set(squads.flatMap(s => (s.parentSquadId ? [s.parentSquadId] : [])));
     const seen = new Set<string>();
     for (const squad of squads) {
       if (seen.has(squad._id!)) continue;
@@ -89,7 +84,7 @@ export default function Orbat() {
       orderedSquads.map(async squad => ({
         squad,
         src: squad.image ? (await turnBase64ToImage(squad.image)).src : null,
-      })),
+      }))
     );
     for (const { squad, src } of decoded) {
       const data: OrbatNode = {
@@ -176,18 +171,17 @@ interface ORBAT_LabelProps {
 
 const ORBAT_Label = ({ option, viewType }: ORBAT_LabelProps) => {
   const [items, setItems] = useState<OrbatPopoverItem[]>([]);
+  const { call: fetchPopoverItems } = useMethod<OrbatPopoverItem[]>('orbat.popover.items');
 
   useEffect(() => {
     let isMounted = true;
-    Meteor.callAsync('orbat.popover.items', option.id)
-      .then((data: OrbatPopoverItem[]) => {
-        if (isMounted) setItems(data);
-      })
-      .catch(() => {});
+    fetchPopoverItems(option.id).then(res => {
+      if (isMounted && res.ok) setItems(res.data);
+    });
     return () => {
       isMounted = false;
     };
-  }, [option.id]);
+  }, [option.id, fetchPopoverItems]);
 
   if (viewType === 'advanced') {
     return <ORBAT_AdvancedLabel option={option} items={items} />;
@@ -257,8 +251,7 @@ const ORBAT_AdvancedLabel = ({ option, items }: ORBAT_AdvancedLabelProps) => {
         {items?.length > 0 ? (
           items.map(item => (
             <div key={item.label}>
-              <Typography.Text strong>{item.label}</Typography.Text>{' '}
-              <Typography.Text>{item.children}</Typography.Text>
+              <Typography.Text strong>{item.label}</Typography.Text> <Typography.Text>{item.children}</Typography.Text>
             </div>
           ))
         ) : (

--- a/imports/ui/profile-picture-input/ProfilePictureInput.tsx
+++ b/imports/ui/profile-picture-input/ProfilePictureInput.tsx
@@ -3,6 +3,11 @@ import type { FormInstance } from 'antd';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
+import useMethod from '../hooks/useMethod';
+
+interface ProfilePictureDoc {
+  value: string;
+}
 
 export async function turnImageFileToBase64(file: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -33,6 +38,7 @@ export default function ProfilePictureInput({ fileList, setFileList, form, profi
   const { notification } = App.useApp();
   const [loading, setLoading] = useState(false);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const { call: fetchProfilePicture } = useMethod<ProfilePictureDoc[]>('profilePictures.read');
 
   async function uploadImage(file: Blob) {
     setLoading(true);
@@ -54,23 +60,15 @@ export default function ProfilePictureInput({ fileList, setFileList, form, profi
   useEffect(() => {
     if (profilePictureId && typeof profilePictureId === 'string') {
       setLoading(true);
-      Meteor.callAsync('profilePictures.read', { _id: profilePictureId })
+      fetchProfilePicture({ _id: profilePictureId })
         .then(res => {
-          if (res?.[0]) {
-            setImageSrc(res[0].value);
-          }
-        })
-        .catch((error: Meteor.Error) => {
-          notification.error({
-            message: error.error as string,
-            description: error.message,
-          });
+          if (res.ok && res.data[0]) setImageSrc(res.data[0].value);
         })
         .finally(() => setLoading(false));
     } else {
       setImageSrc(null);
     }
-  }, [profilePictureId, notification]);
+  }, [profilePictureId, fetchProfilePicture]);
 
   return (
     <Upload.Dragger

--- a/imports/ui/registration/RegistrationExtra.tsx
+++ b/imports/ui/registration/RegistrationExtra.tsx
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import React, { useCallback, useEffect, useState } from 'react';
 import type { Registration } from '../../api/types';
 import type { Member } from '../../api/types/member';
+import useMethod from '../hooks/useMethod';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 
 interface ConfirmModalProps {
@@ -84,24 +85,18 @@ export default function RegistrationExtra({ record }: RegistrationExtraProps) {
   const [open, setOpen] = useState(false);
 
   const [createdAlready, setCreatedAlready] = useState(true);
+  const { call: findMember } = useMethod<Member | undefined>('members.findOne');
 
   useEffect(() => {
     let cancelled = false;
-    Meteor.callAsync('members.findOne', { 'profile.registrationId': record._id }, { fields: { services: 0 } })
-      .then((res: Member | undefined) => {
-        if (cancelled) return;
-        setCreatedAlready(Boolean(res));
-      })
-      .catch(error => {
-        // Swallow rather than let the rejection bubble — the dev-server overlay
-        // turns unhandled rejections into a full-page "Unexpected error" that
-        // intercepts pointer events on every row in the table.
-        if (Meteor.isDevelopment) console.warn('RegistrationExtra members.findOne failed', error);
-      });
+    findMember({ 'profile.registrationId': record._id }, { fields: { services: 0 } }).then(res => {
+      if (cancelled || !res.ok) return;
+      setCreatedAlready(Boolean(res.data));
+    });
     return () => {
       cancelled = true;
     };
-  }, [record]);
+  }, [record, findMember]);
 
   return (
     <Space>

--- a/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
+++ b/imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx
@@ -1,7 +1,7 @@
 import { Tag, Tooltip } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { DiscoveryType } from '../../../api/types/misc';
+import useMethod from '../../hooks/useMethod';
 
 interface DiscoveryTypeTagProps {
   discoveryTypeId?: string;
@@ -9,6 +9,7 @@ interface DiscoveryTypeTagProps {
 
 export default function DiscoveryTypeTag({ discoveryTypeId }: DiscoveryTypeTagProps) {
   const [match, setMatch] = useState<DiscoveryType | null>(null);
+  const { call } = useMethod<DiscoveryType[]>('discoveryTypes.read');
 
   useEffect(() => {
     if (!discoveryTypeId) {
@@ -16,21 +17,13 @@ export default function DiscoveryTypeTag({ discoveryTypeId }: DiscoveryTypeTagPr
       return;
     }
     let cancelled = false;
-    Meteor.callAsync('discoveryTypes.read', { _id: discoveryTypeId }, { limit: 1 })
-      .then((res: DiscoveryType[]) => {
-        if (cancelled) return;
-        setMatch(res[0]);
-      })
-      .catch(error => {
-        // Swallow rather than let the rejection bubble — unhandled rejections
-        // surface via the dev-server overlay. The Tag falls back to the
-        // "Not found" state, which is benign for a row-level decoration.
-        if (Meteor.isDevelopment) console.warn('DiscoveryTypeTag discoveryTypes.read failed', error);
-      });
+    call({ _id: discoveryTypeId }, { limit: 1 }).then(res => {
+      if (!cancelled && res.ok) setMatch(res.data[0]);
+    });
     return () => {
       cancelled = true;
     };
-  }, [discoveryTypeId]);
+  }, [discoveryTypeId, call]);
 
   if (!discoveryTypeId) return <Tag>-</Tag>;
   if (!match) return <Tag>Not found</Tag>;

--- a/imports/ui/specializations/specializations.columns.tsx
+++ b/imports/ui/specializations/specializations.columns.tsx
@@ -1,9 +1,9 @@
 import type { ColumnsType } from 'antd/es/table';
 import { Tag } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { Specialization } from '../../api/types/misc';
 import type { LanguageContextValue } from '../../i18n/LanguageContext';
+import useMethod from '../hooks/useMethod';
 import type { SectionPermissions, RowClickEvent } from '../section/types';
 import RankTag from '../members/ranks/RankTag';
 import TableActions from '../table/body/actions/TableActions';
@@ -23,15 +23,13 @@ interface SpecializationTagsProps {
 
 const SpecializationTags = ({ specializations }: SpecializationTagsProps) => {
   const [values, setValues] = useState<OptionShape[] | string>('loading...');
+  const { call } = useMethod<OptionShape[]>('specializations.options');
   useEffect(() => {
     if (!specializations?.length) setValues([]);
-    Meteor.callAsync('specializations.options')
-      .then((res: OptionShape[]) => {
-        const data = res.filter(option => specializations!.includes(option.value));
-        setValues(data);
-      })
-      .catch(() => {});
-  }, [specializations]);
+    call().then(res => {
+      if (res.ok) setValues(res.data.filter(option => specializations!.includes(option.value)));
+    });
+  }, [specializations, call]);
 
   if (!Array.isArray(values)) return <>{values}</>;
   if (!values.length) return <>-</>;
@@ -53,7 +51,7 @@ const getSpecializationColumns = (
   handleEdit: (e: RowClickEvent, record: Specialization) => void,
   handleDelete: (e: RowClickEvent, record: Specialization) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TFn,
+  t: TFn
 ): ColumnsType<Specialization> => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/squads/SquadMembers.tsx
+++ b/imports/ui/squads/SquadMembers.tsx
@@ -1,8 +1,8 @@
 import { Empty, List, Spin, Tag } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/LanguageContext';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
+import useMethod from '../hooks/useMethod';
 
 interface SquadMemberItem {
   _id: string;
@@ -22,13 +22,13 @@ export default function SquadMembers({ squadId }: SquadMembersProps) {
   const [members, setMembers] = useState<SquadMemberItem[]>([]);
   const [loading, setLoading] = useState(true);
   const { t } = useTranslation();
+  const { call } = useMethod<SquadMemberItem[]>('squads.members');
 
   useEffect(() => {
-    Meteor.callAsync('squads.members', squadId)
-      .then(result => setMembers(result as SquadMemberItem[]))
-      .catch(() => setMembers([]))
+    call(squadId)
+      .then(res => setMembers(res.ok ? res.data : []))
       .finally(() => setLoading(false));
-  }, [squadId]);
+  }, [squadId, call]);
 
   if (loading) return <Spin size="small" />;
   if (members.length === 0) return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('squads.noMembers')} />;
@@ -39,7 +39,9 @@ export default function SquadMembers({ squadId }: SquadMembersProps) {
       dataSource={members}
       renderItem={member => (
         <List.Item key={member._id}>
-          <span>{member.id} &quot;{member.name}&quot;</span>
+          <span>
+            {member.id} &quot;{member.name}&quot;
+          </span>
           {member.rankName && (
             <Tag color={member.rankColor ?? undefined} style={{ marginLeft: 8 }}>
               <span style={{ color: member.rankColor ? getLegibleTextColor(member.rankColor) : undefined }}>{member.rankName}</span>

--- a/imports/ui/squads/squads.columns.tsx
+++ b/imports/ui/squads/squads.columns.tsx
@@ -1,9 +1,9 @@
 import { Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { Squad } from '../../api/types/squad';
 import getLegibleTextColor from '../../helpers/colors/getLegibleTextColor';
+import useMethod from '../hooks/useMethod';
 import type { ColumnsFactory, RowClickEvent, SectionPermissions, TranslateFn } from '../section/types';
 import TableActions from '../table/body/actions/TableActions';
 
@@ -19,20 +19,18 @@ interface SquadOption {
 
 export const SquadTags = ({ squadIds }: SquadTagsProps) => {
   const [squadNames, setSquadNames] = useState<SquadOption[]>([]);
+  const { call } = useMethod<SquadOption[]>('squads.options');
 
   useEffect(() => {
     let cancelled = false;
-    Meteor.callAsync('squads.options')
-      .then(options => {
-        if (cancelled) return;
-        const filtered = (options as SquadOption[]).filter(option => squadIds.includes(option.value));
-        setSquadNames(filtered);
-      })
-      .catch(() => {});
+    call().then(res => {
+      if (cancelled || !res.ok) return;
+      setSquadNames(res.data.filter(option => squadIds.includes(option.value)));
+    });
     return () => {
       cancelled = true;
     };
-  }, [squadIds]);
+  }, [squadIds, call]);
 
   return (
     <>
@@ -51,7 +49,7 @@ const getSquadsColumns: ColumnsFactory<Squad> = (
   handleEdit: (e: RowClickEvent, record: Squad) => void,
   handleDelete: (e: RowClickEvent, record: Squad) => void,
   permissions: SectionPermissions = defaultPermissions,
-  t: TranslateFn,
+  t: TranslateFn
 ) => {
   const { canUpdate = true, canDelete = true } = permissions;
 

--- a/imports/ui/tasks/TaskForm.tsx
+++ b/imports/ui/tasks/TaskForm.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from '../../i18n/LanguageContext';
 import { useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import FormFooter from '../components/FormFooter';
+import useMethod from '../hooks/useMethod';
 import MembersSelectJs from '../members/MembersSelect';
 import TaskStatusForm from './task-status/TaskStatusForm';
 
@@ -50,11 +51,10 @@ export default function TaskForm() {
   );
 
   const [participantOptions, setParticipantOptions] = useState<MemberOption[]>([]);
+  const { call: fetchMemberOptions } = useMethod<MemberOption[]>('members.options');
   useEffect(() => {
-    Meteor.callAsync('members.options')
-      .then((res: MemberOption[]) => setParticipantOptions(res))
-      .catch(() => {});
-  }, []);
+    fetchMemberOptions().then(res => res.ok && setParticipantOptions(res.data));
+  }, [fetchMemberOptions]);
 
   const [form] = Form.useForm();
 
@@ -102,7 +102,13 @@ export default function TaskForm() {
         FormComponent={TaskStatusForm}
       />
       <Form.Item label={t('tasks.participants')} name="participants" rules={[{ required: false, type: 'array' }]}>
-        <Select mode="multiple" placeholder={t('forms.placeholders.selectParticipants')} allowClear options={participantOptions} optionFilterProp="label" />
+        <Select
+          mode="multiple"
+          placeholder={t('forms.placeholders.selectParticipants')}
+          allowClear
+          options={participantOptions}
+          optionFilterProp="label"
+        />
       </Form.Item>
       <MembersSelect multiple name="completedBy" label={t('tasks.completedBy')} rules={[{ type: 'array' }]} defaultValue={model?.completedBy} />
       <Form.Item label={t('tasks.priority')} name="priority" rules={[{ required: false, type: 'string' }]}>

--- a/imports/ui/tasks/task-status/TaskStatusTag.tsx
+++ b/imports/ui/tasks/task-status/TaskStatusTag.tsx
@@ -1,7 +1,7 @@
 import { Tag, Tooltip } from 'antd';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { TaskStatus } from '../../../api/types/misc';
+import useMethod from '../../hooks/useMethod';
 
 interface TaskStatusTagProps {
   taskStatusId?: string;
@@ -9,14 +9,12 @@ interface TaskStatusTagProps {
 
 export default function TaskStatusTag({ taskStatusId }: TaskStatusTagProps) {
   const [match, setMatch] = useState<TaskStatus | null>(null);
+  const { call } = useMethod<TaskStatus[]>('taskStatus.read');
 
   useEffect(() => {
     if (!taskStatusId) setMatch(null);
-    else
-      Meteor.callAsync('taskStatus.read', { _id: taskStatusId }, { limit: 1 }).then((res: TaskStatus[]) =>
-        setMatch(res[0])
-      );
-  }, [taskStatusId]);
+    else call({ _id: taskStatusId }, { limit: 1 }).then(res => res.ok && setMatch(res.data[0]));
+  }, [taskStatusId, call]);
 
   if (!taskStatusId) return <Tag>-</Tag>;
   if (!match) return <Tag>Not found</Tag>;

--- a/imports/ui/tasks/task.columns.tsx
+++ b/imports/ui/tasks/task.columns.tsx
@@ -1,10 +1,10 @@
 import dayjs from 'dayjs';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import type { ColumnsType } from 'antd/es/table';
 import TaskStatusCollection from '../../api/collections/taskStatus.collection';
 import type { Task } from '../../api/types/task';
 import type { LanguageContextValue } from '../../i18n/LanguageContext';
+import useMethod from '../hooks/useMethod';
 import type { SectionPermissions } from '../section/types';
 import TableActions from '../table/body/actions/TableActions';
 import TaskStatusTag from './task-status/TaskStatusTag';
@@ -17,18 +17,16 @@ interface ParticipantsProps {
 
 export function Participants({ participants }: ParticipantsProps) {
   const [value, setValue] = useState<string>('loading...');
+  const { call } = useMethod<string>('members.participantNames');
 
   useEffect(() => {
     if (!participants?.length) setValue('-');
     const filter = { _id: { $in: participants } };
     const options = { fields: { 'profile.name': 1, 'profile.id': 1, 'profile.rankId': 1 } };
-    Meteor.callAsync('members.participantNames', filter, options)
-      .then((res: string) => {
-        if (!res?.length) setValue('-');
-        else setValue(res);
-      })
-      .catch(() => {});
-  }, [participants]);
+    call(filter, options).then(res => {
+      if (res.ok) setValue(res.data?.length ? res.data : '-');
+    });
+  }, [participants, call]);
 
   return <>{value}</>;
 }
@@ -37,7 +35,7 @@ export function getTaskColumns(
   handleTaskEdit: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
   handleTaskDelete: (e: React.MouseEvent<HTMLElement>, record: Task) => void,
   permissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true },
-  t: TFn,
+  t: TFn
 ): ColumnsType<Task> {
   const { canUpdate = true, canDelete = true } = permissions;
 


### PR DESCRIPTION
## What

Migrates the imperative **read-only** `Meteor.callAsync` sites in `imports/ui/` onto the `useMethod` seam (issue #242, parent #241). Each one-shot fetch now binds its method name via a top-level `useMethod<T>(name)` hook and branches on the discriminated `{ ok, data }` result, instead of re-deriving error narrowing / notification at the call site.

## Read sites migrated (21 across 19 files)

- `imports/ui/squads/SquadMembers.tsx` — `squads.members`
- `imports/ui/squads/squads.columns.tsx` — `squads.options` (SquadTags)
- `imports/ui/specializations/specializations.columns.tsx` — `specializations.options` (SpecializationTags)
- `imports/ui/tasks/TaskForm.tsx` — `members.options` (insert/update/addComment left for #243)
- `imports/ui/tasks/task.columns.tsx` — `members.participantNames` (Participants)
- `imports/ui/tasks/task-status/TaskStatusTag.tsx` — `taskStatus.read`
- `imports/ui/members/MembersSelect.tsx` — `members.groupedOptions`
- `imports/ui/members/ProfileModal.tsx` — `members.profileStats`
- `imports/ui/members/MemberProfile.tsx` — `members.profileStats` + `members.profileAccess` + `members.attendanceBreakdown` (Promise.all) and `specializations.options` (openSpecModal); `specializations.request` left for #243
- `imports/ui/members/ranks/RankTag.tsx` — `ranks.read`
- `imports/ui/registration/RegistrationExtra.tsx` — `members.findOne` (`members.insert` left for #243)
- `imports/ui/registration/discovery-types/DiscoveryTypeTag.tsx` — `discoveryTypes.read`
- `imports/ui/orbat/Orbat.tsx` — `orbat.squads` (Orbat) + `orbat.popover.items` (ORBAT_Label)
- `imports/ui/dashboard/Dashboard.tsx` — `dashboard.stats`
- `imports/ui/events/EventDetailPopover.tsx` — `events.detail` (`events.rsvp` left, see below)
- `imports/ui/events/EventForm.tsx` — both `members.read` reads in SquadQuickAdd (insert/update/remove/validators left for #243/#244)
- `imports/ui/events/EventAttendance.tsx` — **`attendances.read` (the required fix)**
- `imports/ui/footer/Footer.tsx` — `profilePictures.read`
- `imports/ui/profile-picture-input/ProfilePictureInput.tsx` — `profilePictures.read` (`profilePictures.insert` left for #243)

### EventAttendance.tsx fix (issue #242 specific requirement)

The `attendances.read` pre-flight in `AttendanceSelect` previously hand-rolled its own error extraction (`error.reason || error.message`). The read now goes through `useMethod`, so the seam owns the single canonical extraction. The subsequent `attendances.update`/`attendances.insert` write is a mutation and is left as `callAsync` (with its existing error handling) for #243.

## Intentionally left as `callAsync`

- **Mutation submit handlers** (insert/update in `*Form.tsx`), **Section.tsx** delete/bulkDelete + their `integrity.preview`/`integrity.previewBulk` pre-flights, `events.rsvp` toggle, `specializations.request`, `tasks.addComment`, `members.insert`, `profilePictures.insert` — **issue #243**. (Section's integrity reads are interleaved inside the delete handlers #243 will rewrite, so they were left there to keep that flow whole rather than split it.)
- **Field validators** `members.validateName`/`validateId`, `registrations.validateName`/`validateId` — **issue #244**.
- **`imports/ui/palette/Palette.tsx` (`palette.search`)** — deliberately left. It is a debounced type-ahead search that silently resets to empty results on failure; routing it through the read tier (default `notify: true`, with `notify: false` explicitly out of bounds for reads) would fire an error notification on every failed keystroke. Does not fit the read tier without the forbidden opt-out.
- **`imports/ui/backup/Backup.tsx` (`backup.create`/`validate`/`restore`)** — left. These are action handlers (not reads feeding UI), use the `message` channel with bespoke `t()` fallback strings, and do substantial post-processing (ZIP build, file download) inside the same try block.

A few migrated files had pre-existing JSX indentation debt (notably `MemberProfile.tsx`, `Dashboard.tsx`) that Prettier corrected, inflating those diffs; the logic changes are confined to the call sites.

## Verification

- `npm test` — **374 passing** (exit 0). The browser-only `useMethod.test.tsx` smoke test needs a browser driver and does not run under server-mode `npm test`, as before.
- `npm run typecheck` (`tsc --noEmit`) — **clean**.
- `npx prettier --check` on all touched files — **passes**.

Refs #242, #241.
