### PR TITLE
Add Claude Code harness hooks for git safety and verify gating

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,61 @@
+# Claude Code hooks
+
+Harness-level guardrails that convert prose rules from `CLAUDE.md` / agent memory
+into checks the harness enforces, so they cannot be silently skipped. Wired up in
+[`.claude/settings.json`](../settings.json). All scripts are referenced via
+`$CLAUDE_PROJECT_DIR` so they also work inside git worktrees.
+
+| Hook | Event | Script | What it does |
+|------|-------|--------|--------------|
+| Dangerous-git guard | `PreToolUse(Bash)` | `block-dangerous-git.sh` | Blocks repo-specific git/gh footguns before they run |
+| Verification recorder | `PostToolUse(Bash)` | `record-verify.sh` | Records when `typecheck`/`test` pass for the current code state |
+| Verification gate | `Stop` | `verify-gate.sh` | Refuses to end a turn with unverified source changes |
+
+## Dangerous-git guard (`block-dangerous-git.sh`)
+
+Branch-aware — the normal `branch → commit → push → PR` flow is **not** blocked.
+Only these are denied (exit 2):
+
+- `git commit` / `git push` while on the default branch (`main`/`master`)
+- `git reset --hard` (irreversible working-tree/index loss)
+- `git branch -D` / `--delete --force` (can drop unmerged commits)
+- `gh pr merge --delete-branch` (auto-closes open child PRs — the stacked-PR footgun)
+
+**Escape hatch:** prefix any one command with `ALLOW_DANGEROUS_GIT=1`, e.g.
+
+```bash
+ALLOW_DANGEROUS_GIT=1 git reset --hard origin/main
+```
+
+## Verification gate (`verify-gate.sh` + `record-verify.sh`)
+
+Prevents an agent from declaring "done" when the branch has **source** changes
+(`imports/`, `server/`, `client/`, `tests/`, `e2e/`, or a root `*.ts`) that have
+not passed `npm run typecheck` **and** `npm test` for the current code state.
+
+How it works:
+
+1. `record-verify.sh` (PostToolUse) watches Bash commands. When a typecheck or
+   test command passes, it records that against a **tree signature**
+   (`HEAD` sha + dirty-tree hash) in `.claude/.verify-state` (gitignored). It is
+   conservative — it records a pass only on an explicit `exit_code == 0` or, as a
+   fallback, when no failure tokens appear in the output — so the gate can never
+   be *falsely* satisfied.
+2. Any edit changes the tree signature, which re-arms the gate.
+3. `verify-gate.sh` (Stop) blocks the turn until both checks are recorded for the
+   current signature. It is inactive on the default branch and when no source
+   files changed.
+
+**Satisfy it** by running `npm run typecheck && npm test` (recorded automatically).
+**Bypass it** with `CLAUDE_SKIP_VERIFY_GATE=1` (not recommended).
+
+## Testing the hooks
+
+Each script reads a JSON event on stdin and signals via exit code (0 allow, 2 block):
+
+```bash
+# should BLOCK (exit 2)
+echo '{"tool_input":{"command":"git reset --hard"}}' | .claude/hooks/block-dangerous-git.sh
+# should ALLOW (exit 0)
+echo '{"tool_input":{"command":"ALLOW_DANGEROUS_GIT=1 git reset --hard"}}' | .claude/hooks/block-dangerous-git.sh
+```

