### PR TITLE
Read-side security hardening (authz + selector guard)

### DIFF
--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -25,6 +25,23 @@ async function getMemberById(memberId: string): Promise<Meteor.User> {
   return member as Meteor.User;
 }
 
+// Post-fetch removal of the `services` block (bcrypt password hashes + reset
+// tokens). Used on every client-reachable path that returns raw member docs.
+// A strip-after-fetch is projection-safe: merging `{ services: 0 }` onto a
+// caller-supplied INCLUSION projection (e.g. `{ name: 1 }`) makes MongoDB throw,
+// and omitting the projection leaks the hash. Deleting the field post-fetch is
+// immune to the projection type and can never leak (SEC-001, Critical).
+function stripServices<T extends object>(member: T): T {
+  if (member && 'services' in member) {
+    delete (member as { services?: unknown }).services;
+  }
+  return member;
+}
+
+function stripServicesFromAll<T extends object>(members: T[]): T[] {
+  return members.map(stripServices);
+}
+
 const getRankName = async (rankId: string | null | undefined): Promise<string | undefined> => {
   const rank = await RanksCollection.findOneAsync({ _id: rankId || null } as never);
   return rank?.name;
@@ -58,7 +75,12 @@ if (Meteor.isServer) {
 
       const squadScope = await getSquadScope(this.userId);
       const scopedFilter = { ...filter, ...squadScope };
-      return await MembersCollection.find(scopedFilter, options).fetchAsync();
+      // Strip the password-hash off every returned doc post-fetch. The caller's
+      // `options` (incl. `fields`) are forwarded verbatim, so a projection merge
+      // would either throw (inclusion projection) or be omittable — the strip is
+      // projection-safe and never leaks (SEC-001, Critical).
+      const members = await MembersCollection.find(scopedFilter, options).fetchAsync();
+      return stripServicesFromAll(members);
     },
     'members.findOne': async function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
       validateUserId(this.userId);
@@ -74,17 +96,17 @@ if (Meteor.isServer) {
       const squadScope = await getSquadScope(this.userId);
       const scopedFilter = { ...filter, ...squadScope };
 
-      // Force the password-hash off the projection regardless of the caller's
-      // requested fields — merge, don't replace, so explicit projections still
-      // apply. Previously a caller could omit `{ services: 0 }` and read the
-      // bcrypt hash (SEC-001, Critical).
-      const callerFields = (options.fields as Record<string, unknown> | undefined) ?? {};
-      const safeOptions = { ...options, fields: { ...callerFields, services: 0 } };
-
+      // Strip the password-hash off the returned doc post-fetch. A projection
+      // merge of `{ services: 0 }` onto a caller-supplied INCLUSION projection
+      // (e.g. `{ name: 1 }`) makes MongoDB throw; omitting it leaks the hash.
+      // The post-fetch strip is immune to the projection type and never leaks
+      // (SEC-001, Critical).
+      //
       // Returns undefined on miss (mirrors Mongo findOneAsync) — callers like
       // RegistrationExtra use this as an existence check and would otherwise
       // unhandled-reject on every miss, surfacing as the dev-server overlay.
-      return MembersCollection.findOneAsync(scopedFilter, safeOptions);
+      const member = await MembersCollection.findOneAsync(scopedFilter, options);
+      return member ? stripServices(member) : member;
     },
     'members.insert': async function (payload: Record<string, unknown> = {}): Promise<string> {
       return runMutation(
@@ -323,8 +345,10 @@ if (Meteor.isServer) {
       if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
 
       const squadScope = await getSquadScope(this.userId);
+      // Strip the password-hash off every returned doc post-fetch — this path
+      // fetched full member docs with no field projection (SEC-001, Critical).
       const members = await MembersCollection.find(squadScope).fetchAsync();
-      return members;
+      return stripServicesFromAll(members);
     },
     'members.groupedOptions': async function () {
       validateUserId(this.userId);

--- a/server/apis/members.server.ts
+++ b/server/apis/members.server.ts
@@ -11,7 +11,7 @@ import RanksCollection from '../../imports/api/collections/ranks.collection';
 import RolesCollection from '../../imports/api/collections/roles.collection';
 import SpecializationsCollection from '../../imports/api/collections/specializations.collection';
 import SquadsCollection from '../../imports/api/collections/squads.collection';
-import { validateObject, validatePublish, validateString, validateNumber, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole } from '../main';
+import { validateObject, validatePublish, validateString, validateNumber, validateUserId, checkPermission, checkSpecialPermission, getSquadScope, isOfficerOrAdmin, getUserRole, assertSafeSelector } from '../main';
 import { createLog } from './logs.server';
 import { runMutation, snapshotTouchedFields } from '../mutation-pipeline';
 import { COLLECTION_REGISTRY } from '../collection-registry';
@@ -64,10 +64,27 @@ if (Meteor.isServer) {
       validateUserId(this.userId);
       validateObject(filter, false);
       validateObject(options, false);
+      assertSafeSelector(filter);
+
+      const hasPermission = await checkPermission(this.userId, 'members', 'read');
+      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
+
+      // Squad-scope the lookup so a scoped caller cannot read members outside
+      // their own squad by crafting an arbitrary selector (SEC-001).
+      const squadScope = await getSquadScope(this.userId);
+      const scopedFilter = { ...filter, ...squadScope };
+
+      // Force the password-hash off the projection regardless of the caller's
+      // requested fields — merge, don't replace, so explicit projections still
+      // apply. Previously a caller could omit `{ services: 0 }` and read the
+      // bcrypt hash (SEC-001, Critical).
+      const callerFields = (options.fields as Record<string, unknown> | undefined) ?? {};
+      const safeOptions = { ...options, fields: { ...callerFields, services: 0 } };
+
       // Returns undefined on miss (mirrors Mongo findOneAsync) — callers like
       // RegistrationExtra use this as an existence check and would otherwise
       // unhandled-reject on every miss, surfacing as the dev-server overlay.
-      return MembersCollection.findOneAsync(filter, options);
+      return MembersCollection.findOneAsync(scopedFilter, safeOptions);
     },
     'members.insert': async function (payload: Record<string, unknown> = {}): Promise<string> {
       return runMutation(
@@ -203,6 +220,10 @@ if (Meteor.isServer) {
     'members.saveTaskFilter': async function (filter: Record<string, unknown> = {}) {
       if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
       validateObject(filter, false);
+      // The persisted taskFilter is later read back and forwarded verbatim into
+      // the tasks publication's selector. Reject code-execution operators here
+      // so a hostile filter can't be smuggled in via the persistence path.
+      assertSafeSelector(filter);
       const user = await MembersCollection.findOneAsync(this.userId);
       if (!user) throw new Meteor.Error(404, 'User not found');
       const profile = { ...user.profile, taskFilter: filter };
@@ -211,7 +232,11 @@ if (Meteor.isServer) {
     'members.options': async function () {
       validateUserId(this.userId);
 
-      const members = await MembersCollection.find({}, { fields: { 'profile.rankId': 1, 'profile.id': 1, 'profile.name': 1 } }).fetchAsync();
+      const hasPermission = await checkPermission(this.userId, 'members', 'read');
+      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
+
+      const squadScope = await getSquadScope(this.userId);
+      const members = await MembersCollection.find(squadScope, { fields: { 'profile.rankId': 1, 'profile.id': 1, 'profile.name': 1 } }).fetchAsync();
 
       const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
       const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
@@ -228,7 +253,14 @@ if (Meteor.isServer) {
       validateUserId(this.userId);
       validateObject(filter, false);
       validateObject(options, false);
-      const members = await MembersCollection.find(filter, options).fetchAsync();
+      assertSafeSelector(filter);
+
+      const hasPermission = await checkPermission(this.userId, 'members', 'read');
+      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
+
+      const squadScope = await getSquadScope(this.userId);
+      const scopedFilter = { ...filter, ...squadScope };
+      const members = await MembersCollection.find(scopedFilter, options).fetchAsync();
 
       const rankIds = [...new Set(members.flatMap(m => m.profile?.rankId ? [m.profile.rankId] : []))];
       const ranks = await RanksCollection.find({ _id: { $in: rankIds } }).fetchAsync();
@@ -287,7 +319,11 @@ if (Meteor.isServer) {
       if (!this.userId) {
         throw new Meteor.Error('not-authorized');
       }
-      const members = await MembersCollection.find({}).fetchAsync();
+      const hasPermission = await checkPermission(this.userId, 'members', 'read');
+      if (!hasPermission) throw new Meteor.Error(403, 'Permission denied');
+
+      const squadScope = await getSquadScope(this.userId);
+      const members = await MembersCollection.find(squadScope).fetchAsync();
       return members;
     },
     'members.groupedOptions': async function () {

--- a/server/crud.lib.ts
+++ b/server/crud.lib.ts
@@ -5,6 +5,8 @@ import {
   validateString,
   validateArrayOfStrings,
   clearRoleCache,
+  assertSafeSelector,
+  checkPermission,
 } from './main';
 import { createLog } from './apis/logs.server';
 import { runMutation, snapshotTouchedFields } from './mutation-pipeline';
@@ -106,11 +108,26 @@ const MAX_PUBLISH_LIMIT = 1000;
 function createCollectionPublish(collection: CrudCollectionName): void {
   if (Meteor.isServer) {
     const Collection = getCollection(collection);
-    const allowsAnonymousRead = COLLECTION_REGISTRY[collection].allowsAnonymous?.read === true;
-    Meteor.publish(collection, function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
+    const registryEntry = COLLECTION_REGISTRY[collection];
+    const allowsAnonymousRead = registryEntry.allowsAnonymous?.read === true;
+    // Async publish body so the permission check can await getUserRole.
+    // Meteor 3 supports async publish handlers (see members.server.ts).
+    Meteor.publish(collection, async function (filter: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
       if (!this.userId && !allowsAnonymousRead) return this.ready();
       validateObject(filter, false);
       validateObject(options, false);
+      assertSafeSelector(filter);
+
+      // Authorize the subscription unless the collection is explicitly anonymous-
+      // readable. Previously any authenticated user could subscribe to any
+      // collection regardless of their role's read permission (SEC-003).
+      if (!allowsAnonymousRead) {
+        const hasPermission = await checkPermission(this.userId, registryEntry.module, 'read');
+        if (!hasPermission) {
+          this.ready();
+          throw new Meteor.Error(403, 'Permission denied');
+        }
+      }
 
       const limitedOptions: Record<string, unknown> = { ...options };
       if (!limitedOptions.limit) {
@@ -145,6 +162,7 @@ function createCollectionMethods(collection: CrudCollectionName): void {
               validate: ([f, o]) => {
                 validateObject(f, false);
                 validateObject(o, false);
+                assertSafeSelector(f);
               },
             },
             [filter, options] as const,
@@ -293,7 +311,10 @@ function createCollectionMethods(collection: CrudCollectionName): void {
               collection,
               operation: 'read',
               permissionModule,
-              validate: ([f]) => validateObject(f, false),
+              validate: ([f]) => {
+                validateObject(f, false);
+                assertSafeSelector(f);
+              },
             },
             [filter] as const,
             async ([f]) => Collection.countDocuments(f),
@@ -309,6 +330,7 @@ function createCollectionMethods(collection: CrudCollectionName): void {
               validate: ([f, o]) => {
                 validateObject(f, false);
                 validateObject(o, false);
+                assertSafeSelector(f);
               },
             },
             [filter, options] as const,

--- a/server/main.ts
+++ b/server/main.ts
@@ -406,3 +406,31 @@ export function validatePublish(userId: unknown, filter: unknown, options: unkno
   validateObject(filter, false);
   validateObject(options, false);
 }
+
+// Mongo query operators that allow arbitrary server-side code execution or
+// expression evaluation. Permitting these in a client-supplied selector lets a
+// caller bypass field-level access controls and run unbounded scans (SEC-002/
+// 005/012). They have no legitimate use in this app's read paths.
+const DISALLOWED_QUERY_OPERATORS: readonly string[] = ['$where', '$expr', '$function', '$accumulator'];
+
+// Recursively asserts that a client-supplied Mongo selector contains none of
+// the code-execution operators above. Throws Meteor.Error(400) on the first
+// offending key. Wire this into every path that forwards an untrusted filter
+// to Mongo (generic .read, publications, members.findOne, persisted filters).
+export function assertSafeSelector(filter: unknown): void {
+  validateObject(filter, false);
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (DISALLOWED_QUERY_OPERATORS.includes(key)) {
+        throw new Meteor.Error(400, `Disallowed query operator: ${key}`);
+      }
+      walk(value);
+    }
+  };
+  walk(filter);
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -24,6 +24,7 @@ import './server/paletteScoring.test';
 import './server/paletteSearch.test';
 import './server/permissions.test';
 import './server/questionnaireInterval.test';
+import './server/readSecurityHardening.test';
 import './server/runMethodCall.test';
 import './server/settingsMethods.test';
 import './server/shouldConfirmTemplateOverwrite.test';

--- a/tests/server/readSecurityHardening.test.ts
+++ b/tests/server/readSecurityHardening.test.ts
@@ -54,18 +54,23 @@ describe('assertSafeSelector — rejects code-execution operators (#259)', () =>
 
 // A bcrypt-shaped services block mirroring what Accounts stores on a real
 // member doc — present so the no-leak assertions are non-trivial (a user with
-// no `services` would pass the assertion vacuously).
-const FIXTURE_SERVICES = {
-  password: { bcrypt: '$2b$10$abcdefghijklmnopqrstuv' },
-  resume: { loginTokens: [{ when: new Date(), hashedToken: 'secrethashedtoken' }] },
-  // Reset tokens are equally sensitive — assert the whole block is gone.
-  password_reset: { token: 'reset-secret', email: 'x@example.com', when: new Date() },
-};
+// no `services` would pass the assertion vacuously). The login-token hash is
+// derived per user because Meteor.users carries a UNIQUE index on
+// services.resume.loginTokens.hashedToken — a shared literal would collide
+// (E11000) on the second fixture insert.
+function fixtureServices(userId: string) {
+  return {
+    password: { bcrypt: '$2b$10$abcdefghijklmnopqrstuv' },
+    resume: { loginTokens: [{ when: new Date(), hashedToken: `secrethashedtoken-${userId}` }] },
+    // Reset tokens are equally sensitive — assert the whole block is gone.
+    password_reset: { token: 'reset-secret', email: 'x@example.com', when: new Date() },
+  };
+}
 
 // Writes a realistic `services` block onto a fixture user. createTestUser does
 // not set one, so the strip assertions would otherwise pass vacuously.
 async function attachServices(userId: string): Promise<void> {
-  await Meteor.users.updateAsync({ _id: userId }, { $set: { services: FIXTURE_SERVICES } });
+  await Meteor.users.updateAsync({ _id: userId }, { $set: { services: fixtureServices(userId) } });
 }
 
 describe('members.findOne — authz + no password-hash leak (#257)', () => {

--- a/tests/server/readSecurityHardening.test.ts
+++ b/tests/server/readSecurityHardening.test.ts
@@ -52,6 +52,22 @@ describe('assertSafeSelector — rejects code-execution operators (#259)', () =>
   });
 });
 
+// A bcrypt-shaped services block mirroring what Accounts stores on a real
+// member doc — present so the no-leak assertions are non-trivial (a user with
+// no `services` would pass the assertion vacuously).
+const FIXTURE_SERVICES = {
+  password: { bcrypt: '$2b$10$abcdefghijklmnopqrstuv' },
+  resume: { loginTokens: [{ when: new Date(), hashedToken: 'secrethashedtoken' }] },
+  // Reset tokens are equally sensitive — assert the whole block is gone.
+  password_reset: { token: 'reset-secret', email: 'x@example.com', when: new Date() },
+};
+
+// Writes a realistic `services` block onto a fixture user. createTestUser does
+// not set one, so the strip assertions would otherwise pass vacuously.
+async function attachServices(userId: string): Promise<void> {
+  await Meteor.users.updateAsync({ _id: userId }, { $set: { services: FIXTURE_SERVICES } });
+}
+
 describe('members.findOne — authz + no password-hash leak (#257)', () => {
   let adminUserId: string;
   let noPermUserId: string;
@@ -65,6 +81,7 @@ describe('members.findOne — authz + no password-hash leak (#257)', () => {
       createTestUser({ roleId: adminRoleId }),
       createTestUser({ roleId: noPermRoleId }),
     ]);
+    await Promise.all([attachServices(adminUserId), attachServices(noPermUserId)]);
   });
 
   after(async () => {
@@ -90,9 +107,103 @@ describe('members.findOne — authz + no password-hash leak (#257)', () => {
     assert.strictEqual(result.services, undefined, 'members.findOne must never expose services (password hash)');
   });
 
+  it('never returns services when the caller explicitly requests fields:{services:1}', async () => {
+    // An inclusion projection would normally make a `{ services: 0 }` merge
+    // throw — the post-fetch strip is immune and still drops the block.
+    const result = (await callAs(adminUserId, 'members.findOne', { _id: adminUserId }, { fields: { services: 1 } })) as
+      | Record<string, unknown>
+      | undefined;
+    assert.ok(result, 'Expected the admin user to be returned');
+    assert.strictEqual(result.services, undefined, 'members.findOne must strip services even when explicitly requested');
+  });
+
+  it('never returns services.password when the caller requests {"services.password":1}', async () => {
+    const result = (await callAs(adminUserId, 'members.findOne', { _id: adminUserId }, { fields: { 'services.password': 1 } })) as
+      | Record<string, unknown>
+      | undefined;
+    assert.ok(result, 'Expected the admin user to be returned');
+    assert.strictEqual(result.services, undefined, 'members.findOne must strip the whole services block');
+  });
+
   it('still returns undefined on a miss (existence-check behavior preserved)', async () => {
     const result = await callAs(adminUserId, 'members.findOne', { 'profile.registrationId': 'nonexistent' });
     assert.strictEqual(result, undefined);
+  });
+});
+
+describe('members.read — never leaks the password hash (SEC-001)', () => {
+  let adminUserId: string;
+  let noPermUserId: string;
+
+  before(async () => {
+    const [adminRoleId, noPermRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      createTestRole({ members: { read: false, create: false, update: false, delete: false } }),
+    ]);
+    [adminUserId, noPermUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: noPermRoleId }),
+    ]);
+    await Promise.all([attachServices(adminUserId), attachServices(noPermUserId)]);
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('denies a caller lacking members read permission — 403', async () => {
+    await assertRejectsWithCode(() => callAs(noPermUserId, 'members.read', {}, {}), 403);
+  });
+
+  it('strips services even when the caller requests fields:{services:1}', async () => {
+    const result = (await callAs(adminUserId, 'members.read', { _id: adminUserId }, { fields: { services: 1 } })) as
+      | Record<string, unknown>[];
+    assert.ok(Array.isArray(result) && result.length > 0, 'Expected at least the admin user');
+    for (const member of result) {
+      assert.strictEqual(member.services, undefined, 'members.read must never expose services (password hash)');
+    }
+  });
+
+  it('strips services when the caller requests {"services.password":1}', async () => {
+    const result = (await callAs(adminUserId, 'members.read', {}, { fields: { 'services.password': 1 } })) as
+      | Record<string, unknown>[];
+    assert.ok(Array.isArray(result) && result.length > 0, 'Expected members to be returned');
+    for (const member of result) {
+      assert.strictEqual(member.services, undefined, 'members.read must strip the whole services block');
+    }
+  });
+});
+
+describe('members.all — never leaks the password hash (SEC-001)', () => {
+  let adminUserId: string;
+  let noPermUserId: string;
+
+  before(async () => {
+    const [adminRoleId, noPermRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      createTestRole({ members: { read: false, create: false, update: false, delete: false } }),
+    ]);
+    [adminUserId, noPermUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: noPermRoleId }),
+    ]);
+    await Promise.all([attachServices(adminUserId), attachServices(noPermUserId)]);
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('denies a caller lacking members read permission — 403', async () => {
+    await assertRejectsWithCode(() => callAs(noPermUserId, 'members.all'), 403);
+  });
+
+  it('returns full member docs with the services block stripped', async () => {
+    const result = (await callAs(adminUserId, 'members.all')) as Record<string, unknown>[];
+    assert.ok(Array.isArray(result) && result.length > 0, 'Expected members to be returned');
+    for (const member of result) {
+      assert.strictEqual(member.services, undefined, 'members.all must never expose services (password hash)');
+    }
   });
 });
 

--- a/tests/server/readSecurityHardening.test.ts
+++ b/tests/server/readSecurityHardening.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import MembersCollection from '../../imports/api/collections/members.collection';
+import { assertSafeSelector } from '../../server/main';
+import {
+  assertRejectsWithCode,
+  callAs,
+  cleanupFixtures,
+  createTestRole,
+  createTestUser,
+} from './fixtures';
+
+// Read-side security hardening (#257/#258/#259/#262): a client-supplied selector
+// must never carry a code-execution operator, read methods/publications must be
+// permission-gated, and members.findOne must never leak the password hash.
+
+describe('assertSafeSelector — rejects code-execution operators (#259)', () => {
+  it('accepts a normal selector', () => {
+    assert.doesNotThrow(() => assertSafeSelector({ 'profile.squadId': 'alpha', 'profile.id': { $gt: 5 } }));
+  });
+
+  it('rejects a top-level $where', () => {
+    assert.throws(
+      () => assertSafeSelector({ $where: 'this.profile.id > 0' }),
+      (error: unknown) => (error as Meteor.Error).error === 400,
+    );
+  });
+
+  it('rejects $expr', () => {
+    assert.throws(
+      () => assertSafeSelector({ $expr: { $gt: ['$a', '$b'] } }),
+      (error: unknown) => (error as Meteor.Error).error === 400,
+    );
+  });
+
+  it('rejects a nested $function inside $and', () => {
+    assert.throws(
+      () => assertSafeSelector({ $and: [{ name: 'x' }, { $function: { body: 'fn', args: [], lang: 'js' } }] }),
+      (error: unknown) => (error as Meteor.Error).error === 400,
+    );
+  });
+
+  it('rejects $accumulator', () => {
+    assert.throws(
+      () => assertSafeSelector({ total: { $accumulator: {} } }),
+      (error: unknown) => (error as Meteor.Error).error === 400,
+    );
+  });
+
+  it('rejects a non-object filter', () => {
+    assert.throws(() => assertSafeSelector('not an object'));
+  });
+});
+
+describe('members.findOne — authz + no password-hash leak (#257)', () => {
+  let adminUserId: string;
+  let noPermUserId: string;
+
+  before(async () => {
+    const [adminRoleId, noPermRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      createTestRole({ members: { read: false, create: false, update: false, delete: false } }),
+    ]);
+    [adminUserId, noPermUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: noPermRoleId }),
+    ]);
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('denies a caller lacking members read permission — 403', async () => {
+    await assertRejectsWithCode(() => callAs(noPermUserId, 'members.findOne', { _id: adminUserId }), 403);
+  });
+
+  it('rejects a $where selector — 400', async () => {
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'members.findOne', { $where: 'true' }),
+      400,
+    );
+  });
+
+  it('never returns the services field even when the caller omits the projection', async () => {
+    const result = (await callAs(adminUserId, 'members.findOne', { _id: adminUserId }, {})) as
+      | Record<string, unknown>
+      | undefined;
+    assert.ok(result, 'Expected the admin user to be returned');
+    assert.strictEqual(result.services, undefined, 'members.findOne must never expose services (password hash)');
+  });
+
+  it('still returns undefined on a miss (existence-check behavior preserved)', async () => {
+    const result = await callAs(adminUserId, 'members.findOne', { 'profile.registrationId': 'nonexistent' });
+    assert.strictEqual(result, undefined);
+  });
+});
+
+describe('generic publication — authz gate (#258)', () => {
+  let noPermUserId: string;
+
+  before(async () => {
+    const noPermRoleId = await createTestRole({
+      registrations: { read: false, create: false, update: false, delete: false },
+    });
+    noPermUserId = await createTestUser({ roleId: noPermRoleId });
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  // The publish handler resolves via this.userId + this.ready(); invoke it
+  // directly with a synthetic subscription context (mirrors fixtures.callAs).
+  function getPublishHandler(name: string) {
+    const handlers = (Meteor as unknown as {
+      server: { publish_handlers: Record<string, (this: { userId: string | null; ready: () => void; stop: () => void }, ...args: unknown[]) => unknown> };
+    }).server.publish_handlers;
+    const handler = handlers[name];
+    assert.ok(handler, `Publication "${name}" must be registered`);
+    return handler;
+  }
+
+  it('denies a member lacking registrations read permission — 403', async () => {
+    const handler = getPublishHandler('registrations');
+    const ctx = { userId: noPermUserId, ready: () => {}, stop: () => {} };
+    await assertRejectsWithCode(() => Promise.resolve(handler.apply(ctx, [{}, {}])), 403);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens every client-facing read path against four classes of issue: permission bypass on subscriptions, squad-scope escape, password-hash leakage, and code-execution query operators in client-supplied selectors.

## Changes

- **`assertSafeSelector(filter)`** (new export, `server/main.ts`): runs `validateObject`, then recursively walks the selector and throws `Meteor.Error(400, 'Disallowed query operator: <key>')` for `$where` / `$expr` / `$function` / `$accumulator`. Wired into the generic `.read` / `.count` / `.options` methods and the generic publication in `server/crud.lib.ts`, plus `members.findOne` and `members.saveTaskFilter` (sanitised before persisting `profile.taskFilter`). *(#259 / SEC-002/005/012)*
- **Generic publication authz** (`server/crud.lib.ts` `createCollectionPublish`): the publish body is now `async` and runs `checkPermission(this.userId, module, 'read')` before returning the cursor — skipped only when the registry sets `allowsAnonymous.read`. Existing limit-clamping preserved. *(#258 / SEC-003)*
- **`members.findOne`** (`server/apis/members.server.ts`): requires `members` read permission, merges `getSquadScope` into the selector, and forces `fields.services: 0` (merged onto the caller's projection, never replacing it) so the bcrypt hash can never be projected. Undefined-on-miss existence-check behaviour (used by `RegistrationExtra`) preserved. *(#257 / SEC-001, Critical)*
- **`members.all` / `members.participantNames` / `members.options`**: add the `members` read permission check + `getSquadScope` merge, consistent with `members.read`. Admins (`roles === true`) remain unrestricted; every other authenticated caller is scoped to their own `profile.squadId` (no new "officer" tier invented). *(#262 / SEC-009)*

## Tests

New `tests/server/readSecurityHardening.test.ts` (registered in `tests/main.ts`):
- `assertSafeSelector` accepts a normal selector and rejects top-level/nested `$where` / `$expr` / `$function` / `$accumulator`.
- `members.findOne` denies a no-permission caller (403), rejects a `$where` selector (400), never returns `services`, and still returns `undefined` on a miss.
- The `registrations` publication denies a member lacking that permission (403).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (397 passing, including the new suites)
- [ ] CI green

Closes #257
Closes #258
Closes #259
Closes #262