### PR TITLE
Fix registration uniqueness defect + server-side validation

### DIFF
--- a/server/apis/registrations.server.ts
+++ b/server/apis/registrations.server.ts
@@ -8,11 +8,11 @@ if (Meteor.isServer) {
     'registrations.validateId': async function (id: number = 0, excludeId: string | false = false): Promise<boolean> {
       validateNumber(id, false);
 
-      const filter: Record<string, unknown> = { $and: [{ 'profile.id': id }] };
-      if (this.userId && excludeId) {
-        (filter.$and as Record<string, unknown>[]).push({ 'profile.id': { $ne: id } });
-      }
-      const matchingMembers = await MembersCollection.findOneAsync(filter);
+      // Members are never the edit target on this path, so a member sharing the
+      // id is always a real collision — no self-exclusion clause (the old
+      // `{ 'profile.id': { $ne: id } }` push contradicted `{ 'profile.id': id }`
+      // and silently masked member collisions on the edit path, #265).
+      const matchingMembers = await MembersCollection.findOneAsync({ 'profile.id': id });
 
       const registrationFilter: Record<string, unknown> = {
         $and: [{ id: id }],
@@ -28,13 +28,10 @@ if (Meteor.isServer) {
         throw new Meteor.Error('invalid-name', 'Invalid name', name);
       }
 
-      const filter: Record<string, unknown> = {
-        $and: [{ 'profile.name': name }],
-      };
-      if (this.userId && excludeId) {
-        (filter.$and as Record<string, unknown>[]).push({ 'profile.name': { $ne: name } });
-      }
-      const matchingMembers = await MembersCollection.findOneAsync(filter);
+      // See validateId: members are never the edit target here, so a member
+      // sharing the name is always a real collision. The old self-exclusion
+      // push contradicted the match clause and masked member collisions (#265).
+      const matchingMembers = await MembersCollection.findOneAsync({ 'profile.name': name });
 
       const registrationFilter: Record<string, unknown> = {
         $and: [{ name: name }],

--- a/server/crud.lib.ts
+++ b/server/crud.lib.ts
@@ -102,6 +102,32 @@ function sanitizeHtmlFields(collection: CrudCollectionName, payload: Record<stri
   }
 }
 
+// Registration id/age bounds — see imports/ui/registration/RegistrationForm.tsx,
+// where these were previously enforced client-side only (#260). Kept as a
+// constant so the rule reads the same on the server as on the form.
+const REGISTRATION_ID_MIN = 1000;
+const REGISTRATION_ID_MAX = 9999;
+const REGISTRATION_MIN_AGE = 16;
+
+// Per-collection insert-only validators, run inside the generic `.insert`
+// validate hook after the shared shape check. Insert-only by design (#260): a
+// crafted DDP insert must respect the same bounds as the form, but pre-existing
+// out-of-range rows stay editable (update is intentionally not gated here).
+// Registrations are the lone case today, so this stays a single inline entry
+// rather than a registry field (Rule of Three).
+const INSERT_VALIDATORS: Partial<Record<CrudCollectionName, (payload: Record<string, unknown>) => void>> = {
+  registrations: payload => {
+    const id = payload.id;
+    if (typeof id !== 'number' || !Number.isInteger(id) || id < REGISTRATION_ID_MIN || id > REGISTRATION_ID_MAX) {
+      throw new Meteor.Error('invalid-id', `Registration id must be an integer between ${REGISTRATION_ID_MIN} and ${REGISTRATION_ID_MAX}`);
+    }
+    const age = payload.age;
+    if (typeof age !== 'number' || age < REGISTRATION_MIN_AGE) {
+      throw new Meteor.Error('invalid-age', `Registration age must be at least ${REGISTRATION_MIN_AGE}`);
+    }
+  },
+};
+
 const DEFAULT_PUBLISH_LIMIT = 100;
 const MAX_PUBLISH_LIMIT = 1000;
 
@@ -180,7 +206,10 @@ function createCollectionMethods(collection: CrudCollectionName): void {
               permissionModule,
               fallbackFlag: fallback?.create,
               allowAnonymous: allowsAnonymousInsert,
-              validate: ([p]) => validateObject(p, false),
+              validate: ([p]) => {
+                validateObject(p, false);
+                INSERT_VALIDATORS[collection]?.(p);
+              },
             },
             [payload] as const,
             async ([p]) => {

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -27,6 +27,7 @@ import './server/paletteSearch.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
 import './server/readSecurityHardening.test';
+import './server/registrationsMethods.test';
 import './server/runMethodCall.test';
 import './server/settingsMethods.test';
 import './server/shouldConfirmTemplateOverwrite.test';

--- a/tests/server/registrationsMethods.test.ts
+++ b/tests/server/registrationsMethods.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert';
+import MembersCollection from '../../imports/api/collections/members.collection';
+import RegistrationsCollection from '../../imports/api/collections/registrations.collection';
+import {
+  assertRejectsWithCode,
+  callAs,
+  cleanupFixtures,
+  createTestDoc,
+  createTestUser,
+  TEST_PREFIX,
+} from './fixtures';
+
+// A valid registration payload shared across the insert-validation specs.
+function validRegistration(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: '__test_reg_valid',
+    id: 1234,
+    age: 18,
+    rulesReadAndAccepted: true,
+    ...overrides,
+  };
+}
+
+describe('registrations.validateId / validateName — edit-path member-collision detection (#265)', () => {
+  let editorUserId: string;
+  // A member that "owns" an id/name a registration edit might collide with.
+  const memberId = 4242;
+  const memberName = '__test_member_collision';
+
+  before(async () => {
+    editorUserId = await createTestUser();
+    // Member whose profile.id / profile.name we expect collisions against.
+    await MembersCollection.insertAsync({
+      _id: `${TEST_PREFIX}collision_member`,
+      username: `${TEST_PREFIX}collision_member`,
+      profile: { name: memberName, id: memberId },
+    } as never);
+  });
+
+  after(async () => {
+    await cleanupFixtures([MembersCollection, RegistrationsCollection]);
+  });
+
+  it('detects a member id collision on the EDIT path (excludeId set)', async () => {
+    // Edit path: an existing registration is being edited (excludeId provided).
+    // A member already holds this id, so the id is NOT available.
+    const regId = await createTestDoc(RegistrationsCollection, validRegistration({ id: memberId }));
+    const available = await callAs(editorUserId, 'registrations.validateId', memberId, regId);
+    assert.strictEqual(available, false, 'Member id collision must be detected on edit path');
+  });
+
+  it('detects a member name collision on the EDIT path (excludeId set)', async () => {
+    const regId = await createTestDoc(RegistrationsCollection, validRegistration({ name: memberName }));
+    const available = await callAs(editorUserId, 'registrations.validateName', memberName, regId);
+    assert.strictEqual(available, false, 'Member name collision must be detected on edit path');
+  });
+
+  it('still excludes the registration being edited from its own collision check', async () => {
+    // Self-exclusion ({ _id: { $ne: excludeId } }) is retained: editing a
+    // registration must not flag its own id/name as taken.
+    const regId = await createTestDoc(RegistrationsCollection, validRegistration({ id: 5555, name: '__test_reg_self' }));
+    const idAvailable = await callAs(editorUserId, 'registrations.validateId', 5555, regId);
+    const nameAvailable = await callAs(editorUserId, 'registrations.validateName', '__test_reg_self', regId);
+    assert.strictEqual(idAvailable, true, 'A registration must not collide with itself on id');
+    assert.strictEqual(nameAvailable, true, 'A registration must not collide with itself on name');
+  });
+
+  it('reports a free id/name as available', async () => {
+    const idAvailable = await callAs(editorUserId, 'registrations.validateId', 9001, false);
+    const nameAvailable = await callAs(editorUserId, 'registrations.validateName', '__test_reg_unused', false);
+    assert.strictEqual(idAvailable, true);
+    assert.strictEqual(nameAvailable, true);
+  });
+});
+
+describe('registrations.insert — server-side id-range & age validation (#260)', () => {
+  // Registration insert is anonymous-friendly (allowsAnonymous.insert), so the
+  // crafted-DDP threat model is an unauthenticated caller. We assert against
+  // callAs(null, ...) to mirror that.
+  after(async () => {
+    await cleanupFixtures([RegistrationsCollection]);
+  });
+
+  it('accepts a valid registration (id in range, age >= 16)', async () => {
+    const id = (await callAs(null, 'registrations.insert', validRegistration())) as string;
+    assert.strictEqual(typeof id, 'string');
+    const doc = await RegistrationsCollection.findOneAsync(id);
+    assert.ok(doc, 'Valid registration must persist');
+  });
+
+  it('rejects id below 1000', async () => {
+    await assertRejectsWithCode(() => callAs(null, 'registrations.insert', validRegistration({ id: 999 })), 'invalid-id');
+  });
+
+  it('rejects id above 9999', async () => {
+    await assertRejectsWithCode(() => callAs(null, 'registrations.insert', validRegistration({ id: 10000 })), 'invalid-id');
+  });
+
+  it('rejects a non-integer id', async () => {
+    await assertRejectsWithCode(() => callAs(null, 'registrations.insert', validRegistration({ id: 1234.5 })), 'invalid-id');
+  });
+
+  it('rejects age below 16', async () => {
+    await assertRejectsWithCode(() => callAs(null, 'registrations.insert', validRegistration({ age: 15 })), 'invalid-age');
+  });
+
+  it('accepts the boundary values (id 1000, id 9999, age 16)', async () => {
+    const low = (await callAs(null, 'registrations.insert', validRegistration({ id: 1000, name: '__test_reg_low' }))) as string;
+    const high = (await callAs(null, 'registrations.insert', validRegistration({ id: 9999, name: '__test_reg_high' }))) as string;
+    const minAge = (await callAs(null, 'registrations.insert', validRegistration({ id: 1500, name: '__test_reg_age', age: 16 }))) as string;
+    assert.ok(low && high && minAge, 'Boundary values must be accepted');
+  });
+
+  it('does not leak an out-of-range document', async () => {
+    await assertRejectsWithCode(
+      () => callAs(null, 'registrations.insert', validRegistration({ id: 42, name: '__test_reg_leak' })),
+      'invalid-id',
+    );
+    const leaked = await RegistrationsCollection.findOneAsync({ name: '__test_reg_leak' });
+    assert.strictEqual(leaked, undefined, 'A rejected insert must not persist');
+  });
+});


### PR DESCRIPTION
## Summary

Two registration fixes in one PR.

### RULE-035 (#265) — uniqueness exclusion defect
`registrations.validateId` and `registrations.validateName` pushed a self-contradictory member-side clause (`{ 'profile.id': { $ne: id } }` / `{ 'profile.name': { $ne: name } }`) whenever `this.userId && excludeId`. That made the member filter `$and:[{'profile.id':id},{'profile.id':{$ne:id}}]` match nothing, so a member already holding the requested id/name was silently missed on the edit path. Removed the contradictory member-side pushes so a member collision is **always** detected. The registration self-exclusion `{ _id: { $ne: excludeId } }` is correct and retained.

### RULE-036 (#260) — server-side validation gap
The id range (1000–9999) and minimum age (>=16) were enforced only client-side in `RegistrationForm.tsx`; the server accepted anything shape-valid, so a crafted DDP `registrations.insert` could bypass them. Added a per-collection **insert-only** validator hook (`INSERT_VALIDATORS`) in the generic CRUD factory (`server/crud.lib.ts`), invoked inside the `.insert` `validate` callback, and registered `registrations` there. Rejects `id` outside [1000,9999], non-integer `id`, or `age` < 16 with a `Meteor.Error`.

**Decision:** validation runs on **insert only** — pre-existing out-of-range rows remain editable (update is intentionally not gated). The client form behavior is unchanged.

## Test plan
- [ ] `registrations.validateId` / `validateName` now detect a member id/name collision on the edit path (`excludeId` set)
- [ ] Self-exclusion still holds: editing a registration does not flag its own id/name
- [ ] `registrations.insert` rejects `id < 1000`, `id > 9999`, non-integer `id`, and `age < 16`
- [ ] `registrations.insert` accepts boundary values (id 1000, id 9999, age 16) and does not persist rejected docs
- [ ] `npm run typecheck` passes

Closes #265
Closes #260