--- a/.claude/hooks/block-dangerous-git.sh
+++ b/.claude/hooks/block-dangerous-git.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# PreToolUse(Bash) guard — blocks repo-specific dangerous git/gh operations.
+#
+# Unlike a blanket "git push" block, this is branch-aware: the normal
+# branch -> commit -> push -> PR workflow stays unblocked. Only the documented
+# footguns are denied:
+#   - git commit / git push while on the default branch (main/master)
+#   - git reset --hard            (irreversible working-tree/index loss)
+#   - git branch -D / --delete --force  (lose unmerged commits)
+#   - gh pr merge --delete-branch (auto-closes open child PRs — stacked-PR footgun)
+#
+# Escape hatch: prefix any single command with ALLOW_DANGEROUS_GIT=1 to bypass,
+# e.g.  ALLOW_DANGEROUS_GIT=1 git reset --hard origin/main
+#
+# The hook reads the tool-call JSON on stdin. The Bash command lives in
+# .tool_input.command; every pattern below is plain ASCII that survives JSON
+# string-escaping unchanged, so we match the raw payload directly and avoid a
+# dependency on jq/node (a guard that silently fails when its parser is missing
+# is worse than no guard).
+#
+# Contract: exit 0 = allow, exit 2 = block (stderr shown to the agent).
+
+set -uo pipefail
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+# Per-command escape hatch.
+if printf '%s' "$INPUT" | grep -q 'ALLOW_DANGEROUS_GIT=1'; then
+  exit 0
+fi
+
+deny() {
+  echo "BLOCKED by .claude/hooks/block-dangerous-git.sh: $1" >&2
+  echo "If this is genuinely intended, re-run the command prefixed with ALLOW_DANGEROUS_GIT=1" >&2
+  exit 2
+}
+
+# --- Always-dangerous, irreversible operations -------------------------------
+
+if printf '%s' "$INPUT" | grep -qE 'git[[:space:]]+reset[[:space:]]+(--[[:alnum:]-]+[[:space:]]+)*--hard'; then
+  deny "'git reset --hard' irreversibly discards working-tree and index changes."
+fi
+
+if printf '%s' "$INPUT" | grep -qE 'git[[:space:]]+branch[[:space:]]+([^|&;\\]*[[:space:]])?(-D|--delete[[:space:]]+--force|--force[[:space:]]+--delete)'; then
+  deny "'git branch -D' force-deletes a branch and can drop unmerged commits. Use -d (safe delete) instead."
+fi
+
+# Stacked-PR footgun: deleting the source branch on merge auto-closes any child PR.
+if printf '%s' "$INPUT" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' \
+   && printf '%s' "$INPUT" | grep -qE '(--delete-branch|[[:space:]]-d([[:space:]]|\\|"))'; then
+  deny "'gh pr merge --delete-branch' auto-closes open child PRs (stacked-PR footgun). Merge first, delete the branch later once no child PR depends on it."
+fi
+
+# --- Commits / pushes on the default branch ----------------------------------
+
+if printf '%s' "$INPUT" | grep -qE 'git[[:space:]]+(commit|push)([[:space:]]|\\|")'; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    deny "Refusing a git commit/push while on '$BRANCH'. Create a feature branch first (CLAUDE.md workflow: issue -> branch -> implement -> PR)."
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/lib.sh
+++ b/.claude/hooks/lib.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the verification-gate hooks. Sourced by record-verify.sh
+# (PostToolUse) and verify-gate.sh (Stop) so the signature definition can never
+# drift between the recorder and the gate.
+
+# tree_sig — a CONTENT-sensitive signature of the current code state.
+# Combines HEAD, the full tracked diff vs HEAD (staged + unstaged content), and
+# the contents of untracked files. Any edit — including to an already-dirty or
+# untracked file — changes the signature and re-arms the gate. Using only
+# `git status --porcelain` would miss content edits (the status line is
+# identical regardless of how the file changed).
+tree_sig() {
+  local head diff others_list others
+  head=$(git rev-parse HEAD 2>/dev/null || echo none)
+  diff=$(git diff HEAD 2>/dev/null | sha1sum | cut -d' ' -f1)
+  others_list=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+  if [ -n "$others_list" ]; then
+    others=$(printf '%s\n' "$others_list" | while IFS= read -r f; do cat "$f" 2>/dev/null; done | sha1sum | cut -d' ' -f1)
+  else
+    others=$(printf '' | sha1sum | cut -d' ' -f1)
+  fi
+  printf '%s:%s:%s' "$head" "$diff" "$others"
+}

--- a/.claude/hooks/record-verify.sh
+++ b/.claude/hooks/record-verify.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# PostToolUse(Bash) recorder — notes when verification commands pass, so the
+# Stop gate (verify-gate.sh) can tell whether the current code state was checked.
+#
+# It records into .claude/.verify-state (gitignored) keyed by a tree signature
+# (HEAD sha + dirty-tree hash). Any new edit changes the signature and re-arms
+# the gate. It is deliberately CONSERVATIVE: it records a pass only when it is
+# confident, so the gate can never be falsely satisfied.
+#
+# The tool-call JSON arrives on stdin (command in .tool_input.command, result in
+# .tool_response). We match the raw payload with grep to avoid a jq/node
+# dependency. Pass detection, in order of preference:
+#   1. an explicit non-zero exit_code/exitCode  -> fail
+#      an explicit zero exit_code/exitCode       -> pass
+#   2. fallback: no failure tokens in the payload -> pass
+#
+# Contract: always exit 0 (a recorder must never block a tool call).
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/.verify-state"
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+# Which verification does this command represent?
+CHECK=""
+if printf '%s' "$INPUT" | grep -qE '(npm run typecheck|tsc[[:space:]]+--noEmit|tsc[[:space:]]+-p)'; then
+  CHECK="typecheck"
+elif printf '%s' "$INPUT" | grep -qE '(npm test|npm run test|meteor test)'; then
+  CHECK="test"
+fi
+[ -z "$CHECK" ] && exit 0   # not a verification command — nothing to record
+
+# --- Did it pass? ------------------------------------------------------------
+PASSED="unknown"
+if printf '%s' "$INPUT" | grep -qE '"(exit_code|exitCode)":[[:space:]]*[1-9]'; then
+  PASSED="no"
+elif printf '%s' "$INPUT" | grep -qE '"(exit_code|exitCode)":[[:space:]]*0'; then
+  PASSED="yes"
+fi
+if [ "$PASSED" = "unknown" ]; then
+  # Fallback: scan the whole payload for common failure signals.
+  if printf '%s' "$INPUT" | grep -qiE 'error TS[0-9]|[0-9]+ failing|✗|not ok|tests? failed|FAIL |npm error|command failed'; then
+    PASSED="no"
+  else
+    PASSED="yes"
+  fi
+fi
+[ "$PASSED" = "yes" ] || exit 0
+
+# --- Record against the current tree signature -------------------------------
+SIG="$(tree_sig)"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+PREV_SIG=""
+[ -f "$STATE_FILE" ] && PREV_SIG=$(grep '^SIG=' "$STATE_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+
+if [ "$PREV_SIG" = "$SIG" ]; then
+  # Same code state: add this check if not already present.
+  grep -qx "$CHECK=1" "$STATE_FILE" 2>/dev/null || echo "$CHECK=1" >>"$STATE_FILE"
+else
+  # New code state: reset the record.
+  { echo "SIG=$SIG"; echo "$CHECK=1"; } >"$STATE_FILE"
+fi
+
+exit 0

--- a/.claude/hooks/verify-gate.sh
+++ b/.claude/hooks/verify-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Stop gate — refuses to let the agent finish a turn when the current feature
+# branch has SOURCE changes that have not passed typecheck + tests.
+#
+# It reads the marker written by record-verify.sh. The marker is keyed to a
+# tree signature, so any edit since the last green run re-arms the gate.
+#
+# Scope guards (keep it low-friction):
+#   - inactive on the default branch (commits there are blocked anyway)
+#   - inactive when no source files changed vs the default branch / working tree
+#   - bypass entirely with CLAUDE_SKIP_VERIFY_GATE=1
+#
+# Contract: exit 0 = allow stop, exit 2 = block (stderr shown to the agent).
+# Guards against infinite loops: if the agent is stopping *because* a prior
+# stop hook already blocked, Claude Code passes stop_hook_active=true.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+[ "${CLAUDE_SKIP_VERIFY_GATE:-}" = "1" ] && exit 0
+
+INPUT=$(cat)
+# Avoid stop-hook loops: Claude Code sets stop_hook_active when re-stopping
+# after a prior Stop-hook block. Matched on the raw payload (no jq dependency).
+if printf '%s' "$INPUT" | grep -qE '"stop_hook_active":[[:space:]]*true'; then
+  exit 0
+fi
+
+STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/.verify-state"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+[ -z "$BRANCH" ] && exit 0
+{ [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; } && exit 0
+
+# Source files changed on this branch: committed vs main + staged + unstaged +
+# untracked (new files don't appear in `git diff`, so list them explicitly).
+BASE=$(git merge-base main HEAD 2>/dev/null || echo "")
+CHANGED=$(
+  {
+    [ -n "$BASE" ] && git diff --name-only "$BASE"...HEAD 2>/dev/null
+    git diff --name-only 2>/dev/null
+    git diff --cached --name-only 2>/dev/null
+    git ls-files --others --exclude-standard 2>/dev/null
+  } | sort -u | grep -E '^(imports|server|client|tests|e2e)/|^[^/]+\.ts$' || true
+)
+[ -z "$CHANGED" ] && exit 0   # no source changes — nothing to gate
+
+# Has the current code state passed both checks?
+SIG="$(tree_sig)"
+MARK_SIG=""
+[ -f "$STATE_FILE" ] && MARK_SIG=$(grep '^SIG=' "$STATE_FILE" 2>/dev/null | head -1 | cut -d= -f2-)
+
+if [ "$MARK_SIG" = "$SIG" ] \
+   && grep -qx 'typecheck=1' "$STATE_FILE" 2>/dev/null \
+   && grep -qx 'test=1' "$STATE_FILE" 2>/dev/null; then
+  exit 0
+fi
+
+echo "BLOCKED by .claude/hooks/verify-gate.sh: branch '$BRANCH' has source changes that have not passed verification for the current code state." >&2
+echo "Run both, then they will be recorded automatically:" >&2
+echo "    npm run typecheck && npm test" >&2
+echo "To finish without verifying (not recommended), set CLAUDE_SKIP_VERIFY_GATE=1." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/record-verify.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ _build
 */build-assets
 */build-chunks
 .rsdoctor
+
+# Claude Code verification-gate marker (local state)
+.claude/.verify-state


### PR DESCRIPTION
## Summary
- First checked-in `.claude/settings.json`, wiring three harness hooks that convert prose guardrails from `CLAUDE.md`/agent memory into enforced checks.
- **`block-dangerous-git.sh`** (PreToolUse/Bash): branch-aware guard. Blocks `commit`/`push` on `main`, `git reset --hard`, `git branch -D`, and `gh pr merge --delete-branch` (stacked-PR footgun). The normal `branch → commit → push → PR` flow stays unblocked. Per-command escape hatch: `ALLOW_DANGEROUS_GIT=1`.
- **`verify-gate.sh`** (Stop) + **`record-verify.sh`** (PostToolUse/Bash): refuse to end a turn when the feature branch has source changes that haven't passed `npm run typecheck` + `npm test` for the current code state. A content-sensitive tree signature (shared `lib.sh`) re-arms the gate on any edit; the recorder is conservative so the gate can never be *falsely* satisfied. Inactive on the default branch and when no source changed; bypass with `CLAUDE_SKIP_VERIFY_GATE=1`.
- Hooks parse the raw stdin payload with `grep` instead of `jq`/`node`, so they never **fail open** when a parser is missing on PATH. Marker file (`.claude/.verify-state`) is gitignored. Docs in `.claude/hooks/README.md`.

## Design notes
- The bundled `git-guardrails` skill blocks *all* `git push`; that would break this repo's PR workflow, so the guard is scoped to the documented footguns and made branch-aware.
- The Stop gate's signature combines `HEAD` + the full tracked diff vs `HEAD` + untracked-file contents — `git status --porcelain` alone misses content edits to already-dirty/untracked files (caught and fixed during testing).

## Test Plan
1. `block-dangerous-git.sh`: 14-case matrix — each footgun blocked (exit 2), every normal/escape-hatch command allowed (exit 0). ✅
2. Stop gate lifecycle: unverified source change blocks → record typecheck+test pass → allows → content edit re-arms → block → re-verify → allows. ✅
3. `npm run typecheck` passes; change touches only `.claude/` + `.gitignore` (no app/test code), so the Meteor test suite is unaffected.
4. `bash -n` clean on all scripts.

## Related Issue
Closes #275