### PR TITLE
Close attendance read-then-write race (upsert + unique index)

### DIFF
--- a/imports/ui/events/EventAttendance.tsx
+++ b/imports/ui/events/EventAttendance.tsx
@@ -12,7 +12,6 @@ import RanksCollection from '../../api/collections/ranks.collection';
 import type { AttendanceStatus } from '../../api/types/shared';
 import type { EventDoc } from '../../api/types/event';
 import { useTranslation } from '../../i18n/LanguageContext';
-import useMethod from '../hooks/useMethod';
 import type { TranslateFn } from '../section/types';
 import TableContainer from '../table/body/TableContainer';
 import Table from '../table/Table';
@@ -78,15 +77,12 @@ interface AttendanceSelectProps {
 function AttendanceSelect({ value, eventId, memberId, setEditting }: AttendanceSelectProps) {
   const { t } = useTranslation();
   const { notification } = App.useApp();
-  const { call: readAttendance } = useMethod<Array<{ _id: string }>>('attendances.read');
   const handleChange = async (newValue: AttendanceStatus) => {
     if (value === newValue) return;
-    const res = await readAttendance({ eventId }, { limit: 1 });
-    if (!res.ok) return;
-    const endpoint = res.data.length ? 'attendances.update' : 'attendances.insert';
-    const args = res.data.length ? [res.data[0]._id, { [memberId]: newValue }] : [{ eventId, [memberId]: newValue }];
+    // Atomic server-side upsert keyed on { eventId } — replaces the former
+    // read-then-write that raced into duplicate per-event rows (#261).
     try {
-      await Meteor.callAsync(endpoint, ...args);
+      await Meteor.callAsync('attendances.upsert', eventId, memberId, newValue);
     } catch (error) {
       const err = error as Meteor.Error;
       notification.error({ message: t('common.error'), description: err.reason || err.message });

--- a/server/apis/attendances.server.ts
+++ b/server/apis/attendances.server.ts
@@ -1,10 +1,17 @@
 import { Meteor } from 'meteor/meteor';
 import AttendancesCollection from '../../imports/api/collections/attendances.collection';
-import { checkPermission, validateNumber, validateString, validateUserId } from '../main';
+import MembersCollection from '../../imports/api/collections/members.collection';
+import { checkPermission, validateNumber, validateString } from '../main';
 import { createLog } from './logs.server';
 import type { AttendanceStatus } from '/imports/api/types/shared';
 
 const ATTENDANCE_STATUSES: readonly AttendanceStatus[] = [-2, -1, 0, 1, 2];
+
+// Mongo/Meteor document ids are 17–24 alphanumerics. The member id is written
+// as a dynamic `[memberId]` document key, so it must be vetted against this
+// strict shape before reaching the database — anything containing `.`/`$` (or
+// colliding with a structural field) could shadow or rewrite indexed state.
+const ID_PATTERN = /^[A-Za-z0-9]{17,24}$/;
 
 function isAttendanceStatus(value: number): value is AttendanceStatus {
   return (ATTENDANCE_STATUSES as readonly number[]).includes(value);
@@ -25,17 +32,29 @@ if (Meteor.isServer) {
      * under concurrency.
      */
     'attendances.upsert': async function (eventId: string = '', memberId: string = '', status: number = 0): Promise<boolean> {
-      validateUserId(this.userId);
+      if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
       validateString(eventId, false);
       validateString(memberId, false);
       validateNumber(status, false);
       if (!isAttendanceStatus(status)) {
         throw new Meteor.Error(400, 'Invalid attendance status');
       }
+      // `memberId` becomes a dynamic document key, so harden it before the write:
+      // enforce the strict id shape, forbid Mongo operator/path chars, and refuse
+      // ids that would collide with the structural `eventId`/`_id` fields.
+      if (!ID_PATTERN.test(memberId) || memberId === eventId || memberId === '_id' || memberId.includes('.') || memberId.includes('$')) {
+        throw new Meteor.Error(400, 'Invalid memberId');
+      }
       const allowed = await checkPermission(this.userId, 'events', 'update');
       if (!allowed) throw new Meteor.Error(403, 'Forbidden');
 
-      await AttendancesCollection.upsertAsync({ eventId } as never, { $set: { eventId, [memberId]: status } } as never);
+      const member = await MembersCollection.findOneAsync({ _id: memberId }, { fields: { _id: 1 } });
+      if (!member) throw new Meteor.Error(404, 'Unknown member');
+
+      // Write the member's status under the dynamic key while pinning `eventId`
+      // via $setOnInsert — keeping the dynamic key out of the selector-mirrored
+      // $set means it can never shadow the indexed { eventId } field.
+      await AttendancesCollection.upsertAsync({ eventId } as never, { $set: { [memberId]: status }, $setOnInsert: { eventId } } as never);
 
       await createLog('attendances.upserted', { userId: this.userId, eventId, memberId, status });
 

--- a/server/apis/attendances.server.ts
+++ b/server/apis/attendances.server.ts
@@ -1,0 +1,45 @@
+import { Meteor } from 'meteor/meteor';
+import AttendancesCollection from '../../imports/api/collections/attendances.collection';
+import { checkPermission, validateNumber, validateString, validateUserId } from '../main';
+import { createLog } from './logs.server';
+import type { AttendanceStatus } from '/imports/api/types/shared';
+
+const ATTENDANCE_STATUSES: readonly AttendanceStatus[] = [-2, -1, 0, 1, 2];
+
+function isAttendanceStatus(value: number): value is AttendanceStatus {
+  return (ATTENDANCE_STATUSES as readonly number[]).includes(value);
+}
+
+if (Meteor.isServer) {
+  Meteor.methods({
+    /**
+     * Atomically record a member's attendance status for an event (#261).
+     *
+     * The grid stores exactly one attendance document per event, with each
+     * member's status held under a dynamic `[memberId]` key. The previous
+     * client flow read-then-wrote (find the row, then insert-or-update), which
+     * raced: two concurrent writers could both observe "no row yet" and each
+     * insert a fresh per-event document. A single `upsertAsync` keyed on
+     * `eventId` collapses that into one atomic operation, and the unique
+     * `{ eventId }` index (see server/main.ts) guarantees a single row even
+     * under concurrency.
+     */
+    'attendances.upsert': async function (eventId: string = '', memberId: string = '', status: number = 0): Promise<boolean> {
+      validateUserId(this.userId);
+      validateString(eventId, false);
+      validateString(memberId, false);
+      validateNumber(status, false);
+      if (!isAttendanceStatus(status)) {
+        throw new Meteor.Error(400, 'Invalid attendance status');
+      }
+      const allowed = await checkPermission(this.userId, 'events', 'update');
+      if (!allowed) throw new Meteor.Error(403, 'Forbidden');
+
+      await AttendancesCollection.upsertAsync({ eventId } as never, { $set: { eventId, [memberId]: status } } as never);
+
+      await createLog('attendances.upserted', { userId: this.userId, eventId, memberId, status });
+
+      return true;
+    },
+  });
+}

--- a/server/apis/attendances.server.ts
+++ b/server/apis/attendances.server.ts
@@ -28,8 +28,8 @@ if (Meteor.isServer) {
      * raced: two concurrent writers could both observe "no row yet" and each
      * insert a fresh per-event document. A single `upsertAsync` keyed on
      * `eventId` collapses that into one atomic operation, and the unique
-     * `{ eventId }` index (see server/main.ts) guarantees a single row even
-     * under concurrency.
+     * `{ eventId }` index (built by ensureAttendancesUniqueIndex in
+     * server/main.ts) guarantees a single row even under concurrency.
      */
     'attendances.upsert': async function (eventId: string = '', memberId: string = '', status: number = 0): Promise<boolean> {
       if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');

--- a/server/main.ts
+++ b/server/main.ts
@@ -195,18 +195,97 @@ async function createTestData(): Promise<void> {
   await Accounts.createUserAsync({ username: 'admin', password: 'admin', profile: { name: 'Admin', roleId: 'admin' } });
 }
 
+// Merge duplicate per-event Attendance docs into a single canonical row, then
+// (re)build the unique { eventId } index. Idempotent and startup-safe.
+//
+// Context: the grid stores exactly ONE document per event, with each member's
+// status held under a dynamic [memberId] key. The unique { eventId } index
+// (#261) closes the read-then-write race in attendances.upsert. But promoting
+// the old non-unique index to `unique: true` on an EXISTING deployment fails
+// two ways with no protection:
+//   1. IndexOptionsConflict (code 85) — a non-unique { eventId } index already
+//      exists, so createIndex with different options is rejected.
+//   2. Duplicate-key build error — pre-existing duplicate per-event docs make
+//      the unique index unbuildable.
+// Both crash startup if unhandled. So: dedupe first, drop any conflicting
+// non-unique index, then create the unique one. The race protection must
+// remain — if the unique index genuinely cannot be created we log loudly
+// rather than swallow it.
+export async function ensureAttendancesUniqueIndex(): Promise<void> {
+  const raw = AttendancesCollection.rawCollection();
+
+  // 1. Dedupe: collapse any groups of docs sharing an eventId into one doc,
+  //    merging their per-member status keys. No-op when there are no dupes.
+  await dedupeAttendancesByEventId();
+
+  // 2. Resolve a pre-existing non-unique { eventId } index that would otherwise
+  //    trigger IndexOptionsConflict. Drop it so the unique index can be created.
+  try {
+    const existing = (await raw.indexes()) as Array<{ name?: string; key?: Record<string, number>; unique?: boolean }>;
+    const conflicting = existing.find(idx => idx.key && idx.key.eventId === 1 && Object.keys(idx.key).length === 1 && !idx.unique);
+    if (conflicting?.name) {
+      await raw.dropIndex(conflicting.name);
+    }
+  } catch (error) {
+    // indexes()/dropIndex can fail on a missing collection (never created yet)
+    // — that's fine, createIndex below will materialise it. Log and continue.
+    console.warn('[attendances] could not inspect/drop existing { eventId } index:', error);
+  }
+
+  // 3. Create the unique index. This is the race protection from #261 and must
+  //    succeed — if it cannot (e.g. dedupe somehow left dupes), log loudly.
+  try {
+    await raw.createIndex({ eventId: 1 }, { unique: true });
+  } catch (error) {
+    console.error(
+      '[attendances] FAILED to create the unique { eventId } index — the attendances.upsert race protection (#261) is NOT active. Investigate duplicate per-event documents:',
+      error,
+    );
+  }
+}
+
+// Find Attendance docs sharing an eventId and merge each group into a single
+// canonical doc (combine per-member status keys; keep the oldest doc, remove
+// the rest). Later docs win on key conflicts. Idempotent: a no-op once every
+// eventId maps to exactly one doc.
+async function dedupeAttendancesByEventId(): Promise<void> {
+  const raw = AttendancesCollection.rawCollection();
+  const duplicateGroups = (await raw
+    .aggregate([
+      { $match: { eventId: { $exists: true } } },
+      { $group: { _id: '$eventId', count: { $sum: 1 } } },
+      { $match: { count: { $gt: 1 } } },
+    ])
+    .toArray()) as Array<{ _id: string }>;
+
+  for (const group of duplicateGroups) {
+    const docs = await AttendancesCollection.find({ eventId: group._id }).fetchAsync();
+    if (docs.length <= 1) continue;
+    // Keep the lexicographically-first _id as canonical; merge all member-status
+    // keys from the rest onto it (later docs override earlier on key collisions).
+    const sorted = [...docs].sort((a, b) => String(a._id).localeCompare(String(b._id)));
+    const [canonical, ...extras] = sorted;
+    const merged: Record<string, unknown> = {};
+    for (const doc of sorted) {
+      for (const [key, value] of Object.entries(doc)) {
+        if (key === '_id' || key === 'eventId') continue;
+        merged[key] = value;
+      }
+    }
+    await AttendancesCollection.updateAsync(canonical._id as string, { $set: merged } as never);
+    await AttendancesCollection.removeAsync({ _id: { $in: extras.map(doc => doc._id as string) } });
+  }
+}
+
 async function createDatabaseIndexes(): Promise<void> {
   // Every createIndex call is independent — race them on startup instead of
-  // running 8 sequential round-trips. Mongo will dedupe if any already exist.
+  // running sequential round-trips. Mongo will dedupe if any already exist.
+  // The Attendances unique { eventId } index needs a dedupe + conflict-resolve
+  // preamble (see ensureAttendancesUniqueIndex), so it runs through that helper.
   await Promise.all([
     MembersCollection.rawCollection().createIndex({ 'profile.squadId': 1 }),
     MembersCollection.rawCollection().createIndex({ 'profile.rankId': 1 }),
-    // One attendance document per event (member statuses are stored as dynamic
-    // keys on that single doc, not as separate rows). The unique index closes
-    // the read-then-write race in attendances.upsert that could otherwise let
-    // concurrent writers create duplicate per-event docs (#261). Supersedes the
-    // former non-unique { eventId: 1 } index.
-    AttendancesCollection.rawCollection().createIndex({ eventId: 1 }, { unique: true }),
+    ensureAttendancesUniqueIndex(),
     LogsCollection.rawCollection().createIndex({ createdAt: -1 }),
     LogsCollection.rawCollection().createIndex({ action: 1 }),
     EventsCollection.rawCollection().createIndex({ eventType: 1 }),

--- a/server/main.ts
+++ b/server/main.ts
@@ -8,6 +8,7 @@ import RegistrationsCollection from '../imports/api/collections/registrations.co
 import RolesCollection from '../imports/api/collections/roles.collection';
 import TasksCollection from '../imports/api/collections/tasks.collection';
 import type { CrudCollectionName, Role } from '/imports/api/types';
+import './apis/attendances.server';
 import './apis/backup.server';
 import './apis/dashboard.server';
 import './apis/demoData.server';
@@ -200,7 +201,12 @@ async function createDatabaseIndexes(): Promise<void> {
   await Promise.all([
     MembersCollection.rawCollection().createIndex({ 'profile.squadId': 1 }),
     MembersCollection.rawCollection().createIndex({ 'profile.rankId': 1 }),
-    AttendancesCollection.rawCollection().createIndex({ eventId: 1 }),
+    // One attendance document per event (member statuses are stored as dynamic
+    // keys on that single doc, not as separate rows). The unique index closes
+    // the read-then-write race in attendances.upsert that could otherwise let
+    // concurrent writers create duplicate per-event docs (#261). Supersedes the
+    // former non-unique { eventId: 1 } index.
+    AttendancesCollection.rawCollection().createIndex({ eventId: 1 }, { unique: true }),
     LogsCollection.rawCollection().createIndex({ createdAt: -1 }),
     LogsCollection.rawCollection().createIndex({ action: 1 }),
     EventsCollection.rawCollection().createIndex({ eventType: 1 }),

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -7,6 +7,7 @@ import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
 import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
+import './server/attendancesDedupeIndex.test';
 import './server/attendancesUpsert.test';
 import './server/backupRestore.test';
 import './server/briefingTemplatesMethods.test';

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -7,6 +7,7 @@ import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
 import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
+import './server/attendancesUpsert.test';
 import './server/backupRestore.test';
 import './server/briefingTemplatesMethods.test';
 import './server/crudMethods.test';

--- a/tests/server/attendancesDedupeIndex.test.ts
+++ b/tests/server/attendancesDedupeIndex.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert';
+import AttendancesCollection from '../../imports/api/collections/attendances.collection';
+import { TEST_PREFIX } from './fixtures';
+import type { ensureAttendancesUniqueIndex as ensureType } from '../../server/main';
+
+// Use require() instead of import to avoid the circular dependency between
+// server/main.ts and crud.lib.ts during module initialization. By the time
+// tests run, all modules are fully initialized. The type-only import above
+// keeps the call site fully typed.
+function loadEnsureAttendancesUniqueIndex(): typeof ensureType {
+  return require('../../server/main').ensureAttendancesUniqueIndex;
+}
+
+// Guards the startup-safe, idempotent index setup for #270. PR #261 promoted
+// the { eventId } index to unique to close the attendances.upsert race, but on
+// an EXISTING deployment that crashed startup two ways: an IndexOptionsConflict
+// against a pre-existing non-unique index, and a duplicate-key build error when
+// duplicate per-event docs already existed. ensureAttendancesUniqueIndex first
+// merges duplicate per-event docs (one doc per event, member statuses under
+// dynamic [memberId] keys), drops any conflicting non-unique index, then builds
+// the unique index — without crashing.
+describe('ensureAttendancesUniqueIndex — startup-safe dedupe + unique index (#270)', () => {
+  const ensureAttendancesUniqueIndex = loadEnsureAttendancesUniqueIndex();
+  const eventId = `${TEST_PREFIX}event_270`;
+  // Mongo-shaped member ids (the dynamic status keys on the per-event doc).
+  const memberA = 'aaaaaaaaaaaaaaaaa';
+  const memberB = 'bbbbbbbbbbbbbbbbb';
+
+  async function dropEventIdIndex(): Promise<void> {
+    const raw = AttendancesCollection.rawCollection();
+    // indexes() throws "ns does not exist" if the collection has never been
+    // materialized (no docs inserted yet) — treat that as "no index to drop".
+    let existing: Array<{ name?: string; key?: Record<string, number> }>;
+    try {
+      existing = (await raw.indexes()) as Array<{ name?: string; key?: Record<string, number> }>;
+    } catch {
+      return;
+    }
+    const idx = existing.find(i => i.key && i.key.eventId === 1 && Object.keys(i.key).length === 1);
+    if (idx?.name) await raw.dropIndex(idx.name);
+  }
+
+  beforeEach(async () => {
+    await AttendancesCollection.removeAsync({ eventId });
+    await dropEventIdIndex();
+  });
+
+  after(async () => {
+    await AttendancesCollection.removeAsync({ eventId });
+  });
+
+  it('merges duplicate per-event docs into one and builds the unique index without throwing', async () => {
+    // Seed two docs for the same eventId with different member-status keys —
+    // exactly the pre-existing state that would block a naive unique-index build.
+    await AttendancesCollection.insertAsync({ eventId, [memberA]: 1 } as never);
+    await AttendancesCollection.insertAsync({ eventId, [memberB]: 2 } as never);
+
+    const before = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(before.length, 2, 'fixture should start with two duplicate per-event docs');
+
+    // Must not throw even though duplicates exist at call time.
+    await assert.doesNotReject(() => ensureAttendancesUniqueIndex());
+
+    // Exactly one doc remains, carrying both members' merged status keys.
+    const after = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(after.length, 1, 'expected exactly one merged attendance doc');
+    assert.strictEqual(after[0][memberA], 1, 'memberA status should survive the merge');
+    assert.strictEqual(after[0][memberB], 2, 'memberB status should survive the merge');
+
+    // The unique { eventId } index now exists.
+    const indexes = (await AttendancesCollection.rawCollection().indexes()) as Array<{
+      key?: Record<string, number>;
+      unique?: boolean;
+    }>;
+    const uniqueIdx = indexes.find(i => i.key && i.key.eventId === 1 && Object.keys(i.key).length === 1 && i.unique === true);
+    assert.ok(uniqueIdx, 'expected a unique { eventId } index after setup');
+
+    // The unique constraint is actually enforced post-setup.
+    await assert.rejects(() => AttendancesCollection.insertAsync({ eventId, [memberA]: 1 } as never));
+  });
+
+  it('resolves a pre-existing non-unique { eventId } index without IndexOptionsConflict', async () => {
+    // Simulate a legacy deployment: a non-unique { eventId } index already there.
+    await AttendancesCollection.rawCollection().createIndex({ eventId: 1 });
+    await AttendancesCollection.insertAsync({ eventId, [memberA]: 1 } as never);
+
+    await assert.doesNotReject(() => ensureAttendancesUniqueIndex());
+
+    const indexes = (await AttendancesCollection.rawCollection().indexes()) as Array<{
+      key?: Record<string, number>;
+      unique?: boolean;
+    }>;
+    const uniqueIdx = indexes.find(i => i.key && i.key.eventId === 1 && Object.keys(i.key).length === 1 && i.unique === true);
+    assert.ok(uniqueIdx, 'expected the non-unique index to be replaced by a unique one');
+  });
+
+  it('is idempotent — a second run on already-clean data is a no-op that still throws nothing', async () => {
+    await AttendancesCollection.insertAsync({ eventId, [memberA]: 1 } as never);
+    await ensureAttendancesUniqueIndex();
+    await assert.doesNotReject(() => ensureAttendancesUniqueIndex());
+
+    const after = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(after.length, 1, 'second run should leave the single doc untouched');
+  });
+});

--- a/tests/server/attendancesUpsert.test.ts
+++ b/tests/server/attendancesUpsert.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import AttendancesCollection from '../../imports/api/collections/attendances.collection';
+import { assertRejectsWithCode, callAs, cleanupFixtures, createTestRole, createTestUser, TEST_PREFIX } from './fixtures';
+
+// Guards the fix for #261: attendance recording used a read-then-write
+// (find the per-event row, then insert-or-update) whose TOCTOU window let
+// concurrent writers each insert a fresh per-event document. The grid stores
+// exactly ONE document per event, with each member's status under a dynamic
+// [memberId] key — so the correct uniqueness constraint is on { eventId }.
+// The fix is an atomic `attendances.upsert` keyed on eventId plus a unique
+// { eventId } index. These tests assert duplicates can no longer arise.
+
+describe('attendances.upsert — atomic write, no duplicate per-event rows (#261)', () => {
+  let adminUserId: string;
+  let unauthorizedUserId: string;
+  const eventId = `${TEST_PREFIX}event_261`;
+  const memberA = `${TEST_PREFIX}member_a`;
+  const memberB = `${TEST_PREFIX}member_b`;
+
+  before(async () => {
+    const [adminRoleId, noPermRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      createTestRole({ events: { read: true, create: false, update: false, delete: false } }),
+    ]);
+    [adminUserId, unauthorizedUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: noPermRoleId }),
+    ]);
+    // Mirror the production unique index (server/main.ts) so the concurrency
+    // assertion holds in the test DB regardless of startup ordering. createIndex
+    // is idempotent — Mongo dedupes if it already exists.
+    await AttendancesCollection.rawCollection().createIndex({ eventId: 1 }, { unique: true });
+  });
+
+  beforeEach(async () => {
+    await AttendancesCollection.removeAsync({ eventId });
+  });
+
+  after(async () => {
+    await AttendancesCollection.removeAsync({ eventId });
+    await cleanupFixtures();
+  });
+
+  it('rejects unauthenticated calls with 401', async () => {
+    await assertRejectsWithCode(() => callAs(null, 'attendances.upsert', eventId, memberA, 1), 401);
+  });
+
+  it('rejects callers without events.update permission with 403', async () => {
+    await assertRejectsWithCode(() => callAs(unauthorizedUserId, 'attendances.upsert', eventId, memberA, 1), 403);
+  });
+
+  it('rejects an out-of-range attendance status with 400', async () => {
+    await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, memberA, 7), 400);
+  });
+
+  it('first write creates exactly one per-event row', async () => {
+    await callAs(adminUserId, 'attendances.upsert', eventId, memberA, 1);
+    const docs = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(docs.length, 1, 'Expected exactly one attendance document for the event');
+    assert.strictEqual(docs[0][memberA], 1);
+  });
+
+  it('concurrent writes for the same event do not create duplicate rows', async () => {
+    // Fire both writes without awaiting in between — the old read-then-write
+    // would have both observed "no row" and each inserted, producing two docs.
+    const results = await Promise.allSettled([
+      callAs(adminUserId, 'attendances.upsert', eventId, memberA, 1),
+      callAs(adminUserId, 'attendances.upsert', eventId, memberB, 2),
+    ]);
+    // At least one must succeed; the unique index serializes the writers so no
+    // duplicate row survives. (A loser may reject with a duplicate-key error,
+    // which is acceptable — the invariant under test is "no duplicate rows".)
+    assert.ok(
+      results.some(r => r.status === 'fulfilled'),
+      'Expected at least one concurrent upsert to succeed'
+    );
+    const docs = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(docs.length, 1, 'Expected exactly one attendance document despite concurrent writes');
+  });
+
+  it('a second write updates the existing row rather than duplicating it', async () => {
+    await callAs(adminUserId, 'attendances.upsert', eventId, memberA, 1);
+    await callAs(adminUserId, 'attendances.upsert', eventId, memberA, -1);
+
+    const docs = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(docs.length, 1, 'Expected the second write to update, not duplicate');
+    assert.strictEqual(docs[0][memberA], -1, 'Expected the member status to be updated to the new value');
+  });
+
+  it('writes for different members accumulate on the same per-event row', async () => {
+    await callAs(adminUserId, 'attendances.upsert', eventId, memberA, 1);
+    await callAs(adminUserId, 'attendances.upsert', eventId, memberB, 2);
+
+    const docs = await AttendancesCollection.find({ eventId }).fetchAsync();
+    assert.strictEqual(docs.length, 1, 'Expected a single shared per-event document');
+    assert.strictEqual(docs[0][memberA], 1);
+    assert.strictEqual(docs[0][memberB], 2);
+  });
+
+  it('the unique { eventId } index rejects a raw duplicate insert', async () => {
+    await AttendancesCollection.insertAsync({ eventId, [memberA]: 1 } as never);
+    await assert.rejects(() => AttendancesCollection.insertAsync({ eventId, [memberB]: 2 } as never));
+  });
+});

--- a/tests/server/attendancesUpsert.test.ts
+++ b/tests/server/attendancesUpsert.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
 import AttendancesCollection from '../../imports/api/collections/attendances.collection';
 import { assertRejectsWithCode, callAs, cleanupFixtures, createTestRole, createTestUser, TEST_PREFIX } from './fixtures';
 
@@ -15,8 +16,12 @@ describe('attendances.upsert — atomic write, no duplicate per-event rows (#261
   let adminUserId: string;
   let unauthorizedUserId: string;
   const eventId = `${TEST_PREFIX}event_261`;
-  const memberA = `${TEST_PREFIX}member_a`;
-  const memberB = `${TEST_PREFIX}member_b`;
+  // The member id is written as a dynamic document key and validated against a
+  // strict Mongo-shaped pattern (/^[A-Za-z0-9]{17,24}$/), so these must be
+  // prefix-free alphanumeric ids AND back real member docs. We clean them up
+  // explicitly in `after` since they fall outside the `test_` prefix range.
+  const memberA = Random.id();
+  const memberB = Random.id();
 
   before(async () => {
     const [adminRoleId, noPermRoleId] = await Promise.all([
@@ -26,6 +31,8 @@ describe('attendances.upsert — atomic write, no duplicate per-event rows (#261
     [adminUserId, unauthorizedUserId] = await Promise.all([
       createTestUser({ roleId: adminRoleId }),
       createTestUser({ roleId: noPermRoleId }),
+      createTestUser({ _id: memberA }),
+      createTestUser({ _id: memberB }),
     ]);
     // Mirror the production unique index (server/main.ts) so the concurrency
     // assertion holds in the test DB regardless of startup ordering. createIndex
@@ -39,6 +46,7 @@ describe('attendances.upsert — atomic write, no duplicate per-event rows (#261
 
   after(async () => {
     await AttendancesCollection.removeAsync({ eventId });
+    await Meteor.users.removeAsync({ _id: { $in: [memberA, memberB] } });
     await cleanupFixtures();
   });
 
@@ -52,6 +60,23 @@ describe('attendances.upsert — atomic write, no duplicate per-event rows (#261
 
   it('rejects an out-of-range attendance status with 400', async () => {
     await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, memberA, 7), 400);
+  });
+
+  it('rejects a memberId containing a dot with 400', async () => {
+    await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, 'profile.roleId', 1), 400);
+  });
+
+  it('rejects a memberId containing a Mongo operator char ($) with 400', async () => {
+    await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, '$where', 1), 400);
+  });
+
+  it('rejects a memberId equal to the eventId with 400', async () => {
+    await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, eventId, 1), 400);
+  });
+
+  it('rejects a structurally valid memberId for a non-existent member with 404', async () => {
+    // Passes the strict id pattern but no such member doc exists.
+    await assertRejectsWithCode(() => callAs(adminUserId, 'attendances.upsert', eventId, Random.id(), 1), 404);
   });
 
   it('first write creates exactly one per-event row', async () => {

--- a/tests/server/fixtures.ts
+++ b/tests/server/fixtures.ts
@@ -26,16 +26,21 @@ export async function createTestRole(permissions: Partial<Role> & Record<string,
 export interface CreateTestUserOptions {
   roleId?: string;
   profile?: Partial<MemberProfile>;
+  // Override the generated `_id`. Callers that need a Mongo-shaped (pure
+  // alphanumeric, prefix-free) id — e.g. to satisfy strict id validation —
+  // pass it here and take responsibility for their own cleanup, since such
+  // ids fall outside the `test_` prefix range cleanupFixtures scopes to.
+  _id?: string;
 }
 
-export async function createTestUser({ roleId, profile = {} }: CreateTestUserOptions = {}): Promise<string> {
-  const _id = prefixedId();
+export async function createTestUser({ roleId, profile = {}, _id }: CreateTestUserOptions = {}): Promise<string> {
+  const id = _id ?? prefixedId();
   await Meteor.users.insertAsync({
-    _id,
-    username: _id,
-    profile: { name: `Test ${_id}`, roleId, ...profile },
+    _id: id,
+    username: id,
+    profile: { name: `Test ${id}`, roleId, ...profile },
   });
-  return _id;
+  return id;
 }
 
 // Loose generic so tests can pass any project collection without per-call casting.


### PR DESCRIPTION
## Summary
- Attendance recording in `imports/ui/events/EventAttendance.tsx` read the per-event row, then branched into insert-or-update. The TOCTOU window let concurrent writers each observe "no row yet" and insert a fresh per-event document, producing duplicate attendance rows for the same event.
- The grid keeps exactly **one document per event**, with each member's status stored under a dynamic `[memberId]` key (no `member` field), so the correct uniqueness constraint is on `{ eventId }`. (The issue's `{ eventId, member }` reflects a schema assumption that doesn't match `attendances.collection.ts`; the real field names are used here.)
- New server method `attendances.upsert(eventId, memberId, status)` does an atomic `upsertAsync` keyed on `eventId` (auth + `events.update` permission + status validation + audit log). `EventAttendance.tsx` now calls it instead of the read-then-write branch — user behavior is unchanged.
- The existing `{ eventId }` index is promoted to `unique: true` so duplicate per-event rows can no longer be created even under concurrency.

## Changes
- `server/apis/attendances.server.ts` (new) — `attendances.upsert` atomic method, registered in `server/main.ts`.
- `server/main.ts` — unique `{ eventId }` index; import new api file.
- `imports/ui/events/EventAttendance.tsx` — call the atomic method, drop the read-then-write + unused `useMethod` import.
- `tests/server/attendancesUpsert.test.ts` (new) + `tests/main.ts` — concurrency / dedupe / update-not-duplicate / unique-index suite.

## Deployment note
Promoting the existing non-unique `{ eventId }` index to `unique` will fail on a deployment that already holds duplicate attendance docs for one event (and Mongo throws `IndexOptionsConflict` if an identical-key non-unique index lingers). Fresh DBs and CI are unaffected. If existing duplicates are possible in prod, dedupe + drop the old index before rollout.

## Test plan
- [ ] `npm run typecheck` (passes locally)
- [ ] `npm test` — new `attendances.upsert` suite green (CI)
- [ ] Manual: recording attendance in calendar/table views still works; rapid repeated writes for one event keep a single row