### PR TITLE
Harden backup.restore (validate + stronger permission + guard privilege fields)

### DIFF
--- a/server/apis/backup.server.ts
+++ b/server/apis/backup.server.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
-import { checkPermission, validateUserId } from '../main';
+import { checkPermission, getUserRole, isOfficerOrAdmin, validateUserId } from '../main';
 import { getCollection } from '../crud.lib';
 import { createLog } from './logs.server';
 import { RATE_LIMITS } from '../config';
@@ -45,6 +45,105 @@ interface RestoreResult {
   restored: Record<string, number>;
   errors: Array<{ collection: string; error: string }>;
   safetyBackup: BackupData | null;
+}
+
+// SEC-004 hardening: restore is the single most privilege-sensitive operation
+// in the app — it can rewrite the `users` and `roles` collections wholesale.
+// Before SEC-004 it inserted attacker-controlled documents verbatim, so a
+// `settings`-read user could upload a backup whose own user doc carried
+// `roles: true` (or arbitrary `services`) and self-promote to admin
+// (CWE-502/915/284). The hardening below:
+//   1. Requires full admin to restore (see method body). `settings` is a
+//      *boolean* module (server/main.ts BOOLEAN_MODULES), so checkPermission
+//      with operation 'update' is identical to 'read' and would NOT have
+//      strengthened anything — hence an explicit admin gate instead.
+//   2. Validates every document of every collection up front, refusing any
+//      `users` doc that carries credential/privilege fields (`services`,
+//      `roles`) or unexpected top-level keys.
+//   3. Validates the whole payload before touching the DB, so a malformed
+//      backup aborts with zero mutations.
+
+// Top-level keys we accept on a restored user document. `services`
+// (credentials) and `roles` (embedded permission grant) are deliberately
+// absent: the app assigns roles via `profile.roleId`, never an embedded
+// `roles` field, and credentials are never carried in a backup.
+const ALLOWED_USER_KEYS: readonly string[] = ['_id', 'username', 'profile', 'createdAt', 'emails'];
+const FORBIDDEN_USER_KEYS: readonly string[] = ['services', 'roles'];
+
+class RestoreValidationError extends Meteor.Error {
+  constructor(collection: string, index: number, reason: string) {
+    super(400, `Invalid backup: ${collection}[${index}] ${reason}`);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Validates a single restored user document. Throws RestoreValidationError on
+// any credential/privilege field or unexpected top-level key. This is the core
+// privilege-escalation guard for SEC-004.
+function validateRestoreUser(doc: unknown, index: number): void {
+  if (!isPlainObject(doc)) {
+    throw new RestoreValidationError('users', index, 'is not an object');
+  }
+  if (typeof doc._id !== 'string' || doc._id.length === 0) {
+    throw new RestoreValidationError('users', index, 'has a missing or non-string _id');
+  }
+  for (const forbidden of FORBIDDEN_USER_KEYS) {
+    if (forbidden in doc) {
+      throw new RestoreValidationError('users', index, `carries forbidden privilege/credential field "${forbidden}"`);
+    }
+  }
+  for (const key of Object.keys(doc)) {
+    if (!ALLOWED_USER_KEYS.includes(key)) {
+      throw new RestoreValidationError('users', index, `carries unexpected field "${key}"`);
+    }
+  }
+  if ('username' in doc && typeof doc.username !== 'string') {
+    throw new RestoreValidationError('users', index, 'has a non-string username');
+  }
+  if ('profile' in doc && !isPlainObject(doc.profile)) {
+    throw new RestoreValidationError('users', index, 'has a non-object profile');
+  }
+  // A `roles: true` grant cannot ride in via profile either.
+  if (isPlainObject(doc.profile) && 'roles' in doc.profile) {
+    throw new RestoreValidationError('users', index, 'carries forbidden privilege field "profile.roles"');
+  }
+}
+
+// Structural validation for every other collection: each document must be a
+// plain object with a string _id so wipe-then-insert is deterministic. The
+// `roles` collection is intentionally NOT specially guarded here because
+// restore now requires full admin (an admin can already mint any role); the
+// _id/object check still rejects malformed payloads.
+function validateRestoreDocument(collectionName: string, doc: unknown, index: number): void {
+  if (collectionName === 'users') {
+    validateRestoreUser(doc, index);
+    return;
+  }
+  if (!isPlainObject(doc)) {
+    throw new RestoreValidationError(collectionName, index, 'is not an object');
+  }
+  if (typeof doc._id !== 'string' || doc._id.length === 0) {
+    throw new RestoreValidationError(collectionName, index, 'has a missing or non-string _id');
+  }
+}
+
+// Validates the entire backup payload before any DB mutation. Throwing here
+// leaves the database untouched (the safety-backup, created earlier, is the
+// belt-and-braces recovery path). `collections` may carry collection names we
+// don't restore — those are ignored, mirroring the restore loop below.
+function validateRestorePayload(collections: Record<string, unknown[]>): void {
+  const restorable = [...BACKUP_COLLECTIONS, 'settings', 'users'];
+  for (const collectionName of restorable) {
+    const documents = collections[collectionName];
+    if (!documents) continue;
+    if (!Array.isArray(documents)) {
+      throw new Meteor.Error(400, `Invalid backup: "${collectionName}" is not an array of documents.`);
+    }
+    documents.forEach((doc, index) => validateRestoreDocument(collectionName, doc, index));
+  }
 }
 
 if (Meteor.isServer) {
@@ -182,9 +281,14 @@ if (Meteor.isServer) {
       validateUserId(this.userId);
       const { createSafetyBackup = true } = options;
 
-      const hasPermission = await checkPermission(this.userId, 'settings', 'read');
-      if (!hasPermission) {
-        throw new Meteor.Error(403, 'Permission denied. Settings access required for restore.');
+      // SEC-004: restore can rewrite users/roles wholesale, so it requires full
+      // admin — not merely `settings` access. `settings` is a boolean module,
+      // so checkPermission(..., 'update') would be identical to 'read' and would
+      // not have closed the privilege-escalation hole. Gate on admin instead.
+      const role = await getUserRole(this.userId);
+      if (!isOfficerOrAdmin(role)) {
+        await createLog('backup.restore.denied', { userId: this.userId });
+        throw new Meteor.Error(403, 'Permission denied. Administrator access is required to restore a backup.');
       }
 
       if (!backupData || typeof backupData !== 'object') {
@@ -198,6 +302,11 @@ if (Meteor.isServer) {
       if (backupData.appName !== 'community-manager') {
         throw new Meteor.Error(400, 'Invalid backup. This backup is not from community-manager.');
       }
+
+      // Validate the entire payload BEFORE wiping anything. A malformed backup —
+      // or one attempting to smuggle credential/privilege fields into `users` —
+      // aborts here with zero DB mutations (fail-before-write).
+      validateRestorePayload(backupData.collections);
 
       let safetyBackup: BackupData | null = null;
       if (createSafetyBackup) {

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -7,6 +7,7 @@ import './helpers/colors/getLegibleTextColor.test';
 import './helpers/colors/getLuminance.test';
 import './helpers/colors/hexToRgb.test';
 import './helpers/colors/parseColor.test';
+import './server/backupRestore.test';
 import './server/briefingTemplatesMethods.test';
 import './server/crudMethods.test';
 import './server/entityFormSubmit.test';

--- a/tests/server/backupRestore.test.ts
+++ b/tests/server/backupRestore.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert';
+import { Meteor } from 'meteor/meteor';
+import MembersCollection from '../../imports/api/collections/members.collection';
+import RolesCollection from '../../imports/api/collections/roles.collection';
+import {
+  assertRejectsWithCode,
+  callAs,
+  cleanupFixtures,
+  createTestRole,
+  createTestUser,
+  TEST_PREFIX,
+} from './fixtures';
+
+// SEC-004 regression suite. The vulnerability: backup.restore required only
+// `settings` read access and inserted uploaded `users` documents verbatim, so
+// a low-privilege user could upload a backup whose own user doc carried
+// `roles: true` (or arbitrary `services`) and self-promote to admin.
+
+interface BackupData {
+  version: string;
+  timestamp: string;
+  appName: string;
+  collections: Record<string, unknown[]>;
+  meta: { totalDocuments: number; collectionCounts: Record<string, number> };
+}
+
+function makeBackup(collections: Record<string, unknown[]>): BackupData {
+  return {
+    version: '1.0',
+    timestamp: new Date().toISOString(),
+    appName: 'community-manager',
+    collections,
+    meta: { totalDocuments: 0, collectionCounts: {} },
+  };
+}
+
+describe('backup.restore — SEC-004 privilege-escalation hardening', () => {
+  let adminUserId: string;
+  let settingsReaderUserId: string;
+
+  before(async () => {
+    const [adminRoleId, settingsRoleId] = await Promise.all([
+      createTestRole({ roles: true }),
+      // `settings` is a boolean module: this grants the exact capability the
+      // pre-SEC-004 restore required, and nothing more.
+      createTestRole({ settings: true }),
+    ]);
+    [adminUserId, settingsReaderUserId] = await Promise.all([
+      createTestUser({ roleId: adminRoleId }),
+      createTestUser({ roleId: settingsRoleId }),
+    ]);
+  });
+
+  after(async () => {
+    await cleanupFixtures();
+  });
+
+  it('rejects unauthenticated callers with a not-authorized error', async () => {
+    await assertRejectsWithCode(
+      () => callAs(null, 'backup.restore', makeBackup({}), { createSafetyBackup: false }),
+      'validateUserId',
+    );
+  });
+
+  it('rejects a settings-only (non-admin) user with 403 — read access is no longer enough', async () => {
+    await assertRejectsWithCode(
+      () => callAs(settingsReaderUserId, 'backup.restore', makeBackup({}), { createSafetyBackup: false }),
+      403,
+    );
+  });
+
+  it('rejects a backup whose user doc carries roles: true (self-promotion) with 400', async () => {
+    const malicious = makeBackup({
+      users: [{ _id: `${TEST_PREFIX}attacker`, username: 'attacker', roles: true }],
+    });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malicious, { createSafetyBackup: false }),
+      400,
+    );
+
+    // The malicious user must NOT have been inserted (fail-before-write).
+    const leaked = await MembersCollection.findOneAsync(`${TEST_PREFIX}attacker`);
+    assert.strictEqual(leaked, undefined, 'Rejected restore must not persist the attacker user doc');
+  });
+
+  it('rejects a backup whose user doc carries a services credential field with 400', async () => {
+    const malicious = makeBackup({
+      users: [{ _id: `${TEST_PREFIX}cred`, username: 'cred', services: { password: { bcrypt: 'x' } } }],
+    });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malicious, { createSafetyBackup: false }),
+      400,
+    );
+  });
+
+  it('rejects a backup whose user doc carries an unexpected top-level field with 400', async () => {
+    const malicious = makeBackup({
+      users: [{ _id: `${TEST_PREFIX}weird`, username: 'weird', isSuperAdmin: true }],
+    });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malicious, { createSafetyBackup: false }),
+      400,
+    );
+  });
+
+  it('rejects a backup smuggling roles via profile with 400', async () => {
+    const malicious = makeBackup({
+      users: [{ _id: `${TEST_PREFIX}sneaky`, username: 'sneaky', profile: { name: 'Sneaky', roles: true } }],
+    });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malicious, { createSafetyBackup: false }),
+      400,
+    );
+  });
+
+  it('rejects a malformed (non-array) collection payload with 400 before any wipe', async () => {
+    const malformed = makeBackup({ users: { not: 'an array' } as unknown as unknown[] });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malformed, { createSafetyBackup: false }),
+      400,
+    );
+
+    // The admin fixture user is still present — nothing was wiped.
+    const stillThere = await MembersCollection.findOneAsync(adminUserId);
+    assert.ok(stillThere, 'Validation failure must leave the users collection untouched');
+  });
+
+  it('rejects a non-users collection doc with a missing _id with 400', async () => {
+    const malformed = makeBackup({ roles: [{ name: 'no id role' }] });
+
+    await assertRejectsWithCode(
+      () => callAs(adminUserId, 'backup.restore', malformed, { createSafetyBackup: false }),
+      400,
+    );
+
+    const leaked = await RolesCollection.findOneAsync({ name: 'no id role' });
+    assert.strictEqual(leaked, undefined, 'Rejected restore must not persist a malformed role doc');
+  });
+});


