### PR TITLE
refactor(ui): route field-availability validators through useMethod

### DIFF
--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -83,6 +83,9 @@ export default function MemberForm() {
     success: t('messages.saveSuccessful'),
   });
 
+  const { call: validateNameCall } = useMethod<boolean>('members.validateName', { notify: false });
+  const { call: validateIdCall } = useMethod<boolean>('members.validateId', { notify: false });
+
   useEffect(() => {
     if (Object.keys(model).length > 0) {
       const data = { ...model } as Record<string, unknown>;
@@ -119,31 +122,29 @@ export default function MemberForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const validateName = useCallback(() => {
+  const validateName = useCallback(async () => {
     const value = form.getFieldValue(['profile', 'name']);
     setNameError('validating');
-    Meteor.callAsync('members.validateName', value, model?._id || false)
-      .then((result: boolean) => {
-        setNameError(result ? 'success' : 'error');
-        setNameAvailable(result);
-      })
-      .catch(() => {
-        setNameError('warning');
-      });
-  }, [form, model?._id]);
+    const res = await validateNameCall(value, model?._id || false);
+    if (res.ok) {
+      setNameError(res.data ? 'success' : 'error');
+      setNameAvailable(res.data);
+    } else {
+      setNameError('warning');
+    }
+  }, [form, model?._id, validateNameCall]);
 
-  const validateId = useCallback(() => {
+  const validateId = useCallback(async () => {
     const value = form.getFieldValue(['profile', 'id']);
     setIdError('validating');
-    Meteor.callAsync('members.validateId', value, model?._id || false)
-      .then((result: boolean) => {
-        setIdError(result ? 'success' : 'error');
-        setIdAvailable(result);
-      })
-      .catch(() => {
-        setIdError('warning');
-      });
-  }, [form, model?._id]);
+    const res = await validateIdCall(value, model?._id || false);
+    if (res.ok) {
+      setIdError(res.data ? 'success' : 'error');
+      setIdAvailable(res.data);
+    } else {
+      setIdError('warning');
+    }
+  }, [form, model?._id, validateIdCall]);
 
   const handleSubmit = useCallback(
     async (values: MemberFormValues) => {

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -50,6 +50,9 @@ export default function RegistrationForm() {
     { success: t('messages.registrationSuccessful') }
   );
 
+  const { call: validateNameCall } = useMethod<boolean>('registrations.validateName', { notify: false });
+  const { call: validateIdCall } = useMethod<boolean>('registrations.validateId', { notify: false });
+
   useEffect(() => {
     if (Object.keys(model).length > 0) {
       form.setFieldsValue(model as unknown as RegistrationFormValues);
@@ -67,31 +70,29 @@ export default function RegistrationForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const validateName = useCallback(() => {
+  const validateName = useCallback(async () => {
     const value = form.getFieldValue('name');
     setNameError('validating');
-    Meteor.callAsync('registrations.validateName', value, (model as Registration)?._id)
-      .then((result: boolean) => {
-        setNameError(result ? 'success' : 'error');
-        setNameAvailable(result);
-      })
-      .catch(() => {
-        setNameError('warning');
-      });
-  }, [form.getFieldValue, (model as Registration)?._id]);
+    const res = await validateNameCall(value, (model as Registration)?._id);
+    if (res.ok) {
+      setNameError(res.data ? 'success' : 'error');
+      setNameAvailable(res.data);
+    } else {
+      setNameError('warning');
+    }
+  }, [form.getFieldValue, (model as Registration)?._id, validateNameCall]);
 
-  const validateId = useCallback(() => {
+  const validateId = useCallback(async () => {
     const value = form.getFieldValue('id');
     setIdError('validating');
-    Meteor.callAsync('registrations.validateId', value, (model as Registration)?._id)
-      .then((result: boolean) => {
-        setIdError(result ? 'success' : 'error');
-        setIdAvailable(result);
-      })
-      .catch(() => {
-        setIdError('warning');
-      });
-  }, [form.getFieldValue, (model as Registration)?._id]);
+    const res = await validateIdCall(value, (model as Registration)?._id);
+    if (res.ok) {
+      setIdError(res.data ? 'success' : 'error');
+      setIdAvailable(res.data);
+    } else {
+      setIdError('warning');
+    }
+  }, [form.getFieldValue, (model as Registration)?._id, validateIdCall]);
 
   useSubscribe('discoveryTypes', {}, {});
   const discoveryTypes = useFind(() => DiscoveryTypesCollection.find({}), []);


### PR DESCRIPTION
## What

Routes the four async field-availability validators through the `useMethod` seam with `{ notify: false }`, completing the MethodCall migration for these form-field validators. Submit handlers (already on `useMethod` from #248) and reads are untouched.

### The 4 validators migrated
- `imports/ui/members/MemberForm.tsx` — `validateName` (`members.validateName`), `validateId` (`members.validateId`)
- `imports/ui/registration/RegistrationForm.tsx` — `validateName` (`registrations.validateName`), `validateId` (`registrations.validateId`)

Each validator gets its own top-level `useMethod<boolean>(..., { notify: false })` hook (MemberForm and RegistrationForm each gain TWO new hooks alongside the existing submit hook).

### Three-state mapping preserved (not regressed from 299cdeb)
The distinct outcomes are kept distinct:
- **`'validating'`** — set before the call (in-flight).
- **`'success'` / `'error'`** — decided by the boolean RESULT on `res.ok`: name/id taken is `res.ok && res.data === false` => `'error'`.
- **`'warning'`** — the old `.catch`, i.e. the call itself FAILED (`res.ok === false`). This is NOT collapsed into the error case — "name taken" and "call failed" remain different states.

`{ notify: false }` keeps validation keystrokes silent: no `notification.error` ever fires from a validation keystroke, and no success toast is shown (no `success` option). Each form's existing state-setters are preserved exactly (both forms call `setNameAvailable`/`setIdAvailable`), and the exact second argument is preserved per form (`model?._id || false` for members, `(model as Registration)?._id` for registrations).

## Verification
- `npm test`: 374 passing (exit 0)
- `npm run typecheck`: clean (exit 0)
- `npx prettier --check` on both changed files: clean

Refs #244, parent #241.
