### PR TITLE
refactor(ui): route form submit and delete mutations through useMethod

### DIFF
--- a/imports/ui/briefing-templates/BriefingTemplatesForm.tsx
+++ b/imports/ui/briefing-templates/BriefingTemplatesForm.tsx
@@ -1,9 +1,9 @@
-import { App, ColorPicker, Form, Input } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useMemo, useState } from 'react';
+import { ColorPicker, Form, Input } from 'antd';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import { useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import FormFooter from '../components/FormFooter';
 import RichTextEditor from '../components/RichTextEditor';
 import type { BriefingTemplate } from '../../api/types';
@@ -11,9 +11,11 @@ import type { BriefingTemplate } from '../../api/types';
 export default function BriefingTemplatesForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<BriefingTemplate>>();
+
+  const { call, loading } = useMethod<string | undefined>(rawModel?._id ? 'briefingTemplates.update' : 'briefingTemplates.insert', {
+    success: rawModel?._id ? t('messages.briefingTemplateUpdated') : t('messages.briefingTemplateCreated'),
+  });
 
   // Provide values synchronously via initialValues (not a setFieldsValue effect):
   // the RichTextEditor initializes its document from `value` on first render, so
@@ -30,24 +32,13 @@ export default function BriefingTemplatesForm() {
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
-      setLoading(true);
       const { name, description, content } = values as { name: string; description?: string; content?: string };
       const args = [...(rawModel?._id ? [rawModel._id] : []), { name, color: getColorFromValues(values), description, content }];
-      try {
-        const result = (await Meteor.callAsync(
-          rawModel?._id ? 'briefingTemplates.update' : 'briefingTemplates.insert',
-          ...args
-        )) as string | undefined;
-        message.success(rawModel?._id ? t('messages.briefingTemplateUpdated') : t('messages.briefingTemplateCreated'));
-        resolve(rawModel?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({ message: err.error as string, description: err.message });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(rawModel?._id ?? res.data);
     },
-    [rawModel, resolve, message, notification, t]
+    [rawModel, resolve, call]
   );
 
   return (
@@ -64,7 +55,7 @@ export default function BriefingTemplatesForm() {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/components/FormFooter.tsx
+++ b/imports/ui/components/FormFooter.tsx
@@ -8,9 +8,10 @@ interface FormFooterProps {
   onCancel?: () => void;
   cancelText?: string;
   submitText?: string;
+  loading?: boolean;
 }
 
-const FormFooter = ({ setOpen, onCancel, cancelText, submitText }: FormFooterProps) => {
+const FormFooter = ({ setOpen, onCancel, cancelText, submitText, loading = false }: FormFooterProps) => {
   const { t } = useTranslation();
   // Anchor stays in the form's DOM so we can reach the owning <form> for submit.
   const anchorRef = useRef<HTMLSpanElement>(null);
@@ -37,7 +38,7 @@ const FormFooter = ({ setOpen, onCancel, cancelText, submitText }: FormFooterPro
             </Button>
           </Col>
           <Col>
-            <Button type="primary" onClick={handleSubmit}>
+            <Button type="primary" onClick={handleSubmit} loading={loading}>
               {submitText || t('common.submit')}
             </Button>
           </Col>

--- a/imports/ui/events/EventForm.tsx
+++ b/imports/ui/events/EventForm.tsx
@@ -49,7 +49,7 @@ export const getDateFromValues = (values: Record<string, unknown>, key = 'date')
 };
 
 const EventForm = () => {
-  const { message, notification, modal } = App.useApp();
+  const { modal } = App.useApp();
   const { t } = useTranslation();
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<EventDoc>>();
 
@@ -63,6 +63,11 @@ const EventForm = () => {
     } as EventFormValues & { _id?: string };
   }, [rawModel]);
 
+  const { call: save, loading } = useMethod<string | undefined>(model?._id ? 'events.update' : 'events.insert', {
+    success: model?._id ? t('messages.eventUpdated') : t('messages.eventCreated'),
+  });
+  const { call: remove } = useMethod('events.remove', { success: t('messages.eventDeleted') });
+
   const handleFinish = useCallback(
     async (values: EventFormValues) => {
       const wireValues = {
@@ -72,20 +77,11 @@ const EventForm = () => {
         end: getDateFromValues(values as unknown as Record<string, unknown>, 'end'),
       };
       const args = [...(model?._id ? [model._id] : []), wireValues];
-      const endpoint = model?._id ? 'events.update' : 'events.insert';
-      try {
-        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
-        message.success(model?._id ? t('messages.eventUpdated') : t('messages.eventCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      }
+      const res = await save(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model?._id, message, notification, resolve, t]
+    [model?._id, save, resolve]
   );
 
   const handleDelete = useCallback(() => {
@@ -95,25 +91,17 @@ const EventForm = () => {
       cancelText: t('common.cancel'),
       okType: 'danger',
       onOk: async () => {
-        try {
-          await Meteor.callAsync('events.remove', model._id);
-          message.success(t('messages.eventDeleted'));
-          cancel();
-        } catch (error) {
-          const err = error as Meteor.Error;
-          notification.error({
-            message: err.error as string,
-            description: err.message,
-          });
-        }
+        const res = await remove(model._id);
+        if (!res.ok) return;
+        cancel();
       },
     });
-  }, [modal, message, cancel, model, notification, t]);
+  }, [modal, cancel, model, remove, t]);
 
   const [form] = Form.useForm<EventFormValues>();
 
   return (
-    <Form form={form} layout="vertical" initialValues={model} onFinish={handleFinish}>
+    <Form form={form} layout="vertical" initialValues={model} onFinish={handleFinish} disabled={loading}>
       <Form.Item name="start" label={t('events.startDate')} rules={[{ required: true, type: 'date' }]}>
         <DatePicker style={styles.datePicker} showTime />
       </Form.Item>
@@ -165,7 +153,7 @@ const EventForm = () => {
             </Col>
           )}
           <Col>
-            <Button type="primary" onClick={() => form.submit()} icon={<SaveOutlined />}>
+            <Button type="primary" onClick={() => form.submit()} icon={<SaveOutlined />} loading={loading}>
               {t('common.save')}
             </Button>
           </Col>

--- a/imports/ui/events/event-types/EventTypesForm.tsx
+++ b/imports/ui/events/event-types/EventTypesForm.tsx
@@ -1,8 +1,9 @@
-import { App, ColorPicker, Form, Input } from 'antd';
+import { ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '../../specializations/SpecializationForm';
 import type { EventType } from '../../../api/types';
@@ -10,9 +11,11 @@ import type { EventType } from '../../../api/types';
 export default function EventTypesForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<EventType>>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'eventTypes.update' : 'eventTypes.insert', {
+    success: model?._id ? t('messages.eventTypeUpdated') : t('messages.eventTypeCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -28,24 +31,13 @@ export default function EventTypesForm() {
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
-      setLoading(true);
       const { name, description } = values as { name: string; description?: string };
       const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'eventTypes.update' : 'eventTypes.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.eventTypeUpdated') : t('messages.eventTypeCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({ message: err.error as string, description: err.message });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -59,7 +51,7 @@ export default function EventTypesForm() {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, App, Button, Col, DatePicker, Divider, Form, Input, InputNumber, Row, Switch } from 'antd';
+import { Alert, Button, Col, DatePicker, Divider, Form, Input, InputNumber, Row, Switch } from 'antd';
 import type { UploadFile } from 'antd/es/upload/interface';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
@@ -10,6 +10,7 @@ import RolesCollection from '../../api/collections/roles.collection';
 import type { Member } from '../../api/types/member';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import { getDateFromValues } from '../events/EventForm';
 import ProfilePictureInput from '../profile-picture-input/ProfilePictureInput';
@@ -55,7 +56,6 @@ interface MemberFormValues {
   profile?: MemberFormProfile;
 }
 
-
 export const transformDateToDays = (values: Record<string, unknown>, key = 'date'): Dayjs | undefined => {
   if (values[key]) return dayjs(values[key] as dayjs.ConfigType);
   return values[key] as undefined;
@@ -64,9 +64,7 @@ export const transformDateToDays = (values: Record<string, unknown>, key = 'date
 export default function MemberForm() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [form] = Form.useForm<any>();
-  const { message, notification } = App.useApp();
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
   // Independent availability signals derived into disableSubmit — see the same
   // pattern in RegistrationForm. Previously a single disableSubmit was written
   // by two async validations that clobbered each other; here they also never
@@ -80,6 +78,11 @@ export default function MemberForm() {
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Member>>();
   const model = useMemo(() => (rawModel || {}) as Member, [rawModel]);
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'members.update' : 'members.insert', {
+    success: t('messages.saveSuccessful'),
+  });
+
   useEffect(() => {
     if (Object.keys(model).length > 0) {
       const data = { ...model } as Record<string, unknown>;
@@ -149,7 +152,6 @@ export default function MemberForm() {
       // hidden submit button — which bypasses `disableSubmit` (name or id
       // already in use / rules not accepted) unless we re-check here.
       if (loading || disableSubmit) return;
-      setLoading(true);
       const payload = {
         ...values,
         profile: {
@@ -159,24 +161,11 @@ export default function MemberForm() {
         },
       };
       const args = model?._id ? [model._id, payload] : [payload];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'members.update' : 'members.insert',
-          ...args
-        )) as string | undefined;
-        message.success(t('messages.saveSuccessful'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model?._id, resolve, message, notification, t, loading, disableSubmit]
+    [model?._id, resolve, call, loading, disableSubmit]
   );
 
   const handleValuesChange = useCallback(
@@ -246,7 +235,13 @@ export default function MemberForm() {
       <Form.Item name={['profile', 'name']} label={t('common.name')} rules={[{ required: true, type: 'string' }]} status={nameError} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>
-      <SquadsSelect multiple={false} name={['profile', 'squadId']} label={t('members.squad')} rules={[{ type: 'string' }]} defaultValue={model?.profile?.squadId} />
+      <SquadsSelect
+        multiple={false}
+        name={['profile', 'squadId']}
+        label={t('members.squad')}
+        rules={[{ type: 'string' }]}
+        defaultValue={model?.profile?.squadId}
+      />
       <CollectionSelect
         defaultValue={model?.profile?.rankId}
         FormComponent={RanksForm}
@@ -288,7 +283,13 @@ export default function MemberForm() {
         defaultValue={model?.profile?.specializationIds}
         multiple
       />
-      <MedalsSelect name={['profile', 'medalIds']} label={t('members.medals')} rules={[{ type: 'array' }]} defaultValue={model?.profile?.medalIds} multiple />
+      <MedalsSelect
+        name={['profile', 'medalIds']}
+        label={t('members.medals')}
+        rules={[{ type: 'array' }]}
+        defaultValue={model?.profile?.medalIds}
+        multiple
+      />
       <CollectionSelect
         name={['profile', 'roleId']}
         label={t('forms.labels.role')}
@@ -317,7 +318,12 @@ export default function MemberForm() {
       <Form.Item name={['profile', 'exitDate']} label={t('members.exitDate')} rules={[{ type: 'date' }]}>
         <DatePicker style={styles.datePicker} placeholder={t('common.selectDate')} />
       </Form.Item>
-      <Form.Item name={['profile', 'hasCustomArmour']} label={t('forms.labels.hasCustomArmour')} valuePropName="checked" rules={[{ type: 'boolean' }]}>
+      <Form.Item
+        name={['profile', 'hasCustomArmour']}
+        label={t('forms.labels.hasCustomArmour')}
+        valuePropName="checked"
+        rules={[{ type: 'boolean' }]}
+      >
         <Switch />
       </Form.Item>
       <DrawerFooter>

--- a/imports/ui/members/medals/MedalsForm.tsx
+++ b/imports/ui/members/medals/MedalsForm.tsx
@@ -1,10 +1,11 @@
-import { App, ColorPicker, Form, Input } from 'antd';
+import { ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Medal } from '../../../api/types/misc';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 
 interface MedalFormValues {
@@ -16,9 +17,11 @@ interface MedalFormValues {
 export default function MedalsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<MedalFormValues>();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<Medal> & { _id?: string }>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'medals.update' : 'medals.insert', {
+    success: model?._id ? t('messages.medalUpdated') : t('messages.medalCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -34,30 +37,16 @@ export default function MedalsForm() {
 
   const handleSubmit = useCallback(
     async (values: MedalFormValues) => {
-      setLoading(true);
       const { name, description } = values;
       const args = [
         ...(model?._id ? [model._id] : []),
         { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description },
       ];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'medals.update' : 'medals.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.medalUpdated') : t('messages.medalCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -71,7 +60,7 @@ export default function MedalsForm() {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/members/positions/PositionsForm.tsx
+++ b/imports/ui/members/positions/PositionsForm.tsx
@@ -1,9 +1,10 @@
-import { App, ColorPicker, Form, Input, InputNumber } from 'antd';
+import { ColorPicker, Form, Input, InputNumber } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 import type { Position } from '../../../api/types/misc';
 
@@ -17,9 +18,11 @@ interface PositionFormValues {
 export default function PositionsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<PositionFormValues>();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<Position> & { _id?: string }>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'positions.update' : 'positions.insert', {
+    success: model?._id ? t('messages.positionUpdated') : t('messages.positionCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -36,30 +39,16 @@ export default function PositionsForm() {
 
   const handleSubmit = useCallback(
     async (values: PositionFormValues) => {
-      setLoading(true);
       const { name, description, order } = values;
       const args = [
         ...(model?._id ? [model._id] : []),
         { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, order },
       ];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'positions.update' : 'positions.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.positionUpdated') : t('messages.positionCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -76,7 +65,7 @@ export default function PositionsForm() {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/members/ranks/RanksForm.tsx
+++ b/imports/ui/members/ranks/RanksForm.tsx
@@ -1,10 +1,11 @@
-import { App, ColorPicker, Form, Input, Select } from 'antd';
+import { ColorPicker, Form, Input, Select } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Rank } from '../../../api/types/rank';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 import RanksSelect from './RanksSelect';
 
@@ -20,9 +21,11 @@ interface RankFormValues {
 export default function RanksForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<RankFormValues>();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<Rank> & { _id?: string }>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'ranks.update' : 'ranks.insert', {
+    success: model?._id ? t('messages.rankUpdated') : t('messages.rankCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -40,30 +43,16 @@ export default function RanksForm() {
 
   const handleSubmit = useCallback(
     async (values: RankFormValues) => {
-      setLoading(true);
       const { name, description, previousRankId, nextRankId, type } = values;
       const args = [
         ...(model?._id ? [model._id] : []),
         { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, previousRankId, nextRankId, type },
       ];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'ranks.update' : 'ranks.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.rankUpdated') : t('messages.rankCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -98,7 +87,7 @@ export default function RanksForm() {
         rules={[{ required: false, type: 'string' }]}
         defaultValue={model?.nextRankId as string | undefined}
       />
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/members/roles/RolesForm.tsx
+++ b/imports/ui/members/roles/RolesForm.tsx
@@ -1,6 +1,5 @@
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
-import { App, Card, Checkbox, ColorPicker, Form, Input, Space, Switch, Typography } from 'antd';
-import { Meteor } from 'meteor/meteor';
+import { Card, Checkbox, ColorPicker, Form, Input, Space, Switch, Typography } from 'antd';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
@@ -8,6 +7,7 @@ import type { TranslateFn } from '../../section/types';
 import type { LocaleKey } from '/imports/i18n';
 import type { CrudPermission, Role } from '../../../api/types/role';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 
 interface RuleInputProps {
@@ -73,34 +73,30 @@ const RolesForm = () => {
   const { t } = useTranslation();
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Role> & { _id?: string }>();
   const model = (rawModel || {}) as Role & { _id?: string };
-  const { message, notification } = App.useApp();
   const { isUpdate, endpoint } = useMemo(
     () => (model?._id ? { isUpdate: true, endpoint: 'roles.update' } : { isUpdate: false, endpoint: 'roles.insert' }),
     [model?._id]
   );
 
+  const { call, loading } = useMethod<string | undefined>(endpoint, {
+    success: isUpdate ? t('messages.roleUpdated') : t('messages.roleCreated'),
+  });
+
   const handleFinish = useCallback(
     async (values: Record<string, unknown>) => {
-      try {
-        const args = [...(model?._id ? [model._id] : []), { ...values, color: getColorFromValues(values) }];
-        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
-        message.success(isUpdate ? t('messages.roleUpdated') : t('messages.roleCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        notification.error({
-          message: (error as Meteor.Error).error as string,
-          description: (error as Meteor.Error).message,
-        });
-      }
+      const args = [...(model?._id ? [model._id] : []), { ...values, color: getColorFromValues(values) }];
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [endpoint, model?._id, resolve, isUpdate, message, notification, t]
+    [model?._id, resolve, call]
   );
 
   const [form] = Form.useForm<Record<string, unknown>>();
   const initialValues = useMemo(() => prepareModelForForm(model), [model]);
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={initialValues}>
+    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={initialValues} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>
@@ -134,7 +130,7 @@ const RolesForm = () => {
       <RuleInput name="canCreateEvents" label={t('members.canCreateEvents')} />
       <RuleInput name="canManageTasks" label={t('members.canManageTasks')} />
 
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 };

--- a/imports/ui/questionnaires/QuestionnaireForm.tsx
+++ b/imports/ui/questionnaires/QuestionnaireForm.tsx
@@ -1,11 +1,11 @@
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import { App, Button, Card, Form, Input, Select, Space, Switch } from 'antd';
-import { Meteor } from 'meteor/meteor';
+import { Button, Card, Form, Input, Select, Space, Switch } from 'antd';
 import React, { useCallback, useMemo } from 'react';
 import type { Questionnaire, QuestionnaireInterval, QuestionnaireStatus, QuestionType } from '../../api/types/questionnaire';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
 import { useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import FormFooter from '../components/FormFooter';
 
 interface QuestionTypeOption {
@@ -42,13 +42,16 @@ interface QuestionItemProps {
 
 const QuestionnaireForm = () => {
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<Questionnaire>>();
-  const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const questionnaire = (model || {}) as unknown as Questionnaire;
   const { isUpdate, endpoint } = useMemo(
     () => (questionnaire?._id ? { isUpdate: true, endpoint: 'questionnaires.update' } : { isUpdate: false, endpoint: 'questionnaires.insert' }),
     [questionnaire?._id]
   );
+
+  const { call, loading } = useMethod<string | undefined>(endpoint, {
+    success: isUpdate ? t('questionnaires.updated') : t('questionnaires.created'),
+  });
 
   const questionTypes: QuestionTypeOption[] = useMemo(
     () => [
@@ -75,31 +78,29 @@ const QuestionnaireForm = () => {
 
   const handleFinish = useCallback(
     async (values: QuestionnaireFormValues) => {
-      try {
-        const payload = {
-          ...values,
-          createdAt: questionnaire?.createdAt || new Date(),
-          updatedAt: new Date(),
-        };
-        const args = isUpdate ? [questionnaire._id, payload] : [payload];
-        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
-        message.success(isUpdate ? t('questionnaires.updated') : t('questionnaires.created'));
-        resolve(questionnaire?._id ?? result);
-      } catch (error) {
-        notification.error({
-          message: (error as Meteor.Error).error,
-          description: (error as Meteor.Error).message,
-        });
-      }
+      const payload = {
+        ...values,
+        createdAt: questionnaire?.createdAt || new Date(),
+        updatedAt: new Date(),
+      };
+      const args = isUpdate ? [questionnaire._id, payload] : [payload];
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(questionnaire?._id ?? res.data);
     },
-    [resolve, endpoint, questionnaire?._id, questionnaire?.createdAt, isUpdate, message, notification, t]
+    [resolve, questionnaire?._id, questionnaire?.createdAt, isUpdate, call]
   );
 
   const [form] = Form.useForm<QuestionnaireFormValues>();
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={questionnaire}>
-      <Form.Item label={t('common.name')} name="name" rules={[{ required: true, type: 'string', message: t('questionnaires.pleaseEnterName') }]} required>
+    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={questionnaire} disabled={loading}>
+      <Form.Item
+        label={t('common.name')}
+        name="name"
+        rules={[{ required: true, type: 'string', message: t('questionnaires.pleaseEnterName') }]}
+        required
+      >
         <Input placeholder={t('questionnaires.enterQuestionnaireName')} />
       </Form.Item>
       <Form.Item label={t('common.description')} name="description" rules={[{ required: false, type: 'string' }]}>
@@ -147,7 +148,7 @@ const QuestionnaireForm = () => {
         </Form.List>
       </Card>
 
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 };
@@ -171,7 +172,12 @@ const QuestionItem = ({ name, restField, remove, t, questionTypes }: QuestionIte
           <Button type="text" danger icon={<DeleteOutlined />} onClick={() => remove(name)} />
         </Space>
         <Space wrap>
-          <Form.Item {...restField} name={[name, 'type']} rules={[{ required: true, message: t('questionnaires.selectAType') }]} style={{ marginBottom: 8 }}>
+          <Form.Item
+            {...restField}
+            name={[name, 'type']}
+            rules={[{ required: true, message: t('questionnaires.selectAType') }]}
+            style={{ marginBottom: 8 }}
+          >
             <Select placeholder={t('questionnaires.questionType')} options={questionTypes} style={{ width: 150 }} />
           </Form.Item>
           <Form.Item {...restField} name={[name, 'required']} style={{ marginBottom: 8 }}>

--- a/imports/ui/questionnaires/QuestionnaireResponseForm.tsx
+++ b/imports/ui/questionnaires/QuestionnaireResponseForm.tsx
@@ -1,9 +1,9 @@
-import { App, Form, Input, InputNumber, Rate, Select, Typography } from 'antd';
-import { Meteor } from 'meteor/meteor';
+import { Form, Input, InputNumber, Rate, Select, Typography } from 'antd';
 import React, { useCallback } from 'react';
 import type { Question, Questionnaire } from '../../api/types/questionnaire';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import FormFooter from '../components/FormFooter';
 
 const { Text } = Typography;
@@ -13,31 +13,27 @@ type ResponseFormValues = Record<string, string | number | string[] | undefined>
 const QuestionnaireResponseForm = () => {
   const { model, resolve, cancel } = useDrawerFrame<true, Questionnaire>();
   const questionnaire = (model || {}) as unknown as Questionnaire;
-  const { message, notification } = App.useApp();
   const { t } = useTranslation();
   const [form] = Form.useForm<ResponseFormValues>();
 
+  const { call, loading } = useMethod('questionnaireResponses.submit', {
+    success: t('questionnaires.submitSuccess'),
+  });
+
   const handleFinish = useCallback(
     async (values: ResponseFormValues) => {
-      try {
-        const answers = (questionnaire.questions || []).map((question, index) => ({
-          questionIndex: index,
-          value: values[`question_${index}`],
-        }));
+      const answers = (questionnaire.questions || []).map((question, index) => ({
+        questionIndex: index,
+        value: values[`question_${index}`],
+      }));
 
-        await Meteor.callAsync('questionnaireResponses.submit', questionnaire._id, answers);
-        message.success(t('questionnaires.submitSuccess'));
-        // Resolve with a truthy sentinel so the opener can detect "submitted"
-        // and refresh its list — undefined would mean "cancelled".
-        resolve(true);
-      } catch (error) {
-        notification.error({
-          message: (error as Meteor.Error).error,
-          description: (error as Meteor.Error).message,
-        });
-      }
+      const res = await call(questionnaire._id, answers);
+      if (!res.ok) return;
+      // Resolve with a truthy sentinel so the opener can detect "submitted"
+      // and refresh its list — undefined would mean "cancelled".
+      resolve(true);
     },
-    [resolve, questionnaire, message, notification, t]
+    [resolve, questionnaire, call]
   );
 
   const renderQuestionField = (question: Question, index: number) => {
@@ -67,10 +63,7 @@ const QuestionnaireResponseForm = () => {
       case 'select':
         return (
           <Form.Item key={key} label={question.text} name={fieldName} rules={rules}>
-            <Select
-              placeholder={t('questionnaires.selectOption')}
-              options={(question.options || []).map(opt => ({ value: opt, label: opt }))}
-            />
+            <Select placeholder={t('questionnaires.selectOption')} options={(question.options || []).map(opt => ({ value: opt, label: opt }))} />
           </Form.Item>
         );
       case 'multiselect':
@@ -103,14 +96,14 @@ const QuestionnaireResponseForm = () => {
   }
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish}>
+    <Form layout="vertical" form={form} onFinish={handleFinish} disabled={loading}>
       {questionnaire.description && (
         <Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
           {questionnaire.description}
         </Text>
       )}
       {questionnaire.questions.map((question, index) => renderQuestionField(question, index))}
-      <FormFooter onCancel={cancel} submitText={t('questionnaires.submitResponse')} />
+      <FormFooter onCancel={cancel} submitText={t('questionnaires.submitResponse')} loading={loading} />
     </Form>
   );
 };

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, App, Button, Col, Form, Input, InputNumber, Row, Switch } from 'antd';
+import { Alert, Button, Col, Form, Input, InputNumber, Row, Switch } from 'antd';
 import type { ValidateStatus } from 'antd/es/form/FormItem';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
@@ -9,6 +9,7 @@ import type { Registration } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
+import useMethod from '../hooks/useMethod';
 import DiscoveryTypeForm from './discovery-types/DiscoveryTypesForm';
 
 interface RegistrationFormValues {
@@ -26,9 +27,7 @@ interface RegistrationFormValues {
 export default function RegistrationForm() {
   const [form] = Form.useForm<RegistrationFormValues>();
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Registration>>();
-  const { message, notification } = App.useApp();
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
   // Track name/id availability as independent signals and derive disableSubmit
   // from them. Folding both into one state let the two async validations
   // clobber each other (last-writer-wins), so an in-use name could be masked by
@@ -45,6 +44,11 @@ export default function RegistrationForm() {
     if (!Meteor.user()) return {};
     return (rawModel as unknown as Registration) || {};
   }, [rawModel]);
+
+  const { call, loading } = useMethod<string | undefined>(
+    Meteor.user() && (model as Registration)?._id ? 'registrations.update' : 'registrations.insert',
+    { success: t('messages.registrationSuccessful') }
+  );
 
   useEffect(() => {
     if (Object.keys(model).length > 0) {
@@ -109,30 +113,16 @@ export default function RegistrationForm() {
       // hidden submit button — which bypasses `disableSubmit` (rules not
       // accepted / name or id already in use) unless we re-check here.
       if (loading || disableSubmit) return;
-      setLoading(true);
       const { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description } = values;
       const args = [
         ...((model as Registration)?._id ? [(model as Registration)._id] : []),
         { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description },
       ];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && (model as Registration)?._id ? 'registrations.update' : 'registrations.insert',
-          ...args
-        )) as string | undefined;
-        message.success(t('messages.registrationSuccessful'));
-        resolve((model as Registration)?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve((model as Registration)?._id ?? res.data);
     },
-    [resolve, model, message, notification, t, loading, disableSubmit],
+    [resolve, model, call, loading, disableSubmit]
   );
 
   const handleValuesChange = useCallback(
@@ -147,7 +137,7 @@ export default function RegistrationForm() {
         handleDiscoveryTypeChange();
       }
     },
-    [validateId, validateName, handleDiscoveryTypeChange],
+    [validateId, validateName, handleDiscoveryTypeChange]
   );
 
   useEffect(() => {

--- a/imports/ui/registration/discovery-types/DiscoveryTypesForm.tsx
+++ b/imports/ui/registration/discovery-types/DiscoveryTypesForm.tsx
@@ -1,8 +1,9 @@
-import { App, ColorPicker, Form, Input, Switch } from 'antd';
+import { ColorPicker, Form, Input, Switch } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { DiscoveryType } from '../../../api/types';
@@ -10,9 +11,11 @@ import type { DiscoveryType } from '../../../api/types';
 export default function DiscoveryTypeForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<DiscoveryType> & { _id?: string }>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'discoveryTypes.update' : 'discoveryTypes.insert', {
+    success: model?._id ? t('messages.discoveryTypeUpdated') : t('messages.discoveryTypeCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -29,27 +32,13 @@ export default function DiscoveryTypeForm() {
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
-      setLoading(true);
       const { name, description, hasTextInput } = values as { name: string; description?: string; hasTextInput?: boolean };
-      const args = [
-        ...(model?._id ? [model._id] : []),
-        { name, color: getColorFromValues(values), description, hasTextInput: !!hasTextInput },
-      ];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'discoveryTypes.update' : 'discoveryTypes.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.discoveryTypeUpdated') : t('messages.discoveryTypeCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({ message: err.error as string, description: err.message });
-      } finally {
-        setLoading(false);
-      }
+      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description, hasTextInput: !!hasTextInput }];
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -66,7 +55,7 @@ export default function DiscoveryTypeForm() {
       <Form.Item name="hasTextInput" label={t('registrations.hasTextInput')} valuePropName="checked" rules={[{ type: 'boolean' }]}>
         <Switch />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }

--- a/imports/ui/section/Section.tsx
+++ b/imports/ui/section/Section.tsx
@@ -8,6 +8,7 @@ import RolesCollection from '../../api/collections/roles.collection';
 import type { Role, CrudPermission } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
 import { useDrawerStack } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import TableContainer from '../table/body/TableContainer';
 import TableFooter from '../table/footer/TableFooter';
 import GroupActionsBar from '../table/header/GroupActionsBar';
@@ -104,6 +105,15 @@ export default function Section<T extends { _id?: string }>({
   const { notification, message, modal } = App.useApp();
   const { t } = useTranslation();
 
+  // Delete-flow seams. Reads (preview/previewBulk) notify on failure (seam
+  // default) and carry no success toast; the remove mutation owns the success
+  // message, while bulkRemove handles its own partial-vs-full messaging on the
+  // resolved result, so it opts out of the success option.
+  const { call: previewDelete } = useMethod<DeleteImpactPreviewData>('integrity.preview');
+  const { call: previewBulkDelete } = useMethod<{ aggregate: DeleteImpactPreviewData; blockedIds: string[] }>('integrity.previewBulk');
+  const { call: removeEntry } = useMethod(`${collectionName}.remove`, { success: t('messages.deleteSuccess') });
+  const { call: bulkRemoveEntries } = useMethod<{ removed: number; errors: unknown[] }>(`${collectionName}.bulkRemove`);
+
   const user = useTracker(() => Meteor.user(), []);
   useSubscribe('roles', { _id: (user?.profile?.roleId ?? null) as unknown as string }, { limit: 1 });
   const roles = useFind(
@@ -168,14 +178,9 @@ export default function Section<T extends { _id?: string }>({
       const recordId = record._id;
       if (!recordId) return;
 
-      let preview: DeleteImpactPreviewData | null = null;
-      try {
-        preview = (await Meteor.callAsync('integrity.preview', collectionName, recordId)) as DeleteImpactPreviewData;
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({ message: err.error as string, description: err.message });
-        return;
-      }
+      const previewRes = await previewDelete(collectionName, recordId);
+      if (!previewRes.ok) return;
+      const preview = previewRes.data;
 
       const isBlocked = preview != null && preview.blockedBy.length > 0;
 
@@ -191,17 +196,11 @@ export default function Section<T extends { _id?: string }>({
         okText: t('common.delete'),
         cancelText: t('common.cancel'),
         onOk: async () => {
-          try {
-            await Meteor.callAsync(`${collectionName}.remove`, recordId);
-            message.success(t('messages.deleteSuccess'));
-          } catch (error) {
-            const err = error as Meteor.Error;
-            notification.error({ message: err.error as string, description: err.message });
-          }
+          await removeEntry(recordId);
         },
       });
     },
-    [notification, message, modal, collectionName, t]
+    [previewDelete, removeEntry, modal, collectionName, t]
   );
 
   const handleBulkDelete = useCallback(async () => {
@@ -212,17 +211,9 @@ export default function Section<T extends { _id?: string }>({
     // structured block panel and disable confirm — matches the single-delete
     // pre-flight pattern. Side-effect counts (pull/setNull/cascade) ride
     // along so admins see "this will affect 23 events" before committing.
-    let preview: { aggregate: DeleteImpactPreviewData; blockedIds: string[] } | null = null;
-    try {
-      preview = (await Meteor.callAsync('integrity.previewBulk', collectionName, ids)) as {
-        aggregate: DeleteImpactPreviewData;
-        blockedIds: string[];
-      };
-    } catch (error) {
-      const err = error as Meteor.Error;
-      notification.error({ message: err.error as string, description: err.message });
-      return;
-    }
+    const previewRes = await previewBulkDelete(collectionName, ids);
+    if (!previewRes.ok) return;
+    const preview = previewRes.data;
 
     const isBlocked = preview != null && preview.blockedIds.length > 0;
 
@@ -237,26 +228,21 @@ export default function Section<T extends { _id?: string }>({
       okButtonProps: { danger: true, disabled: isBlocked },
       onOk: async () => {
         setBulkActionLoading(true);
-        try {
-          const result = (await Meteor.callAsync(`${collectionName}.bulkRemove`, selectedRowKeys)) as {
-            removed: number;
-            errors: unknown[];
-          };
-          if (result.errors.length > 0) {
-            message.warning(t('messages.bulkDeletePartial', { removed: result.removed, errors: result.errors.length }));
+        // bulkRemove reports partial vs full success itself, so it skips the
+        // seam success option; the seam still notifies on outright failure.
+        const res = await bulkRemoveEntries(selectedRowKeys);
+        if (res.ok) {
+          if (res.data.errors.length > 0) {
+            message.warning(t('messages.bulkDeletePartial', { removed: res.data.removed, errors: res.data.errors.length }));
           } else {
-            message.success(t('messages.bulkDeleteSuccess', { count: result.removed }));
+            message.success(t('messages.bulkDeleteSuccess', { count: res.data.removed }));
           }
           setSelectedRowKeys([]);
-        } catch (error) {
-          const err = error as Meteor.Error;
-          notification.error({ message: err.error as string, description: err.message });
-        } finally {
-          setBulkActionLoading(false);
         }
+        setBulkActionLoading(false);
       },
     });
-  }, [selectedRowKeys, collectionName, modal, message, notification, t]);
+  }, [selectedRowKeys, collectionName, modal, message, previewBulkDelete, bulkRemoveEntries, t]);
 
   const handleClearSelection = useCallback(() => {
     setSelectedRowKeys([]);

--- a/imports/ui/specializations/SpecializationForm.tsx
+++ b/imports/ui/specializations/SpecializationForm.tsx
@@ -1,9 +1,9 @@
-import { App, Col, ColorPicker, Form, Input, Row } from 'antd';
+import { Col, ColorPicker, Form, Input, Row } from 'antd';
 import type { Rule } from 'antd/es/form';
-import { Meteor } from 'meteor/meteor';
 import React, { ComponentType, useCallback, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import FormFooter from '../components/FormFooter';
 import MembersSelect from '../members/MembersSelect';
 import RanksSelect from '../members/ranks/RanksSelect';
@@ -39,37 +39,32 @@ interface SpecializationFormValues {
 const SpecializationForm = () => {
   const { t } = useTranslation();
   const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Specialization> & { _id?: string }>();
-  const { message, notification } = App.useApp();
 
   const { model, endpoint } = useMemo(() => {
     const newModel = (rawModel || {}) as unknown as Specialization;
     return { model: newModel, endpoint: newModel?._id ? 'specializations.update' : 'specializations.insert' };
   }, [rawModel]);
 
+  const { call, loading } = useMethod<string | undefined>(endpoint, {
+    success: model?._id ? t('messages.specializationUpdated') : t('messages.specializationCreated'),
+  });
+
   const handleFinish = useCallback(
     async (values: SpecializationFormValues) => {
       const color = getColorFromValues(values);
       values.color = color;
       const args = [...(model?._id ? [model._id] : []), values];
-      try {
-        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
-        message.success(model?._id ? t('messages.specializationUpdated') : t('messages.specializationCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [resolve, notification, message, model?._id, endpoint, t]
+    [resolve, model?._id, call]
   );
 
   const [form] = Form.useForm<SpecializationFormValues>();
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model}>
+    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]}>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>
@@ -85,7 +80,13 @@ const SpecializationForm = () => {
           </Form.Item>
         </Col>
       </Row>
-      <MembersSelectTyped multiple name="instructors" label={t('specializations.instructors')} rules={[{ required: false, type: 'array' }]} defaultValue={model?.instructors} />
+      <MembersSelectTyped
+        multiple
+        name="instructors"
+        label={t('specializations.instructors')}
+        rules={[{ required: false, type: 'array' }]}
+        defaultValue={model?.instructors}
+      />
       <SpecializationsSelect
         multiple
         name="requiredSpecializations"
@@ -93,11 +94,16 @@ const SpecializationForm = () => {
         rules={[{ required: false, type: 'array' }]}
         defaultValue={model?.requiredSpecializations}
       />
-      <RanksSelectTyped name="requiredRankId" label={t('specializations.requiredRank')} rules={[{ required: false, type: 'string' }]} defaultValue={model?.requiredRankId} />
+      <RanksSelectTyped
+        name="requiredRankId"
+        label={t('specializations.requiredRank')}
+        rules={[{ required: false, type: 'string' }]}
+        defaultValue={model?.requiredRankId}
+      />
       <Form.Item name="description" label={t('common.description')} rules={[{ required: false, type: 'string' }]}>
         <Input.TextArea autoSize placeholder={t('forms.placeholders.enterDescription')} />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 };

--- a/imports/ui/squads/SquadsForm.tsx
+++ b/imports/ui/squads/SquadsForm.tsx
@@ -1,10 +1,11 @@
-import { App, Col, ColorPicker, Form, Input, Row, Switch, Upload } from 'antd';
+import { Col, ColorPicker, Form, Input, Row, Switch, Upload } from 'antd';
 import type { RcFile } from 'antd/es/upload';
 import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import type { Squad } from '../../api/types/squad';
 import { useDrawerFrame } from '../drawer-stack';
+import useMethod from '../hooks/useMethod';
 import FormFooter from '../components/FormFooter';
 import { turnBase64ToImage, turnImageFileToBase64 } from '../profile-picture-input/ProfilePictureInput';
 import { getColorFromValues } from '../specializations/SpecializationForm';
@@ -23,10 +24,13 @@ interface SquadsFormValues {
 
 const SquadsForm = () => {
   const { t } = useTranslation();
-  const { message, notification } = App.useApp();
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<Squad> & { _id?: string }>();
 
   const squad = (model || {}) as unknown as Squad;
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && squad?._id ? 'squads.update' : 'squads.insert', {
+    success: squad?._id ? t('messages.squadUpdated') : t('messages.squadCreated'),
+  });
 
   const [file, setFile] = useState<RcFile | null>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -56,24 +60,13 @@ const SquadsForm = () => {
     const image = imageSrc;
     values.image = image;
     const args = [...(squad?._id ? [squad._id] : []), values];
-    try {
-      const result = (await Meteor.callAsync(
-        Meteor.user() && squad?._id ? 'squads.update' : 'squads.insert',
-        ...args
-      )) as string | undefined;
-      message.success(squad?._id ? t('messages.squadUpdated') : t('messages.squadCreated'));
-      resolve(squad?._id ?? result);
-    } catch (error) {
-      const err = error as Meteor.Error;
-      notification.error({
-        message: err.error as string,
-        description: err.message,
-      });
-    }
+    const res = await call(...args);
+    if (!res.ok) return;
+    resolve(squad?._id ?? res.data);
   };
 
   return (
-    <Form layout="vertical" initialValues={squad} onFinish={handleFinish}>
+    <Form layout="vertical" initialValues={squad} onFinish={handleFinish} disabled={loading}>
       <Form.Item label={t('squads.logo')} name="image" rules={[{ required: false }]}>
         <Upload.Dragger
           fileList={file ? [file] : []}
@@ -97,7 +90,12 @@ const SquadsForm = () => {
           </Form.Item>
         </Col>
       </Row>
-      <SquadsSelect label={t('squads.parentSquad')} name="parentSquadId" rules={[{ required: false, type: 'string' }]} defaultValue={squad.parentSquadId} />
+      <SquadsSelect
+        label={t('squads.parentSquad')}
+        name="parentSquadId"
+        rules={[{ required: false, type: 'string' }]}
+        defaultValue={squad.parentSquadId}
+      />
       <Form.Item label={t('squads.shortRangeFrequency')} name="shortRangeFrequency" rules={[{ required: false, type: 'string' }]}>
         <Input placeholder={t('forms.placeholders.enterShortRangeFrequency')} />
       </Form.Item>
@@ -110,7 +108,7 @@ const SquadsForm = () => {
       <Form.Item label={t('squads.excludeFromOrbat')} name="excludeFromOrbat" valuePropName="checked">
         <Switch />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 };

--- a/imports/ui/tasks/TaskForm.tsx
+++ b/imports/ui/tasks/TaskForm.tsx
@@ -32,22 +32,18 @@ export default function TaskForm() {
     [model?._id]
   );
 
+  const { call, loading } = useMethod<string | undefined>(endpoint, {
+    success: isUpdate ? t('messages.taskUpdated') : t('messages.taskCreated'),
+  });
+
   const handleFinish = useCallback(
     async (values: Partial<Task>) => {
-      try {
-        const args = isUpdate ? [model._id as string, values] : [values];
-        const result = (await Meteor.callAsync(endpoint, ...args)) as string | undefined;
-        message.success(isUpdate ? t('messages.taskUpdated') : t('messages.taskCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({
-          message: err.error as string,
-          description: err.message,
-        });
-      }
+      const args = isUpdate ? [model._id as string, values] : [values];
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [resolve, endpoint, model?._id, isUpdate, message, notification, t]
+    [resolve, model?._id, isUpdate, call]
   );
 
   const [participantOptions, setParticipantOptions] = useState<MemberOption[]>([]);
@@ -87,7 +83,7 @@ export default function TaskForm() {
   }, [commentText, model?._id, message, notification, t]);
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model}>
+    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model} disabled={loading}>
       <Form.Item label={t('common.name')} name="name" rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>
@@ -138,7 +134,7 @@ export default function TaskForm() {
         subscription="tasks"
         FormComponent={TaskForm}
       />
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
 
       {/* Comments Section */}
       {isUpdate && (

--- a/imports/ui/tasks/task-status/TaskStatusForm.tsx
+++ b/imports/ui/tasks/task-status/TaskStatusForm.tsx
@@ -1,8 +1,9 @@
-import { App, ColorPicker, Form, Input } from 'antd';
+import { ColorPicker, Form, Input } from 'antd';
 import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { useDrawerFrame } from '../../drawer-stack';
+import useMethod from '../../hooks/useMethod';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { TaskStatus } from '/imports/api/types/misc';
@@ -10,9 +11,11 @@ import type { TaskStatus } from '/imports/api/types/misc';
 export default function TaskStatusForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { message, notification } = App.useApp();
-  const [loading, setLoading] = useState(false);
   const { model, resolve, cancel } = useDrawerFrame<string, Partial<TaskStatus>>();
+
+  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'taskStatus.update' : 'taskStatus.insert', {
+    success: model?._id ? t('messages.taskStatusUpdated') : t('messages.taskStatusCreated'),
+  });
 
   useEffect(() => {
     if (model && Object.keys(model).length > 0) {
@@ -28,24 +31,13 @@ export default function TaskStatusForm() {
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
-      setLoading(true);
       const { name, description } = values as { name: string; description?: string };
       const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      try {
-        const result = (await Meteor.callAsync(
-          Meteor.user() && model?._id ? 'taskStatus.update' : 'taskStatus.insert',
-          ...args
-        )) as string | undefined;
-        message.success(model?._id ? t('messages.taskStatusUpdated') : t('messages.taskStatusCreated'));
-        resolve(model?._id ?? result);
-      } catch (error) {
-        const err = error as Meteor.Error;
-        notification.error({ message: err.error as string, description: err.message });
-      } finally {
-        setLoading(false);
-      }
+      const res = await call(...args);
+      if (!res.ok) return;
+      resolve(model?._id ?? res.data);
     },
-    [model, resolve, message, notification, t]
+    [model, resolve, call]
   );
 
   return (
@@ -59,7 +51,7 @@ export default function TaskStatusForm() {
       <Form.Item name="color" label={t('common.color')}>
         <ColorPicker format="hex" />
       </Form.Item>
-      <FormFooter onCancel={cancel} />
+      <FormFooter onCancel={cancel} loading={loading} />
     </Form>
   );
 }


### PR DESCRIPTION
## Summary

Migrates the **mutation-tier** call sites onto the `useMethod` seam (issue #243, parent #241). After the read-site migration (#247), all read-only calls already use `useMethod`; this PR completes the picture by routing form-submit and delete mutations through the same hook, so the `unknown → Meteor.Error` narrowing, the failure-notification policy, the success toast, and the in-flight `loading` state are owned by the seam instead of re-derived in each handler.

## Forms migrated (insert/update submit handlers)

- `SquadsForm`, `MemberForm`, `RanksForm`, `MedalsForm`, `PositionsForm`, `RolesForm`
- `TaskStatusForm`, `EventTypesForm`, `DiscoveryTypesForm`
- `TaskForm`, `EventForm`, `RegistrationForm`, `QuestionnaireForm`, `BriefingTemplatesForm`
- `SpecializationForm` (`specializations.insert`/`specializations.update`), `QuestionnaireResponseForm` (`questionnaireResponses.submit`)

`EventForm` also has an in-form delete (`events.remove`); both its save and delete mutations now use separate `useMethod` instances.

## Section delete flow

`Section.tsx` `handleDelete` and `handleBulkDelete` are fully rewritten through `useMethod`, **including** the interleaved `integrity.preview` / `integrity.previewBulk` reads that the #242 sweep deliberately left woven into the delete handlers. Four hook instances: `integrity.preview`, `integrity.previewBulk` (reads, notify-on-failure, no success toast), `<collection>.remove` (carries the success toast), and `<collection>.bulkRemove`. `bulkRemove` keeps its partial-vs-full messaging on the resolved result, so it opts out of the seam `success` option and branches `message.warning`/`message.success` on `res.ok`.

## Loading-state wiring

`FormFooter` gains an optional `loading` prop (passed to the submit button). The hook's `loading` now drives submit-button loading and the form's `disabled` state, replacing the hand-rolled `useState` loading flags previously in MedalsForm, RanksForm, PositionsForm, TaskStatusForm, EventTypesForm, DiscoveryTypesForm, BriefingTemplatesForm, MemberForm, RegistrationForm. EventForm wires `loading` onto its custom Save button. The guard `if (loading || disableSubmit) return` in MemberForm/RegistrationForm now reads the hook's `loading`.

## Scope notes

- **Create-vs-update branching stays at the call site** (computed method name `model?._id ? '<c>.update' : '<c>.insert'`), per #245 — not collapsed here.
- **Left for #244:** the field-availability validators `members.validateName`/`validateId` and `registrations.validateName`/`validateId` are untouched.
- **Left as standalone actions** (not in #243 scope): `tasks.addComment` in TaskForm, and `specializations.request` in MemberProfile (a standalone action, not a form submit).

## Verification

- `npm test` — **374 passing** (exit 0)
- `npm run typecheck` — clean
- `npx prettier --check` on changed files — all pass
- `package-lock.json` left unchanged (incidental install churn reverted)

