### PR TITLE
feat(ui): add useEntityForm and adopt it across entity forms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,10 +90,10 @@ The deep module (`imports/ui/hooks/useEntityForm.ts`) that owns the create-vs-up
 
 The seam is one hook:
 
-- **`useEntityForm<V, P>({ collection, created, updated, toPayload? })`** — self-sources the drawer frame (`useDrawerFrame`) and returns `{ onFinish, loading, model, cancel }`.
+- **`useEntityForm<V, M>({ collection, created, updated, toPayload? })`** — self-sources the drawer frame (`useDrawerFrame`) and returns `{ onFinish, loading, model, cancel }`. `V` is the antd form-values shape; `M` is the model type read from the frame.
   - `collection` is a `CrudCollectionName`; the method name is derived mechanically as `${collection}.update` / `${collection}.insert`.
-  - `created` / `updated` are `LocaleKey`s; the hook picks between them, so the call site no longer writes the `model?._id ? t(a) : t(b)` ternary.
-  - `toPayload(values: V) => P` (optional, defaults to identity) is the one genuinely form-specific step — which fields, color extraction, date parsing — and closes over component state (`imageSrc`, …).
+  - `created` / `updated` are `ParameterlessLocaleKey`s (a success toast carries no interpolation params); the hook picks between them, so the call site no longer writes the `model?._id ? t(a) : t(b)` ternary.
+  - `toPayload(values: V) => unknown` (optional, defaults to identity) is the one genuinely form-specific step — which fields, color extraction, date parsing — and closes over component state (`imageSrc`, …). The payload is sent untyped through `useMethod`/`callAsync`, so it is intentionally not constrained to a payload generic (TS cannot infer it alongside the explicit `<V, M>`).
   - `onFinish(values)` is the ready-to-use antd `<Form onFinish>` handler: it shapes args as `[...(isUpdate ? [model._id] : []), toPayload(values)]`, calls the method through `useMethod`, and on success resolves the frame with `model?._id ?? data`. On failure it does nothing (the seam already notified).
   - `model` / `cancel` are re-exposed from the self-sourced frame, so the form needs no separate `useDrawerFrame` call (`initialValues={model}`, `<FormFooter onCancel={cancel} loading={loading} />`).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,7 +82,34 @@ Channel convention is baked in: success → `message` (toast), failure → `noti
 
 Internally the seam has a private core: `runMethodCall(invoke, policy, feedback)` (`imports/ui/hooks/runMethodCall.ts`) holds all the policy — narrowing, notify/success decisions, the discriminated outcome — with no React and no antd. `useMethod` is the thin adapter that wires React `loading`/`error`/`data` state and `App.useApp()` feedback onto it. That internal seam is what makes the policy testable in the server test context (`tests/server/runMethodCall.test.ts`, DOM-free), with the hook's React wiring covered by a browser-only smoke test (`tests/client/hooks/useMethod.test.tsx`) — the same split the [[DrawerStack]] uses (pure `drawerStackStore` + browser hook test).
 
-What the previous design could not express, now structural: the `error as Meteor.Error` cast (forced into every `catch` by `strict`) lives in one place; changing notification policy, adding telemetry, or adding retry is one edit instead of touching ~69 call sites; and the accidental error-extraction drift (`error.reason || error.message` at one site, a missing `as string` cast at two others) cannot recur because there is exactly one extraction — `{ message: error.error, description: error.reason || error.message }`, preferring the clean reason and dropping the `[<code>]` suffix Meteor appends to `.message`. The bespoke success *strings* stay at the call sites where they belong, so the hook is not a pass-through. The per-form create-vs-update branching of *name* and *message* is deliberately **not** absorbed here — that is the job of a future `useEntityForm` lifecycle built on top of this seam.
+What the previous design could not express, now structural: the `error as Meteor.Error` cast (forced into every `catch` by `strict`) lives in one place; changing notification policy, adding telemetry, or adding retry is one edit instead of touching ~69 call sites; and the accidental error-extraction drift (`error.reason || error.message` at one site, a missing `as string` cast at two others) cannot recur because there is exactly one extraction — `{ message: error.error, description: error.reason || error.message }`, preferring the clean reason and dropping the `[<code>]` suffix Meteor appends to `.message`. The bespoke success *strings* stay at the call sites where they belong, so the hook is not a pass-through. The per-form create-vs-update branching of *name* and *message* is deliberately **not** absorbed here — that is the job of the [[EntityForm]] lifecycle (`useEntityForm`) built on top of this seam.
+
+### EntityForm
+
+The deep module (`imports/ui/hooks/useEntityForm.ts`) that owns the create-vs-update submit lifecycle of a drawer entity form. Built on top of [[MethodCall]]: where `useMethod` owns one client method call, `useEntityForm` owns the whole "save this entity" flow — choosing insert vs update, computing the success message, shaping the call arguments, and resolving the drawer frame on success.
+
+The seam is one hook:
+
+- **`useEntityForm<V, P>({ collection, created, updated, toPayload? })`** — self-sources the drawer frame (`useDrawerFrame`) and returns `{ onFinish, loading, model, cancel }`.
+  - `collection` is a `CrudCollectionName`; the method name is derived mechanically as `${collection}.update` / `${collection}.insert`.
+  - `created` / `updated` are `LocaleKey`s; the hook picks between them, so the call site no longer writes the `model?._id ? t(a) : t(b)` ternary.
+  - `toPayload(values: V) => P` (optional, defaults to identity) is the one genuinely form-specific step — which fields, color extraction, date parsing — and closes over component state (`imageSrc`, …).
+  - `onFinish(values)` is the ready-to-use antd `<Form onFinish>` handler: it shapes args as `[...(isUpdate ? [model._id] : []), toPayload(values)]`, calls the method through `useMethod`, and on success resolves the frame with `model?._id ?? data`. On failure it does nothing (the seam already notified).
+  - `model` / `cancel` are re-exposed from the self-sourced frame, so the form needs no separate `useDrawerFrame` call (`initialValues={model}`, `<FormFooter onCancel={cancel} loading={loading} />`).
+
+The create-vs-update axis is a single derived predicate: `isUpdate = !!Meteor.user() && !!model?._id`, used for **both** the method name and the success message. The `Meteor.user() &&` clause means an anonymous caller always inserts (load-bearing for the anonymous RegistrationForm; a no-op for forms only reachable while authenticated). This unifies a latent inconsistency in the hand-rolled forms, where the name used the user-guarded predicate but the message used only `model?._id`.
+
+Escape hatches are **composition, not configuration**. The interface stays tiny; forms that deviate compose around it rather than feeding it flags:
+
+- a pre-submit guard (Member/Registration `disableSubmit`) wraps `onFinish`;
+- an extra mutation (Event's in-form delete, Task's add-comment) is a separate `useMethod` alongside;
+- a form that is not create-vs-update at all (QuestionnaireResponseForm — a single `questionnaireResponses.submit` resolving `true`) keeps using `useMethod` directly and does not adopt the hook.
+
+There is deliberately no `canSubmit` / `resolveWith` / `extraActions` / `method`-override config — that path is the DSL drift the [[Rule of three]] guards against.
+
+Internally the seam splits like [[MethodCall]] and [[DrawerStack]]: a pure DOM-free core (the `isUpdate` rule, method-name derivation, arg shaping, resolve-value computation) tested under server-mode `npm test`, with the hook as the thin adapter wiring `useDrawerFrame` + `useMethod`, covered by a browser-only smoke test.
+
+What becomes structurally impossible: the ~10× duplicated insert/update plumbing (name ternary, `[...(id?[id]:[]), payload]` arg shaping, `if (!res.ok) return; resolve(id ?? data)`) collapses to one implementation; the name/message create-vs-update inconsistency cannot recur; and a new entity form declares only its `collection`, its two message keys, and its `toPayload`.
 
 ## Doctrines
 

--- a/imports/ui/briefing-templates/BriefingTemplatesForm.tsx
+++ b/imports/ui/briefing-templates/BriefingTemplatesForm.tsx
@@ -1,9 +1,8 @@
 import { ColorPicker, Form, Input } from 'antd';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
-import { useDrawerFrame } from '../drawer-stack';
-import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import FormFooter from '../components/FormFooter';
 import RichTextEditor from '../components/RichTextEditor';
 import type { BriefingTemplate } from '../../api/types';
@@ -11,10 +10,19 @@ import type { BriefingTemplate } from '../../api/types';
 export default function BriefingTemplatesForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<BriefingTemplate>>();
-
-  const { call, loading } = useMethod<string | undefined>(rawModel?._id ? 'briefingTemplates.update' : 'briefingTemplates.insert', {
-    success: rawModel?._id ? t('messages.briefingTemplateUpdated') : t('messages.briefingTemplateCreated'),
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<Record<string, unknown>, Partial<BriefingTemplate>>({
+    collection: 'briefingTemplates',
+    created: 'messages.briefingTemplateCreated',
+    updated: 'messages.briefingTemplateUpdated',
+    toPayload: values => {
+      const { name, description, content } = values as { name: string; description?: string; content?: string };
+      return { name, color: getColorFromValues(values), description, content };
+    },
   });
 
   // Provide values synchronously via initialValues (not a setFieldsValue effect):
@@ -30,19 +38,8 @@ export default function BriefingTemplatesForm() {
     [rawModel]
   );
 
-  const handleSubmit = useCallback(
-    async (values: Record<string, unknown>) => {
-      const { name, description, content } = values as { name: string; description?: string; content?: string };
-      const args = [...(rawModel?._id ? [rawModel._id] : []), { name, color: getColorFromValues(values), description, content }];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(rawModel?._id ?? res.data);
-    },
-    [rawModel, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" initialValues={model} onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" initialValues={model} onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/events/EventForm.tsx
+++ b/imports/ui/events/EventForm.tsx
@@ -13,9 +13,10 @@ import type { EventDoc, BriefingTemplate } from '../../api/types';
 import type { CollectionDoc } from '../components/CollectionSelect';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
-import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter } from '../drawer-stack';
 import CollectionSelect from '../components/CollectionSelect';
 import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import MembersSelect from '../members/MembersSelect';
 import RichTextEditor from '../components/RichTextEditor';
 import shouldConfirmTemplateOverwrite from '/imports/helpers/shouldConfirmTemplateOverwrite';
@@ -51,7 +52,22 @@ export const getDateFromValues = (values: Record<string, unknown>, key = 'date')
 const EventForm = () => {
   const { modal } = App.useApp();
   const { t } = useTranslation();
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<EventDoc>>();
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<EventFormValues, Partial<EventDoc>>({
+    collection: 'events',
+    created: 'messages.eventCreated',
+    updated: 'messages.eventUpdated',
+    toPayload: values => ({
+      ...values,
+      color: getColorFromValues(values as unknown as Record<string, unknown>),
+      start: getDateFromValues(values as unknown as Record<string, unknown>, 'start'),
+      end: getDateFromValues(values as unknown as Record<string, unknown>, 'end'),
+    }),
+  });
 
   const model = useMemo(() => {
     const data = (rawModel || {}) as unknown as EventDoc;
@@ -63,26 +79,7 @@ const EventForm = () => {
     } as EventFormValues & { _id?: string };
   }, [rawModel]);
 
-  const { call: save, loading } = useMethod<string | undefined>(model?._id ? 'events.update' : 'events.insert', {
-    success: model?._id ? t('messages.eventUpdated') : t('messages.eventCreated'),
-  });
   const { call: remove } = useMethod('events.remove', { success: t('messages.eventDeleted') });
-
-  const handleFinish = useCallback(
-    async (values: EventFormValues) => {
-      const wireValues = {
-        ...values,
-        color: getColorFromValues(values as unknown as Record<string, unknown>),
-        start: getDateFromValues(values as unknown as Record<string, unknown>, 'start'),
-        end: getDateFromValues(values as unknown as Record<string, unknown>, 'end'),
-      };
-      const args = [...(model?._id ? [model._id] : []), wireValues];
-      const res = await save(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model?._id, save, resolve]
-  );
 
   const handleDelete = useCallback(() => {
     modal.confirm({
@@ -101,7 +98,7 @@ const EventForm = () => {
   const [form] = Form.useForm<EventFormValues>();
 
   return (
-    <Form form={form} layout="vertical" initialValues={model} onFinish={handleFinish} disabled={loading}>
+    <Form form={form} layout="vertical" initialValues={model} onFinish={onFinish} disabled={loading}>
       <Form.Item name="start" label={t('events.startDate')} rules={[{ required: true, type: 'date' }]}>
         <DatePicker style={styles.datePicker} showTime />
       </Form.Item>

--- a/imports/ui/events/event-types/EventTypesForm.tsx
+++ b/imports/ui/events/event-types/EventTypesForm.tsx
@@ -1,9 +1,7 @@
 import { ColorPicker, Form, Input } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '../../specializations/SpecializationForm';
 import type { EventType } from '../../../api/types';
@@ -11,10 +9,14 @@ import type { EventType } from '../../../api/types';
 export default function EventTypesForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<EventType>>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'eventTypes.update' : 'eventTypes.insert', {
-    success: model?._id ? t('messages.eventTypeUpdated') : t('messages.eventTypeCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<Record<string, unknown>, Partial<EventType>>({
+    collection: 'eventTypes',
+    created: 'messages.eventTypeCreated',
+    updated: 'messages.eventTypeUpdated',
+    toPayload: values => {
+      const { name, description } = values as { name: string; description?: string };
+      return { name, color: getColorFromValues(values), description };
+    },
   });
 
   useEffect(() => {
@@ -29,19 +31,8 @@ export default function EventTypesForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: Record<string, unknown>) => {
-      const { name, description } = values as { name: string; description?: string };
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/hooks/entityFormSubmit.ts
+++ b/imports/ui/hooks/entityFormSubmit.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure logic core of the EntityForm seam (see CONTEXT.md → EntityForm).
+ *
+ * Owns the create-vs-update decisions — the `isUpdate` rule, the method-name
+ * derivation, the call-argument shaping, and the frame resolve value — with no
+ * React, no antd, and no Meteor runtime, so it is fully testable without a DOM.
+ * The `useEntityForm` hook is the thin adapter that wires `useDrawerFrame` and
+ * `useMethod` onto these functions.
+ */
+
+/**
+ * The single create-vs-update predicate. A model id alone is not enough: an
+ * anonymous caller always inserts (load-bearing for the anonymous RegistrationForm).
+ */
+export function entityIsUpdate(hasUser: boolean, modelId: string | undefined): boolean {
+  return hasUser && !!modelId;
+}
+
+/** Derives `<collection>.update` / `<collection>.insert` mechanically. */
+export function entityMethodName(collection: string, isUpdate: boolean): string {
+  return `${collection}.${isUpdate ? 'update' : 'insert'}`;
+}
+
+/** Shapes the method call arguments: `[id, payload]` to update, `[payload]` to insert. */
+export function entityArgs(isUpdate: boolean, modelId: string | undefined, payload: unknown): unknown[] {
+  return isUpdate ? [modelId, payload] : [payload];
+}
+
+/**
+ * The value the drawer frame resolves with on success: the existing model id
+ * (an update resolves the same doc) or, failing that, the data the insert returned.
+ */
+export function entityResolveValue(modelId: string | undefined, data: unknown): unknown {
+  return modelId ?? data;
+}

--- a/imports/ui/hooks/useEntityForm.ts
+++ b/imports/ui/hooks/useEntityForm.ts
@@ -1,0 +1,82 @@
+import { useCallback, useRef } from 'react';
+import { Meteor } from 'meteor/meteor';
+import { useTranslation } from '/imports/i18n/LanguageContext';
+import type { ParameterlessLocaleKey } from '/imports/i18n';
+import type { CrudCollectionName } from '/imports/api/types/crud';
+import { useDrawerFrame } from '../drawer-stack';
+import useMethod from './useMethod';
+import { entityArgs, entityIsUpdate, entityMethodName, entityResolveValue } from './entityFormSubmit';
+
+/**
+ * The EntityForm seam — see CONTEXT.md → EntityForm.
+ *
+ * Owns the create-vs-update submit lifecycle of a drawer entity form. Built on
+ * top of MethodCall: where `useMethod` owns one client method call, this hook
+ * owns the whole "save this entity" flow — choosing insert vs update, computing
+ * the success message, shaping the call arguments, and resolving the drawer
+ * frame on success. The DOM-free decision logic lives in `entityFormSubmit`.
+ *
+ * Escape hatches are composition, not configuration: a pre-submit guard wraps
+ * `onFinish`, an extra mutation is a separate `useMethod` alongside, and a form
+ * that is not create-vs-update keeps using `useMethod` directly.
+ */
+
+interface EntityModel {
+  _id?: string;
+}
+
+export interface UseEntityFormOptions<V> {
+  /** The collection — the method name is derived as `<collection>.update` / `<collection>.insert`. */
+  collection: CrudCollectionName;
+  /** Success message shown when inserting. */
+  created: ParameterlessLocaleKey;
+  /** Success message shown when updating. */
+  updated: ParameterlessLocaleKey;
+  /**
+   * The one form-specific step: map antd form values to the wire payload
+   * (field selection, color extraction, date parsing, …). Defaults to identity.
+   * The payload is sent untyped through `useMethod`, so its shape is intentionally
+   * not constrained to `V`.
+   */
+  toPayload?: (values: V) => unknown;
+}
+
+export interface UseEntityForm<V, M> {
+  onFinish: (values: V) => Promise<void>;
+  loading: boolean;
+  model: M;
+  cancel: () => void;
+}
+
+export default function useEntityForm<V, M extends EntityModel = EntityModel>(options: UseEntityFormOptions<V>): UseEntityForm<V, M> {
+  const { collection, created, updated, toPayload } = options;
+  const { t } = useTranslation();
+  const { model, resolve, cancel } = useDrawerFrame<string, M>();
+
+  const modelId = model?._id;
+  // Non-reactive read, exactly as the hand-rolled forms did — anonymous callers
+  // always insert (load-bearing for the anonymous RegistrationForm).
+  const isUpdate = entityIsUpdate(!!Meteor.user(), modelId);
+
+  const { call, loading } = useMethod<string | undefined>(entityMethodName(collection, isUpdate), {
+    success: t(isUpdate ? updated : created),
+  });
+
+  // Store toPayload in a ref refreshed each render so onFinish closes over the
+  // latest component state (imageSrc, …) without itself churning identity.
+  const toPayloadRef = useRef(toPayload);
+  toPayloadRef.current = toPayload;
+
+  const onFinish = useCallback(
+    async (values: V) => {
+      const transform = toPayloadRef.current;
+      const payload = transform ? transform(values) : values;
+      const res = await call(...entityArgs(isUpdate, modelId, payload));
+      if (!res.ok) return;
+      resolve(entityResolveValue(modelId, res.data) as string | undefined);
+    },
+    [call, isUpdate, modelId, resolve]
+  );
+
+  return { onFinish, loading, model, cancel };
+}

--- a/imports/ui/members/MemberForm.tsx
+++ b/imports/ui/members/MemberForm.tsx
@@ -9,8 +9,9 @@ import RanksCollection from '../../api/collections/ranks.collection';
 import RolesCollection from '../../api/collections/roles.collection';
 import type { Member } from '../../api/types/member';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter } from '../drawer-stack';
 import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import { getDateFromValues } from '../events/EventForm';
 import ProfilePictureInput from '../profile-picture-input/ProfilePictureInput';
@@ -76,12 +77,25 @@ export default function MemberForm() {
   const [nameError, setNameError] = useState<ValidationStatus>(undefined);
   const [idError, setIdError] = useState<ValidationStatus>(undefined);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Member>>();
-  const model = useMemo(() => (rawModel || {}) as Member, [rawModel]);
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'members.update' : 'members.insert', {
-    success: t('messages.saveSuccessful'),
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<MemberFormValues, Partial<Member>>({
+    collection: 'members',
+    created: 'messages.saveSuccessful',
+    updated: 'messages.saveSuccessful',
+    toPayload: values => ({
+      ...values,
+      profile: {
+        ...values.profile,
+        entryDate: getDateFromValues(values.profile as unknown as Record<string, unknown>, 'entryDate'),
+        exitDate: getDateFromValues(values.profile as unknown as Record<string, unknown>, 'exitDate'),
+      },
+    }),
   });
+  const model = useMemo(() => (rawModel || {}) as Member, [rawModel]);
 
   const { call: validateNameCall } = useMethod<boolean>('members.validateName', { notify: false });
   const { call: validateIdCall } = useMethod<boolean>('members.validateId', { notify: false });
@@ -147,26 +161,16 @@ export default function MemberForm() {
   }, [form, model?._id, validateIdCall]);
 
   const handleSubmit = useCallback(
-    async (values: MemberFormValues) => {
+    (values: MemberFormValues) => {
       // Guard the submit itself, not just the footer button. The button's
       // `disabled` blocks clicks, but Enter-to-submit fires through the form's
       // hidden submit button — which bypasses `disableSubmit` (name or id
-      // already in use / rules not accepted) unless we re-check here.
+      // already in use / rules not accepted) unless we re-check here. The
+      // create-vs-update plumbing lives in useEntityForm; this only adds the guard.
       if (loading || disableSubmit) return;
-      const payload = {
-        ...values,
-        profile: {
-          ...values.profile,
-          entryDate: getDateFromValues(values.profile as unknown as Record<string, unknown>, 'entryDate'),
-          exitDate: getDateFromValues(values.profile as unknown as Record<string, unknown>, 'exitDate'),
-        },
-      };
-      const args = model?._id ? [model._id, payload] : [payload];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
+      onFinish(values);
     },
-    [model?._id, resolve, call, loading, disableSubmit]
+    [onFinish, loading, disableSubmit]
   );
 
   const handleValuesChange = useCallback(

--- a/imports/ui/members/medals/MedalsForm.tsx
+++ b/imports/ui/members/medals/MedalsForm.tsx
@@ -1,11 +1,9 @@
 import { ColorPicker, Form, Input } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Medal } from '../../../api/types/misc';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 
 interface MedalFormValues {
@@ -17,10 +15,11 @@ interface MedalFormValues {
 export default function MedalsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<MedalFormValues>();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Medal> & { _id?: string }>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'medals.update' : 'medals.insert', {
-    success: model?._id ? t('messages.medalUpdated') : t('messages.medalCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<MedalFormValues, Partial<Medal> & { _id?: string }>({
+    collection: 'medals',
+    created: 'messages.medalCreated',
+    updated: 'messages.medalUpdated',
+    toPayload: values => ({ name: values.name, color: getColorFromValues(values), description: values.description }),
   });
 
   useEffect(() => {
@@ -35,22 +34,8 @@ export default function MedalsForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: MedalFormValues) => {
-      const { name, description } = values;
-      const args = [
-        ...(model?._id ? [model._id] : []),
-        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description },
-      ];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/members/positions/PositionsForm.tsx
+++ b/imports/ui/members/positions/PositionsForm.tsx
@@ -1,10 +1,8 @@
 import { ColorPicker, Form, Input, InputNumber } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 import type { Position } from '../../../api/types/misc';
 
@@ -18,10 +16,11 @@ interface PositionFormValues {
 export default function PositionsForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<PositionFormValues>();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Position> & { _id?: string }>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'positions.update' : 'positions.insert', {
-    success: model?._id ? t('messages.positionUpdated') : t('messages.positionCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<PositionFormValues, Partial<Position> & { _id?: string }>({
+    collection: 'positions',
+    created: 'messages.positionCreated',
+    updated: 'messages.positionUpdated',
+    toPayload: values => ({ name: values.name, color: getColorFromValues(values), description: values.description, order: values.order }),
   });
 
   useEffect(() => {
@@ -37,22 +36,8 @@ export default function PositionsForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: PositionFormValues) => {
-      const { name, description, order } = values;
-      const args = [
-        ...(model?._id ? [model._id] : []),
-        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, order },
-      ];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/members/ranks/RanksForm.tsx
+++ b/imports/ui/members/ranks/RanksForm.tsx
@@ -1,11 +1,9 @@
 import { ColorPicker, Form, Input, Select } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { Rank } from '../../../api/types/rank';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 import RanksSelect from './RanksSelect';
 
@@ -21,10 +19,14 @@ interface RankFormValues {
 export default function RanksForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm<RankFormValues>();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Rank> & { _id?: string }>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'ranks.update' : 'ranks.insert', {
-    success: model?._id ? t('messages.rankUpdated') : t('messages.rankCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<RankFormValues, Partial<Rank> & { _id?: string }>({
+    collection: 'ranks',
+    created: 'messages.rankCreated',
+    updated: 'messages.rankUpdated',
+    toPayload: values => {
+      const { name, description, previousRankId, nextRankId, type } = values;
+      return { name, color: getColorFromValues(values), description, previousRankId, nextRankId, type };
+    },
   });
 
   useEffect(() => {
@@ -41,22 +43,8 @@ export default function RanksForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: RankFormValues) => {
-      const { name, description, previousRankId, nextRankId, type } = values;
-      const args = [
-        ...(model?._id ? [model._id] : []),
-        { name, color: getColorFromValues(values as unknown as Record<string, unknown>), description, previousRankId, nextRankId, type },
-      ];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/members/roles/RolesForm.tsx
+++ b/imports/ui/members/roles/RolesForm.tsx
@@ -1,13 +1,12 @@
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Card, Checkbox, ColorPicker, Form, Input, Space, Switch, Typography } from 'antd';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { TranslateFn } from '../../section/types';
 import type { LocaleKey } from '/imports/i18n';
 import type { CrudPermission, Role } from '../../../api/types/role';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 
 interface RuleInputProps {
@@ -71,32 +70,24 @@ function prepareModelForForm(model: Role | null | undefined): Record<string, unk
 
 const RolesForm = () => {
   const { t } = useTranslation();
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Role> & { _id?: string }>();
-  const model = (rawModel || {}) as Role & { _id?: string };
-  const { isUpdate, endpoint } = useMemo(
-    () => (model?._id ? { isUpdate: true, endpoint: 'roles.update' } : { isUpdate: false, endpoint: 'roles.insert' }),
-    [model?._id]
-  );
-
-  const { call, loading } = useMethod<string | undefined>(endpoint, {
-    success: isUpdate ? t('messages.roleUpdated') : t('messages.roleCreated'),
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<Record<string, unknown>, Partial<Role> & { _id?: string }>({
+    collection: 'roles',
+    created: 'messages.roleCreated',
+    updated: 'messages.roleUpdated',
+    toPayload: values => ({ ...values, color: getColorFromValues(values) }),
   });
-
-  const handleFinish = useCallback(
-    async (values: Record<string, unknown>) => {
-      const args = [...(model?._id ? [model._id] : []), { ...values, color: getColorFromValues(values) }];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model?._id, resolve, call]
-  );
+  const model = (rawModel || {}) as Role & { _id?: string };
 
   const [form] = Form.useForm<Record<string, unknown>>();
   const initialValues = useMemo(() => prepareModelForForm(model), [model]);
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={initialValues} disabled={loading}>
+    <Form layout="vertical" form={form} onFinish={onFinish} initialValues={initialValues} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/questionnaires/QuestionnaireForm.tsx
+++ b/imports/ui/questionnaires/QuestionnaireForm.tsx
@@ -1,11 +1,10 @@
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Button, Card, Form, Input, Select, Space, Switch } from 'antd';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import type { Questionnaire, QuestionnaireInterval, QuestionnaireStatus, QuestionType } from '../../api/types/questionnaire';
 import { useTranslation } from '../../i18n/LanguageContext';
 import type { TranslateFn } from '../section/types';
-import { useDrawerFrame } from '../drawer-stack';
-import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import FormFooter from '../components/FormFooter';
 
 interface QuestionTypeOption {
@@ -41,17 +40,18 @@ interface QuestionItemProps {
 }
 
 const QuestionnaireForm = () => {
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Questionnaire>>();
   const { t } = useTranslation();
-  const questionnaire = (model || {}) as unknown as Questionnaire;
-  const { isUpdate, endpoint } = useMemo(
-    () => (questionnaire?._id ? { isUpdate: true, endpoint: 'questionnaires.update' } : { isUpdate: false, endpoint: 'questionnaires.insert' }),
-    [questionnaire?._id]
-  );
-
-  const { call, loading } = useMethod<string | undefined>(endpoint, {
-    success: isUpdate ? t('questionnaires.updated') : t('questionnaires.created'),
+  const { onFinish, loading, model, cancel } = useEntityForm<QuestionnaireFormValues, Partial<Questionnaire>>({
+    collection: 'questionnaires',
+    created: 'questionnaires.created',
+    updated: 'questionnaires.updated',
+    toPayload: values => ({
+      ...values,
+      createdAt: questionnaire?.createdAt || new Date(),
+      updatedAt: new Date(),
+    }),
   });
+  const questionnaire = (model || {}) as unknown as Questionnaire;
 
   const questionTypes: QuestionTypeOption[] = useMemo(
     () => [
@@ -76,25 +76,10 @@ const QuestionnaireForm = () => {
     [t]
   );
 
-  const handleFinish = useCallback(
-    async (values: QuestionnaireFormValues) => {
-      const payload = {
-        ...values,
-        createdAt: questionnaire?.createdAt || new Date(),
-        updatedAt: new Date(),
-      };
-      const args = isUpdate ? [questionnaire._id, payload] : [payload];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(questionnaire?._id ?? res.data);
-    },
-    [resolve, questionnaire?._id, questionnaire?.createdAt, isUpdate, call]
-  );
-
   const [form] = Form.useForm<QuestionnaireFormValues>();
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={questionnaire} disabled={loading}>
+    <Form layout="vertical" form={form} onFinish={onFinish} initialValues={questionnaire} disabled={loading}>
       <Form.Item
         label={t('common.name')}
         name="name"

--- a/imports/ui/registration/RegistrationForm.tsx
+++ b/imports/ui/registration/RegistrationForm.tsx
@@ -7,9 +7,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import DiscoveryTypesCollection from '../../api/collections/discoveryTypes.collection';
 import type { Registration } from '../../api/types';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { DrawerFooter, useDrawerFrame } from '../drawer-stack';
+import { DrawerFooter } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import DiscoveryTypeForm from './discovery-types/DiscoveryTypesForm';
 
 interface RegistrationFormValues {
@@ -26,8 +27,28 @@ interface RegistrationFormValues {
 
 export default function RegistrationForm() {
   const [form] = Form.useForm<RegistrationFormValues>();
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Registration>>();
   const { t } = useTranslation();
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<RegistrationFormValues, Partial<Registration>>({
+    collection: 'registrations',
+    created: 'messages.registrationSuccessful',
+    updated: 'messages.registrationSuccessful',
+    toPayload: ({ name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description }) => ({
+      name,
+      id,
+      age,
+      discoveryType,
+      discoveryTypeDetails,
+      steamProfileLink,
+      discordTag,
+      rulesReadAndAccepted,
+      description,
+    }),
+  });
   // Track name/id availability as independent signals and derive disableSubmit
   // from them. Folding both into one state let the two async validations
   // clobber each other (last-writer-wins), so an in-use name could be masked by
@@ -44,11 +65,6 @@ export default function RegistrationForm() {
     if (!Meteor.user()) return {};
     return (rawModel as unknown as Registration) || {};
   }, [rawModel]);
-
-  const { call, loading } = useMethod<string | undefined>(
-    Meteor.user() && (model as Registration)?._id ? 'registrations.update' : 'registrations.insert',
-    { success: t('messages.registrationSuccessful') }
-  );
 
   const { call: validateNameCall } = useMethod<boolean>('registrations.validateName', { notify: false });
   const { call: validateIdCall } = useMethod<boolean>('registrations.validateId', { notify: false });
@@ -108,22 +124,16 @@ export default function RegistrationForm() {
   }, [form, discoveryTypes]);
 
   const handleSubmit = useCallback(
-    async (values: RegistrationFormValues) => {
+    (values: RegistrationFormValues) => {
       // Guard the submit itself, not just the footer button. The button's
       // `disabled` blocks clicks, but Enter-to-submit fires through the form's
       // hidden submit button — which bypasses `disableSubmit` (rules not
-      // accepted / name or id already in use) unless we re-check here.
+      // accepted / name or id already in use) unless we re-check here. The
+      // insert-vs-update plumbing (anonymous always inserts) lives in useEntityForm.
       if (loading || disableSubmit) return;
-      const { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description } = values;
-      const args = [
-        ...((model as Registration)?._id ? [(model as Registration)._id] : []),
-        { name, id, age, discoveryType, discoveryTypeDetails, steamProfileLink, discordTag, rulesReadAndAccepted, description },
-      ];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve((model as Registration)?._id ?? res.data);
+      onFinish(values);
     },
-    [resolve, model, call, loading, disableSubmit]
+    [onFinish, loading, disableSubmit]
   );
 
   const handleValuesChange = useCallback(

--- a/imports/ui/registration/discovery-types/DiscoveryTypesForm.tsx
+++ b/imports/ui/registration/discovery-types/DiscoveryTypesForm.tsx
@@ -1,9 +1,7 @@
 import { ColorPicker, Form, Input, Switch } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { DiscoveryType } from '../../../api/types';
@@ -11,10 +9,14 @@ import type { DiscoveryType } from '../../../api/types';
 export default function DiscoveryTypeForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<DiscoveryType> & { _id?: string }>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'discoveryTypes.update' : 'discoveryTypes.insert', {
-    success: model?._id ? t('messages.discoveryTypeUpdated') : t('messages.discoveryTypeCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<Record<string, unknown>, Partial<DiscoveryType> & { _id?: string }>({
+    collection: 'discoveryTypes',
+    created: 'messages.discoveryTypeCreated',
+    updated: 'messages.discoveryTypeUpdated',
+    toPayload: values => {
+      const { name, description, hasTextInput } = values as { name: string; description?: string; hasTextInput?: boolean };
+      return { name, color: getColorFromValues(values), description, hasTextInput: !!hasTextInput };
+    },
   });
 
   useEffect(() => {
@@ -30,19 +32,8 @@ export default function DiscoveryTypeForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: Record<string, unknown>) => {
-      const { name, description, hasTextInput } = values as { name: string; description?: string; hasTextInput?: boolean };
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description, hasTextInput: !!hasTextInput }];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/specializations/SpecializationForm.tsx
+++ b/imports/ui/specializations/SpecializationForm.tsx
@@ -1,9 +1,8 @@
 import { Col, ColorPicker, Form, Input, Row } from 'antd';
 import type { Rule } from 'antd/es/form';
-import React, { ComponentType, useCallback, useMemo } from 'react';
+import React, { ComponentType, useMemo } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { useDrawerFrame } from '../drawer-stack';
-import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import FormFooter from '../components/FormFooter';
 import MembersSelect from '../members/MembersSelect';
 import RanksSelect from '../members/ranks/RanksSelect';
@@ -38,33 +37,24 @@ interface SpecializationFormValues {
 
 const SpecializationForm = () => {
   const { t } = useTranslation();
-  const { model: rawModel, resolve, cancel } = useDrawerFrame<string, Partial<Specialization> & { _id?: string }>();
-
-  const { model, endpoint } = useMemo(() => {
-    const newModel = (rawModel || {}) as unknown as Specialization;
-    return { model: newModel, endpoint: newModel?._id ? 'specializations.update' : 'specializations.insert' };
-  }, [rawModel]);
-
-  const { call, loading } = useMethod<string | undefined>(endpoint, {
-    success: model?._id ? t('messages.specializationUpdated') : t('messages.specializationCreated'),
+  const {
+    onFinish,
+    loading,
+    model: rawModel,
+    cancel,
+  } = useEntityForm<SpecializationFormValues, Partial<Specialization> & { _id?: string }>({
+    collection: 'specializations',
+    created: 'messages.specializationCreated',
+    updated: 'messages.specializationUpdated',
+    toPayload: values => ({ ...values, color: getColorFromValues(values) }),
   });
 
-  const handleFinish = useCallback(
-    async (values: SpecializationFormValues) => {
-      const color = getColorFromValues(values);
-      values.color = color;
-      const args = [...(model?._id ? [model._id] : []), values];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [resolve, model?._id, call]
-  );
+  const model = useMemo(() => (rawModel || {}) as unknown as Specialization, [rawModel]);
 
   const [form] = Form.useForm<SpecializationFormValues>();
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model} disabled={loading}>
+    <Form layout="vertical" form={form} onFinish={onFinish} initialValues={model} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]}>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/squads/SquadsForm.tsx
+++ b/imports/ui/squads/SquadsForm.tsx
@@ -1,11 +1,9 @@
 import { Col, ColorPicker, Form, Input, Row, Switch, Upload } from 'antd';
 import type { RcFile } from 'antd/es/upload';
-import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
 import type { Squad } from '../../api/types/squad';
-import { useDrawerFrame } from '../drawer-stack';
-import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import FormFooter from '../components/FormFooter';
 import { turnBase64ToImage, turnImageFileToBase64 } from '../profile-picture-input/ProfilePictureInput';
 import { getColorFromValues } from '../specializations/SpecializationForm';
@@ -24,16 +22,17 @@ interface SquadsFormValues {
 
 const SquadsForm = () => {
   const { t } = useTranslation();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Squad> & { _id?: string }>();
-
-  const squad = (model || {}) as unknown as Squad;
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && squad?._id ? 'squads.update' : 'squads.insert', {
-    success: squad?._id ? t('messages.squadUpdated') : t('messages.squadCreated'),
-  });
-
   const [file, setFile] = useState<RcFile | null>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
+
+  const { onFinish, loading, model, cancel } = useEntityForm<SquadsFormValues, Partial<Squad> & { _id?: string }>({
+    collection: 'squads',
+    created: 'messages.squadCreated',
+    updated: 'messages.squadUpdated',
+    toPayload: values => ({ ...values, color: getColorFromValues(values), image: imageSrc }),
+  });
+
+  const squad = (model || {}) as unknown as Squad;
 
   useEffect(() => {
     if (!squad.image) return;
@@ -54,19 +53,8 @@ const SquadsForm = () => {
     return setFile(fileList[0]);
   };
 
-  const handleFinish = async (values: SquadsFormValues) => {
-    const color = getColorFromValues(values);
-    values.color = color;
-    const image = imageSrc;
-    values.image = image;
-    const args = [...(squad?._id ? [squad._id] : []), values];
-    const res = await call(...args);
-    if (!res.ok) return;
-    resolve(squad?._id ?? res.data);
-  };
-
   return (
-    <Form layout="vertical" initialValues={squad} onFinish={handleFinish} disabled={loading}>
+    <Form layout="vertical" initialValues={squad} onFinish={onFinish} disabled={loading}>
       <Form.Item label={t('squads.logo')} name="image" rules={[{ required: false }]}>
         <Upload.Dragger
           fileList={file ? [file] : []}

--- a/imports/ui/tasks/TaskForm.tsx
+++ b/imports/ui/tasks/TaskForm.tsx
@@ -8,10 +8,10 @@ import TasksCollection from '../../api/collections/tasks.collection';
 import TaskStatusCollection from '../../api/collections/taskStatus.collection';
 import type { Task, TaskComment } from '../../api/types/task';
 import { useTranslation } from '../../i18n/LanguageContext';
-import { useDrawerFrame } from '../drawer-stack';
 import CollectionSelect, { type CollectionDoc } from '../components/CollectionSelect';
 import FormFooter from '../components/FormFooter';
 import useMethod from '../hooks/useMethod';
+import useEntityForm from '../hooks/useEntityForm';
 import MembersSelectJs from '../members/MembersSelect';
 import TaskStatusForm from './task-status/TaskStatusForm';
 
@@ -24,27 +24,16 @@ interface MemberOption {
 }
 
 export default function TaskForm() {
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<Task>>();
   const { message, notification } = App.useApp();
   const { t } = useTranslation();
-  const { isUpdate, endpoint } = useMemo(
-    () => (model?._id ? { isUpdate: true, endpoint: 'tasks.update' } : { isUpdate: false, endpoint: 'tasks.insert' }),
-    [model?._id]
-  );
-
-  const { call, loading } = useMethod<string | undefined>(endpoint, {
-    success: isUpdate ? t('messages.taskUpdated') : t('messages.taskCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<Partial<Task>, Partial<Task>>({
+    collection: 'tasks',
+    created: 'messages.taskCreated',
+    updated: 'messages.taskUpdated',
   });
-
-  const handleFinish = useCallback(
-    async (values: Partial<Task>) => {
-      const args = isUpdate ? [model._id as string, values] : [values];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [resolve, model?._id, isUpdate, call]
-  );
+  // Drives the comments section visibility (existing task only) — separate from
+  // useEntityForm's internal create-vs-update predicate.
+  const isUpdate = !!model?._id;
 
   const [participantOptions, setParticipantOptions] = useState<MemberOption[]>([]);
   const { call: fetchMemberOptions } = useMethod<MemberOption[]>('members.options');
@@ -83,7 +72,7 @@ export default function TaskForm() {
   }, [commentText, model?._id, message, notification, t]);
 
   return (
-    <Form layout="vertical" form={form} onFinish={handleFinish} initialValues={model} disabled={loading}>
+    <Form layout="vertical" form={form} onFinish={onFinish} initialValues={model} disabled={loading}>
       <Form.Item label={t('common.name')} name="name" rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/imports/ui/tasks/task-status/TaskStatusForm.tsx
+++ b/imports/ui/tasks/task-status/TaskStatusForm.tsx
@@ -1,9 +1,7 @@
 import { ColorPicker, Form, Input } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from '/imports/i18n/LanguageContext';
-import { useDrawerFrame } from '../../drawer-stack';
-import useMethod from '../../hooks/useMethod';
+import useEntityForm from '../../hooks/useEntityForm';
 import FormFooter from '../../components/FormFooter';
 import { getColorFromValues } from '/imports/helpers/colors/getColorFromValues';
 import type { TaskStatus } from '/imports/api/types/misc';
@@ -11,10 +9,14 @@ import type { TaskStatus } from '/imports/api/types/misc';
 export default function TaskStatusForm() {
   const { t } = useTranslation();
   const [form] = Form.useForm();
-  const { model, resolve, cancel } = useDrawerFrame<string, Partial<TaskStatus>>();
-
-  const { call, loading } = useMethod<string | undefined>(Meteor.user() && model?._id ? 'taskStatus.update' : 'taskStatus.insert', {
-    success: model?._id ? t('messages.taskStatusUpdated') : t('messages.taskStatusCreated'),
+  const { onFinish, loading, model, cancel } = useEntityForm<Record<string, unknown>, Partial<TaskStatus>>({
+    collection: 'taskStatus',
+    created: 'messages.taskStatusCreated',
+    updated: 'messages.taskStatusUpdated',
+    toPayload: values => {
+      const { name, description } = values as { name: string; description?: string };
+      return { name, color: getColorFromValues(values), description };
+    },
   });
 
   useEffect(() => {
@@ -29,19 +31,8 @@ export default function TaskStatusForm() {
     }
   }, [model, form.setFieldsValue]);
 
-  const handleSubmit = useCallback(
-    async (values: Record<string, unknown>) => {
-      const { name, description } = values as { name: string; description?: string };
-      const args = [...(model?._id ? [model._id] : []), { name, color: getColorFromValues(values), description }];
-      const res = await call(...args);
-      if (!res.ok) return;
-      resolve(model?._id ?? res.data);
-    },
-    [model, resolve, call]
-  );
-
   return (
-    <Form form={form} layout="vertical" onFinish={handleSubmit} disabled={loading}>
+    <Form form={form} layout="vertical" onFinish={onFinish} disabled={loading}>
       <Form.Item name="name" label={t('common.name')} rules={[{ required: true, type: 'string' }]} required>
         <Input placeholder={t('forms.placeholders.enterName')} />
       </Form.Item>

--- a/tests/client/hooks/useEntityForm.test.tsx
+++ b/tests/client/hooks/useEntityForm.test.tsx
@@ -1,0 +1,163 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import React, { type ReactNode } from 'react';
+
+// React-wiring smoke test for the EntityForm seam: proves the hook self-sources
+// the drawer frame, derives the method name via the pure core, shapes args, and
+// resolves the frame on success. The exhaustive create-vs-update logic lives in
+// tests/server/entityFormSubmit.test.ts (pure, DOM-free). This file only runs in
+// the Meteor client test context (a browser).
+if (Meteor.isClient) {
+  const ReactDOMClient = require('react-dom/client') as typeof import('react-dom/client');
+  const { act } = require('react-dom/test-utils') as { act: (cb: () => void | Promise<void>) => Promise<void> };
+  const { App } = require('antd') as typeof import('antd');
+  const { LanguageProvider } = require('/imports/i18n/LanguageContext') as typeof import('/imports/i18n/LanguageContext');
+  const { FrameContext } = require('/imports/ui/drawer-stack/DrawerStackProvider') as typeof import('/imports/ui/drawer-stack/DrawerStackProvider');
+
+  type UseEntityFormHook = typeof import('/imports/ui/hooks/useEntityForm').default;
+  type UseEntityForm<V, M> = import('/imports/ui/hooks/useEntityForm').UseEntityForm<V, M>;
+  type UseEntityFormOptions<V> = import('/imports/ui/hooks/useEntityForm').UseEntityFormOptions<V>;
+  const useEntityForm = (require('/imports/ui/hooks/useEntityForm') as { default: UseEntityFormHook }).default;
+
+  const realCallAsync = Meteor.callAsync.bind(Meteor);
+  const realUser = Meteor.user.bind(Meteor);
+  function stubCallAsync(impl: (name: string, ...args: unknown[]) => Promise<unknown>) {
+    (Meteor as unknown as { callAsync: typeof Meteor.callAsync }).callAsync = impl as typeof Meteor.callAsync;
+  }
+  function stubUser(user: unknown) {
+    (Meteor as unknown as { user: typeof Meteor.user }).user = (() => user) as typeof Meteor.user;
+  }
+  afterEach(() => {
+    (Meteor as unknown as { callAsync: typeof Meteor.callAsync }).callAsync = realCallAsync;
+    (Meteor as unknown as { user: typeof Meteor.user }).user = realUser;
+  });
+
+  async function mountUseEntityForm<V, M extends { _id?: string }>(model: M, options: UseEntityFormOptions<V>) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const captured: { current: UseEntityForm<V, M> | null } = { current: null };
+    const resolved: unknown[] = [];
+
+    const fakeFrame = {
+      model,
+      resolve: (value: unknown) => resolved.push(value),
+      cancel: () => {},
+      confirmCloseRef: { current: null },
+      footerContainer: null,
+    };
+
+    function Probe() {
+      captured.current = useEntityForm<V, M>(options);
+      return null;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(async () => {
+      root.render(
+        <App>
+          <LanguageProvider>
+            <FrameContext.Provider value={fakeFrame}>
+              <Probe />
+            </FrameContext.Provider>
+          </LanguageProvider>
+        </App>
+      );
+    });
+
+    return {
+      get current() {
+        return captured.current!;
+      },
+      resolved,
+      unmount: async () => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      },
+    };
+  }
+
+  describe('useEntityForm — React wiring of the EntityForm seam', () => {
+    it('returns { onFinish, loading:false, model, cancel } and re-exposes the frame model', async () => {
+      stubUser(null);
+      stubCallAsync(async () => undefined);
+      const model = { _id: 'sq1', name: 'Alpha' };
+      const hook = await mountUseEntityForm(model, {
+        collection: 'squads',
+        created: 'messages.squadCreated',
+        updated: 'messages.squadUpdated',
+      });
+      assert.strictEqual(typeof hook.current.onFinish, 'function');
+      assert.strictEqual(hook.current.loading, false);
+      assert.strictEqual(typeof hook.current.cancel, 'function');
+      assert.deepStrictEqual(hook.current.model, model);
+      await hook.unmount();
+    });
+
+    it('updates (calls <c>.update with [id, payload]) and resolves the frame with the existing id when a user is present', async () => {
+      stubUser({ _id: 'u1' });
+      const seen: unknown[][] = [];
+      stubCallAsync(async (name, ...args) => {
+        seen.push([name, ...args]);
+        return 'ignored-return';
+      });
+      const hook = await mountUseEntityForm(
+        { _id: 'sq1', name: 'Alpha' },
+        {
+          collection: 'squads',
+          created: 'messages.squadCreated',
+          updated: 'messages.squadUpdated',
+          toPayload: (v: { name?: string }) => ({ name: v.name }),
+        }
+      );
+      await act(async () => {
+        await hook.current.onFinish({ name: 'Bravo' });
+      });
+      assert.deepStrictEqual(seen, [['squads.update', 'sq1', { name: 'Bravo' }]]);
+      assert.deepStrictEqual(hook.resolved, ['sq1']);
+      await hook.unmount();
+    });
+
+    it('inserts (calls <c>.insert with [payload]) and resolves the frame with the returned id when anonymous (even with a model id)', async () => {
+      stubUser(null);
+      const seen: unknown[][] = [];
+      stubCallAsync(async (name, ...args) => {
+        seen.push([name, ...args]);
+        return 'new-id';
+      });
+      const hook = await mountUseEntityForm(
+        { _id: 'sq1' },
+        {
+          collection: 'squads',
+          created: 'messages.squadCreated',
+          updated: 'messages.squadUpdated',
+          toPayload: (v: { name?: string }) => ({ name: v.name }),
+        }
+      );
+      await act(async () => {
+        await hook.current.onFinish({ name: 'Charlie' });
+      });
+      assert.deepStrictEqual(seen, [['squads.insert', { name: 'Charlie' }]]);
+      // Anonymous always inserts, so the new id from the server is resolved.
+      assert.deepStrictEqual(hook.resolved, ['new-id']);
+      await hook.unmount();
+    });
+
+    it('does not resolve the frame on failure', async () => {
+      stubUser({ _id: 'u1' });
+      stubCallAsync(async () => {
+        throw new Meteor.Error('forbidden', 'Not allowed');
+      });
+      const hook = await mountUseEntityForm(
+        { _id: 'sq1' },
+        { collection: 'squads', created: 'messages.squadCreated', updated: 'messages.squadUpdated' }
+      );
+      await act(async () => {
+        await hook.current.onFinish({} as never);
+      });
+      assert.strictEqual(hook.resolved.length, 0);
+      await hook.unmount();
+    });
+  });
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,6 +1,7 @@
 import './client/config.test';
 import './client/hooks/drawerStackHooks.test';
 import './client/hooks/drawerStackStore.test';
+import './client/hooks/useEntityForm.test';
 import './client/hooks/useMethod.test';
 import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
@@ -8,6 +9,7 @@ import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
 import './server/briefingTemplatesMethods.test';
 import './server/crudMethods.test';
+import './server/entityFormSubmit.test';
 import './server/eventsDescriptionSanitize.test';
 import './server/getCollection.test';
 import './server/htmlSanitizer.test';

--- a/tests/server/entityFormSubmit.test.ts
+++ b/tests/server/entityFormSubmit.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert';
+import { entityArgs, entityIsUpdate, entityMethodName, entityResolveValue } from '/imports/ui/hooks/entityFormSubmit';
+
+// Pure DOM-free core of the EntityForm seam — the create-vs-update logic (see
+// CONTEXT.md → EntityForm). No React, no antd, no Meteor runtime, so it runs in
+// the server test context; the hook's React wiring is the browser-only smoke test.
+
+describe('entityFormSubmit — the EntityForm logic core', () => {
+  describe('entityIsUpdate', () => {
+    it('is true only when there is a user AND a model id', () => {
+      assert.strictEqual(entityIsUpdate(true, 'abc'), true);
+    });
+
+    it('is false when there is a model id but no user (anonymous always inserts)', () => {
+      assert.strictEqual(entityIsUpdate(false, 'abc'), false);
+    });
+
+    it('is false when there is a user but no model id (create)', () => {
+      assert.strictEqual(entityIsUpdate(true, undefined), false);
+    });
+
+    it('is false when there is neither a user nor a model id', () => {
+      assert.strictEqual(entityIsUpdate(false, undefined), false);
+    });
+  });
+
+  describe('entityMethodName', () => {
+    it('derives <collection>.update when updating', () => {
+      assert.strictEqual(entityMethodName('squads', true), 'squads.update');
+    });
+
+    it('derives <collection>.insert when creating', () => {
+      assert.strictEqual(entityMethodName('squads', false), 'squads.insert');
+    });
+  });
+
+  describe('entityArgs', () => {
+    it('shapes [modelId, payload] when updating', () => {
+      assert.deepStrictEqual(entityArgs(true, 'abc', { name: 'Alpha' }), ['abc', { name: 'Alpha' }]);
+    });
+
+    it('shapes [payload] when creating', () => {
+      assert.deepStrictEqual(entityArgs(false, undefined, { name: 'Alpha' }), [{ name: 'Alpha' }]);
+    });
+
+    it('omits the id when inserting even if a stale id is passed', () => {
+      assert.deepStrictEqual(entityArgs(false, 'abc', { name: 'Alpha' }), [{ name: 'Alpha' }]);
+    });
+  });
+
+  describe('entityResolveValue', () => {
+    it('prefers the existing model id (update resolves the same doc)', () => {
+      assert.strictEqual(entityResolveValue('abc', 'new-id'), 'abc');
+    });
+
+    it('falls back to the returned data (insert resolves the new id)', () => {
+      assert.strictEqual(entityResolveValue(undefined, 'new-id'), 'new-id');
+    });
+
+    it('falls back to the returned data when both are absent', () => {
+      assert.strictEqual(entityResolveValue(undefined, undefined), undefined);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **EntityForm** seam (`useEntityForm`) that owns the create-vs-update submit lifecycle of a drawer entity form, built on top of the existing **MethodCall** seam, and adopts it across the entity forms. See `CONTEXT.md` → EntityForm for the authoritative contract.

Closes #245 (parent: #241).

## The seam (pure core + hook)

Mirrors the MethodCall / DrawerStack split — a pure DOM-free core plus a thin React adapter:

- **`imports/ui/hooks/entityFormSubmit.ts`** — pure logic core, no React/antd/Meteor-runtime imports:
  - `entityIsUpdate(hasUser, modelId)` → `hasUser && !!modelId`
  - `entityMethodName(collection, isUpdate)` → `<collection>.update` / `<collection>.insert`
  - `entityArgs(isUpdate, modelId, payload)` → `[id, payload]` vs `[payload]`
  - `entityResolveValue(modelId, data)` → `modelId ?? data`
- **`imports/ui/hooks/useEntityForm.ts`** — `useEntityForm<V, M>({ collection, created, updated, toPayload? })` self-sources `useDrawerFrame`, reads `Meteor.user()` non-reactively, computes `isUpdate` via the core, drives `useMethod`, and returns `{ onFinish, loading, model, cancel }`. `toPayload` is stored in a ref so `onFinish` stays stable while still closing over the latest component state (e.g. `imageSrc`).

The single derived predicate `isUpdate = !!Meteor.user() && !!model?._id` drives **both** the method name and the success message. This unifies a latent inconsistency in the hand-rolled forms, where the name used the user-guarded predicate but the message used only `model?._id`.

## Forms migrated directly (simple)

Squads, Medals, Ranks, Positions, Roles, TaskStatus, EventTypes, DiscoveryTypes, Specialization, BriefingTemplates, **Questionnaire**. Each keeps its exact `created`/`updated` LocaleKeys and its exact payload transform (field selection, `getColorFromValues`, etc.) expressed as `toPayload`.

> Note: QuestionnaireForm was not in the original list but is a textbook create-vs-update form that hand-rolled the same ternary + arg-shaping; migrating it keeps the "no form hand-rolls the plumbing" invariant true. Its `createdAt`/`updatedAt` stamping became its `toPayload`.

## Forms composed (complex — composition, not config flags)

- **MemberForm** / **RegistrationForm** — use `useEntityForm` for the submit and wrap `onFinish` with the existing `disableSubmit` guard (`v => { if (loading || disableSubmit) return; onFinish(v); }`). Validators (`members.validateName/Id`, `registrations.validateName/Id` via `useMethod` notify:false) and the custom Save button are untouched. The anonymous RegistrationForm still always inserts when logged out — exactly what the `!!Meteor.user()` clause preserves.
- **EventForm** — uses `useEntityForm` for the save; keeps the separate `useMethod('events.remove')` in-form delete and the `members.read` reads. `loading` wired into the custom Save button.
- **TaskForm** — uses `useEntityForm` for the submit; keeps `tasks.addComment` (raw `Meteor.callAsync`) and the `members.options` read. A local `isUpdate = !!model?._id` drives the comments-section visibility.

## Deliberately excluded

**QuestionnaireResponseForm** stays on raw `useMethod` — it is a single `questionnaireResponses.submit` resolving `true`, not a create-vs-update form (per CONTEXT.md).

## Tests

- `tests/server/entityFormSubmit.test.ts` (TDD-first) — exhaustive truth table for the pure core (isUpdate, method-name, arg shaping, resolve value).
- `tests/client/hooks/useEntityForm.test.tsx` — browser-only smoke test mirroring `useMethod.test.tsx`, mounted under real antd `<App>` + `LanguageProvider` + a `FrameContext` provider.
- Both registered in `tests/main.ts` (alphabetical).

## Verification

- `npm test`: **386 passing**, real exit code **0** (was 374; +12 from the new pure-core suite). The client smoke test runs only under a browser driver, same as the existing `useMethod`/drawer client tests.
- `npm run typecheck`: clean (exit 0).
- `npx prettier --check` on all changed files: all pass.
- Grep confirms no migrated form still hand-rolls the `<c>.update : <c>.insert` ternary or the `[...(id?[id]:[]), payload]` arg-shaping for its main submit.