### PR DESCRIPTION
## Summary
Closes SEC-004 (CWE-502/915/284): `backup.restore` required only `settings` access and inserted uploaded documents verbatim into every collection — including `users`. A low-privilege user could upload a backup whose own user doc carried `roles: true` or arbitrary `services` and self-promote to admin.

## What changed
`server/apis/backup.server.ts`:

1. **Stronger permission.** Restore now requires **full admin** (`getUserRole` + `isOfficerOrAdmin`), not `settings` access. Note: `settings` is a *boolean* module (`BOOLEAN_MODULES` in `server/main.ts`), so a `checkPermission(..., 'settings', 'update')` check would be byte-for-byte identical to `'read'` and would **not** have closed the hole — hence an explicit admin gate. A denied attempt now writes a `backup.restore.denied` audit entry.

2. **Validation before any write.** New `validateRestorePayload` runs over the whole backup *before* the first wipe:
   - every document must be a plain object with a non-empty string `_id`;
   - `users` docs are rejected if they carry credential/privilege fields (`services`, `roles`, or `profile.roles`) or any top-level key outside an allow-list (`_id`, `username`, `profile`, `createdAt`, `emails`);
   - a non-array collection payload is rejected.
   Rejection throws `Meteor.Error(400, …)` with a clear, indexed reason — preferred over silently dropping fields.

3. **Preserved behavior.** Current-user survival (RULE-059) and safety-backup-first are unchanged.

## Atomicity
True multi-document Mongo transactions are **not** implemented, because they require a replica set and this deployment runs a standalone `mongod` (`docker-compose.yml`: `mongo:7.0` with `--bind_ip_all --auth`, no `--replSet`); Meteor's dev Mongo is standalone too. Instead:
- **Validation runs before any wipe**, so a malformed or malicious backup aborts with **zero DB mutations** (fail-before-write) — the common failure mode.
- The existing **safety-backup is still created first**, giving an operator recovery path.
- **Residual non-atomicity:** a mid-insert *infrastructure* failure (after validation passes and wiping has begun) can still leave the DB partially restored; the safety backup is the recovery path. This is not claimed to be transactional.

## Tests
`tests/server/backupRestore.test.ts` (wired into `tests/main.ts`):
- a `settings`-only (non-admin) user is rejected with 403;
- a backup whose user doc sets `roles: true` is rejected with 400 and **not** persisted;
- `services` credential field, unexpected top-level field, and `profile.roles` smuggling are each rejected;
- malformed (non-array) payload and a missing-`_id` doc are rejected, leaving the DB untouched.

## Verification
- `npm run typecheck` — clean.
- `npm test` — 386 passing, 0 failing (includes the new SEC-004 suite).

Closes #263