### PR TITLE
Update scaffolder skills to current conventions + add drift guard

### DIFF
--- a/.claude/skills/collection.md
+++ b/.claude/skills/collection.md
@@ -3,70 +3,89 @@
 Scaffold a new MongoDB collection with all required files and registrations.
 
 ## Usage
-`/collection <name>` - Create collection (e.g., `/collection announcements`)
+`/collection <name>` — create collection (e.g., `/collection announcements`)
 
-## Instructions
+> This codebase is **fully TypeScript (`strict: true`)**. Every file below is `.ts`/`.tsx`.
+> Before writing, read the live shapes you must extend — do not trust a frozen template:
+> - `imports/api/types/crud.ts` — the `CrudCollectionMap` interface (source of the `CrudCollectionName` union)
+> - `server/collection-registry.ts` — `CollectionRegistryEntry` and the `COLLECTION_REGISTRY` map
+> - `server/crud.lib.ts` — the `COLLECTIONS` map and `getCollection()`
+> - `server/main.ts` — the `collectionNames` array (drives method/publish registration)
+> - an existing collection, e.g. `imports/api/collections/squads.collection.ts`
 
-Follow these steps to create a complete collection:
+## Steps
 
-### 1. Create Collection File
+### 1. Define the document type
 
-Create `imports/api/collections/<name>.collection.js`:
+Add an interface in `imports/api/types/` (e.g. `imports/api/types/<name>.ts`) and re-export it from `imports/api/types/index.ts`. Mirror an existing type such as `squad.ts`.
 
-```javascript
+### 2. Create the collection file
+
+`imports/api/collections/<name>.collection.ts`:
+
+```typescript
 import { Mongo } from 'meteor/mongo';
+import type { <Type> } from '/imports/api/types';
 
-const <Name>Collection = new Mongo.Collection('<name>');
+const <Name>Collection = new Mongo.Collection<<Type>>('<name>');
 
 export default <Name>Collection;
 ```
 
-### 2. Register in crud.lib.js
+### 3. Add to the `CrudCollectionMap`
 
-Add import at top of `server/crud.lib.js`:
-```javascript
+In `imports/api/types/crud.ts`, add the entry **alphabetically** (this extends the `CrudCollectionName` union and makes a `COLLECTION_REGISTRY` entry compile-mandatory):
+
+```typescript
+export interface CrudCollectionMap {
+  // ...
+  <name>: <Type>;
+}
+```
+
+### 4. Register in `server/crud.lib.ts`
+
+Import the collection and add it to the `COLLECTIONS` map **alphabetically**:
+
+```typescript
 import <Name>Collection from '../imports/api/collections/<name>.collection';
+// ...
+const COLLECTIONS: CollectionMap = {
+  // ...
+  <name>: <Name>Collection,
+};
 ```
 
-Add case to `getCollection()` switch:
-```javascript
-case '<name>':
-  return <Name>Collection;
+### 5. Register methods + publication in `server/main.ts`
+
+Add `'<name>'` to the `collectionNames` array **alphabetically**. The boot loop calls `createCollectionPublish()` + `createCollectionMethods()` for every entry. (Use `methodOnlyCollections` instead if the collection should expose methods but no reactive publication.)
+
+### 6. Add the `COLLECTION_REGISTRY` entry
+
+In `server/collection-registry.ts`, add **alphabetically** (minimum `{ module }`; add `foreignKeys`, `displayField`, `redact`, `allowsAnonymous` as needed — see `CollectionRegistryEntry`):
+
+```typescript
+<name>: { module: '<module>' },
 ```
 
-Add at bottom with other registrations:
-```javascript
-createCollectionMethods('<name>');
-createCollectionPublish('<name>');
-```
+If `<module>` is a new permission module, also add it to the CRUD-modules list in `server/main.ts`.
 
-### 3. Add Permission Mapping
+### 7. Update docs
 
-In `server/main.js`, add to `COLLECTION_TO_MODULE`:
-```javascript
-<name>: '<name>',  // or map to existing module
-```
+Add the collection to the Collections list in `CLAUDE.md` and to `docs/collections.md`.
 
-If new permission module, add to `CRUD_MODULES` array:
-```javascript
-const CRUD_MODULES = [
-  // ... existing modules
-  '<name>',
-];
-```
+## Naming conventions
 
-### 4. Update CLAUDE.md
+- Collection name (DDP + map keys): camelCase (e.g. `announcements`, `taskStatus`)
+- Variable: PascalCase + `Collection` (e.g. `AnnouncementsCollection`)
+- File: `<name>.collection.ts`
 
-Add the new collection to the Collections list.
+## Verify
 
-## Naming Conventions
+- `npm run typecheck` (the `Record<CrudCollectionName, _>` registry will fail to compile if step 6 is skipped)
+- `npm run lint`
 
-- Collection name: camelCase singular or plural as appropriate (e.g., `announcements`)
-- Collection variable: PascalCase + "Collection" (e.g., `AnnouncementsCollection`)
-- File name: camelCase + `.collection.js` (e.g., `announcements.collection.js`)
+## Next
 
-## Output
-
-After scaffolding, suggest creating:
-- Form component with `/form <name>`
-- Section page with `/section <name>`
+- `/form <name>` — drawer form
+- `/section <name>` — full CRUD page

--- a/.claude/skills/component.md
+++ b/.claude/skills/component.md
@@ -3,93 +3,94 @@
 Scaffold a React component following project patterns.
 
 ## Usage
-`/component <name>` - Create component (e.g., `/component UserCard`)
-`/component <folder>/<name>` - Create in specific folder
+`/component <name>` — create component (e.g., `/component UserCard`)
+`/component <folder>/<name>` — create in a specific folder
 
-## Instructions
+> Fully TypeScript, `strict: true`. **Function components only — no `React.FC`, no PropTypes.**
+> Props are a TypeScript `interface` declared **above** the component. Mirror an existing
+> component such as `imports/ui/squads/SquadMembers.tsx`.
 
-Create component file at `imports/ui/<folder>/<Name>.jsx`:
+Create the component at `imports/ui/<folder>/<Name>.tsx`:
 
-```javascript
-import PropTypes from 'prop-types';
+```tsx
 import React from 'react';
 
-export default function <Name>({ prop1 = '', prop2 = [] }) {
-  return (
-    <div>
-      {/* Component content */}
-    </div>
-  );
+interface <Name>Props {
+  prop1?: string;
+  prop2?: string[];
 }
 
-<Name>.propTypes = {
-  prop1: PropTypes.string,
-  prop2: PropTypes.array,
-};
+export default function <Name>({ prop1 = '', prop2 = [] }: <Name>Props) {
+  return <div>{/* content */}</div>;
+}
 ```
 
 ## Patterns
 
-### With Meteor Data
-```javascript
-import { useFind, useSubscribe } from 'meteor/react-meteor-data';
-import PropTypes from 'prop-types';
-import React, { useMemo } from 'react';
-import Collection from '../../api/collections/<name>.collection';
+### With Meteor data
 
-export default function <Name>({ filter = {} }) {
-  useSubscribe('<collection>', filter, { limit: 20 });
-  const data = useFind(() => Collection.find(filter), [filter]);
+```tsx
+import { useFind, useSubscribe } from 'meteor/react-meteor-data';
+import React from 'react';
+import <Name>Collection from '../../api/collections/<name>.collection';
+import type { <Type> } from '../../api/types';
+
+interface <Name>Props {
+  filter?: Record<string, unknown>;
+}
+
+export default function <Name>({ filter = {} }: <Name>Props) {
+  useSubscribe('<name>', filter, { limit: 20 });
+  const data = useFind(() => <Name>Collection.find(filter), [filter]);
 
   return (
     <div>
-      {data.map(item => (
+      {data.map((item: <Type>) => (
         <div key={item._id}>{item.name}</div>
       ))}
     </div>
   );
 }
-
-<Name>.propTypes = {
-  filter: PropTypes.object,
-};
 ```
 
-### With Event Handlers
-```javascript
+### With a method call
+
+Prefer the `useMethod` hook (the MethodCall seam) over a raw `Meteor.callAsync`. Get
+`message`/`notification` from `App.useApp()` — never the static antd singletons (they
+don't render inside drawer context).
+
+```tsx
 import { App } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
+import useMethod from '../hooks/useMethod';
 
-export default function <Name>({ onSuccess = () => {} }) {
-  const { notification, message } = App.useApp();
-
-  const handleClick = useCallback(async () => {
-    try {
-      await Meteor.callAsync('<collection>.method', args);
-      message.success('Success');
-      onSuccess();
-    } catch (error) {
-      notification.error({ message: error.error, description: error.message });
-    }
-  }, [onSuccess, message, notification]);
-
-  return (
-    <button onClick={handleClick}>Click</button>
-  );
+interface <Name>Props {
+  onSuccess?: () => void;
 }
 
-<Name>.propTypes = {
-  onSuccess: PropTypes.func,
-};
+export default function <Name>({ onSuccess = () => {} }: <Name>Props) {
+  const { message } = App.useApp();
+  const { call, loading } = useMethod('<name>.method');
+
+  const handleClick = useCallback(async () => {
+    const res = await call(/* args */);
+    if (res.ok) {
+      message.success('Success');
+      onSuccess();
+    } else {
+      message.error(res.error.message);
+    }
+  }, [call, message, onSuccess]);
+
+  return <button onClick={handleClick} disabled={loading}>Click</button>;
+}
 ```
 
 ## Guidelines
 
-- Function components only
-- PropTypes required for all props
-- Destructure props with defaults
-- Use `useCallback` for event handlers
-- Use `useMemo` for computed values
-- Use Ant Design components for UI
+- Function components only; **no `React.FC`** (these are lint-enforced — see `eslint.config.mjs`).
+- Props interface named `<Name>Props`, declared above the component; destructure with defaults in the signature.
+- **No PropTypes** — the codebase is TypeScript.
+- `useCallback` for event handlers, `useMemo` for computed values; narrow dependency arrays to specific fields.
+- Use Ant Design components; use `useTranslation()` (`t()`) for user-facing strings.
+- On `member.profile.X` access use a non-null assertion (`member.profile.X`), never optional chaining.

--- a/.claude/skills/form.md
+++ b/.claude/skills/form.md
@@ -1,123 +1,102 @@
 # /form
 
-Scaffold an Ant Design form component with drawer integration.
+Scaffold an Ant Design drawer form component.
 
 ## Usage
-`/form <name>` - Create form (e.g., `/form Announcements`)
+`/form <name>` — create form (e.g., `/form Announcements`)
 
-## Instructions
+> Fully TypeScript, `strict: true`. Forms run inside the **DrawerStack** and submit through
+> the **`useEntityForm`** hook (the MethodCall seam) — there is no `setOpen`, `useSubdrawer`,
+> `DrawerContext`, or `SubdrawerContext` anymore, and no raw `Meteor.callAsync` in forms.
+> Read the live contract before writing:
+> - `imports/ui/hooks/useEntityForm.ts` — `UseEntityFormOptions` / `UseEntityForm`
+> - `imports/ui/components/FormFooter.tsx`
+> - a real form, e.g. `imports/ui/squads/SquadsForm.tsx`
 
-Create form file at `imports/ui/<name>/<Name>Form.jsx`:
+Create the form at `imports/ui/<name>/<Name>Form.tsx`:
 
-```javascript
+```tsx
 import { Form, Input } from 'antd';
-import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
-import React, { useContext, useMemo } from 'react';
-import { DrawerContext, SubdrawerContext } from '../app/App';
+import React from 'react';
+import { useTranslation } from '/imports/i18n/LanguageContext';
+import type { <Type> } from '../../api/types';
+import useEntityForm from '../hooks/useEntityForm';
 import FormFooter from '../components/FormFooter';
 
-export default function <Name>Form({ setOpen, useSubdrawer = false }) {
-  const drawer = useContext(DrawerContext);
-  const subdrawer = useContext(SubdrawerContext);
-
-  const model = useMemo(() => {
-    return useSubdrawer ? subdrawer.drawerModel || {} : drawer.drawerModel || {};
-  }, [drawer, subdrawer, useSubdrawer]);
-
-  const handleFinish = async values => {
-    const args = [...(model?._id ? [model._id] : []), values];
-    const method = model?._id ? '<collection>.update' : '<collection>.insert';
-
-    Meteor.callAsync(method, ...args)
-      .then(() => {
-        setOpen(false);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-  };
-
-  return (
-    <Form layout="vertical" initialValues={model} onFinish={handleFinish}>
-      <Form.Item
-        label="Name"
-        name="name"
-        rules={[{ required: true, type: 'string' }]}
-        required
-      >
-        <Input placeholder="Enter name" />
-      </Form.Item>
-
-      {/* Add more Form.Item components as needed */}
-
-      <FormFooter />
-    </Form>
-  );
+interface <Name>FormValues {
+  name?: string;
 }
 
-<Name>Form.propTypes = {
-  setOpen: PropTypes.func,
-  useSubdrawer: PropTypes.bool,
+const <Name>Form = () => {
+  const { t } = useTranslation();
+
+  // useEntityForm derives <name>.insert / <name>.update from `collection`,
+  // reads the model from the drawer frame, and resolves the frame on success.
+  const { onFinish, loading, model } = useEntityForm<<Name>FormValues, Partial<<Type>> & { _id?: string }>({
+    collection: '<name>',
+    created: 'messages.<name>Created',
+    updated: 'messages.<name>Updated',
+    // toPayload maps antd values to the wire payload — omit if a 1:1 mapping.
+  });
+
+  return (
+    <Form layout="vertical" initialValues={model} onFinish={onFinish} disabled={loading}>
+      <Form.Item label={t('common.name')} name="name" rules={[{ required: true, type: 'string' }]} required>
+        <Input placeholder={t('forms.placeholders.enterName')} />
+      </Form.Item>
+
+      {/* more Form.Item fields */}
+
+      <FormFooter loading={loading} />
+    </Form>
+  );
 };
+
+export default <Name>Form;
 ```
 
-## Common Form Fields
+Add the `messages.<name>Created` / `messages.<name>Updated` keys to `imports/i18n/translations.ts` (all three locales).
 
-### Text Input
-```javascript
-<Form.Item label="Label" name="fieldName" rules={[{ required: true }]}>
-  <Input placeholder="Enter value" />
-</Form.Item>
-```
+## Common fields
 
 ### TextArea
-```javascript
-<Form.Item label="Description" name="description">
-  <Input.TextArea rows={4} placeholder="Enter description" />
+```tsx
+<Form.Item label={t('common.description')} name="description" rules={[{ required: false, type: 'string' }]}>
+  <Input.TextArea autoSize placeholder={t('forms.placeholders.enterDescription')} />
 </Form.Item>
 ```
 
-### Select
-```javascript
-<Form.Item label="Type" name="type" rules={[{ required: true }]}>
-  <Select placeholder="Select type">
-    <Select.Option value="a">Option A</Select.Option>
-    <Select.Option value="b">Option B</Select.Option>
-  </Select>
+### Switch / Checkbox — **must** set `valuePropName="checked"`
+```tsx
+<Form.Item label={t('...')} name="active" valuePropName="checked">
+  <Switch />
 </Form.Item>
 ```
 
-### CollectionSelect
-```javascript
+### CollectionSelect (FK field with inline create/edit)
+```tsx
 <CollectionSelect
   name="memberId"
-  label="Member"
+  label={t('...')}
   rules={[{ required: true }]}
   collection={MembersCollection}
   subscription="members"
   FormComponent={MembersForm}
-  placeholder="Select member"
 />
 ```
 
-### Date Picker
-```javascript
-<Form.Item label="Date" name="date">
+### Date
+```tsx
+<Form.Item label={t('...')} name="date">
   <DatePicker style={{ width: '100%' }} />
-</Form.Item>
-```
-
-### Switch
-```javascript
-<Form.Item label="Active" name="active" valuePropName="checked">
-  <Switch />
 </Form.Item>
 ```
 
 ## Guidelines
 
-- Always use `layout="vertical"`
-- Get model from DrawerContext or SubdrawerContext
-- Handle both create (no _id) and update (has _id) modes
-- Use FormFooter component for submit/cancel buttons
+- Always `layout="vertical"`; `initialValues={model}`; `disabled={loading}`.
+- The model comes from `useEntityForm` (it reads the drawer frame) — never from a context or prop.
+- `useEntityForm` handles both create (no `_id`) and update (has `_id`) automatically.
+- Use `FormFooter` (`loading`, and `onCancel`/`onFinish` as needed) for the action buttons.
+- Component is a plain function component — **no `React.FC`, no PropTypes** (lint-enforced).
+- For nullable string fields, convert with `?? undefined` **only** at the antd DOM boundary, never on the write path.

--- a/.claude/skills/section.md
+++ b/.claude/skills/section.md
@@ -1,143 +1,124 @@
 # /section
 
-Scaffold a full Section page with collection, form, columns, and page component.
+Scaffold a full Section page: collection, form, typed columns, and the page component.
 
 ## Usage
-`/section <name>` - Create full section (e.g., `/section announcements`)
+`/section <name>` — create a full CRUD section (e.g., `/section announcements`)
 
-## Instructions
+> Fully TypeScript, `strict: true`. The generic `Section<T>` component drives the table,
+> search, and drawer. Read the live contract and a real example before writing:
+> - `imports/ui/section/types.ts` — `ColumnsFactory`, `SectionPermissions`, `RowClickEvent`, `TranslateFn`
+> - `imports/ui/squads/Squads.tsx` (page), `imports/ui/squads/squads.columns.tsx` (columns)
 
-This creates a complete CRUD section with:
-1. Collection (if not exists)
-2. Form component
-3. Section page with columns
+## Steps
 
-### 1. Create Folder Structure
+### 1. Collection — `/collection <name>`
+If the collection doesn't exist yet, scaffold it first.
 
+### 2. Folder structure
 ```
 imports/ui/<name>/
-  ├── <Name>Form.jsx
-  ├── <Name>Page.jsx
-  └── <Name>Select.jsx (optional)
+  ├── <Name>.tsx           # the page (renders <Section<T>>)
+  ├── <Name>Form.tsx       # /form <name>
+  ├── <name>.columns.tsx   # ColumnsFactory<T>
+  └── <Name>Select.tsx     # optional, for FK selection elsewhere
 ```
 
-### 2. Create Page Component
+### 3. Columns — `imports/ui/<name>/<name>.columns.tsx`
 
-`imports/ui/<name>/<Name>Page.jsx`:
+```tsx
+import type { ColumnsType } from 'antd/es/table';
+import React from 'react';
+import type { <Type> } from '../../api/types';
+import type { ColumnsFactory, RowClickEvent, SectionPermissions, TranslateFn } from '../section/types';
+import TableActions from '../table/body/actions/TableActions';
 
-```javascript
-import React, { useCallback } from 'react';
-import <Name>Collection from '../../api/collections/<name>.collection';
-import Section from '../section/Section';
-import <Name>Form from './<Name>Form';
+const defaultPermissions: SectionPermissions = { canCreate: true, canUpdate: true, canDelete: true };
 
-function filterFactory(searchString) {
-  return { name: { $regex: searchString, $options: 'i' } };
-}
+const get<Name>Columns: ColumnsFactory<<Type>> = (
+  handleEdit: (e: RowClickEvent, record: <Type>) => void,
+  handleDelete: (e: RowClickEvent, record: <Type>) => void,
+  permissions: SectionPermissions = defaultPermissions,
+  t: TranslateFn
+) => {
+  const { canUpdate = true, canDelete = true } = permissions;
 
-function columnsFactory(handleEdit, handleDelete, permissions) {
-  return [
+  const columns: ColumnsType<<Type>> = [
     {
-      title: 'Name',
+      title: t('common.name'),
       dataIndex: 'name',
       key: 'name',
-    },
-    // Add more columns as needed
-    {
-      title: 'Actions',
-      dataIndex: 'actions',
-      key: 'actions',
-      render: (_, record) => (
-        <Space>
-          {permissions.canUpdate && (
-            <Button type="link" onClick={e => handleEdit(e, record)}>
-              Edit
-            </Button>
-          )}
-          {permissions.canDelete && (
-            <Popconfirm
-              title="Delete this entry?"
-              onConfirm={e => handleDelete(e, record)}
-            >
-              <Button type="link" danger>Delete</Button>
-            </Popconfirm>
-          )}
-        </Space>
-      ),
+      sorter: (a: <Type>, b: <Type>) => String(a.name).localeCompare(String(b.name)),
+      render: (name: string | undefined) => name || '-',
     },
   ];
-}
 
-export default function <Name>Page() {
+  if (canUpdate || canDelete) {
+    columns.push({
+      title: t('common.actions'),
+      dataIndex: 'actions',
+      key: 'actions',
+      render: (_id: unknown, record: <Type>) => (
+        <TableActions record={record} handleEdit={handleEdit} handleDelete={handleDelete} canUpdate={canUpdate} canDelete={canDelete} />
+      ),
+    });
+  }
+
+  return columns;
+};
+
+export default get<Name>Columns;
+```
+
+### 4. Page — `imports/ui/<name>/<Name>.tsx`
+
+```tsx
+import React from 'react';
+import type { <Type> } from '../../api/types';
+import <Name>Collection from '../../api/collections/<name>.collection';
+import { useTranslation } from '../../i18n/LanguageContext';
+import Section from '../section/Section';
+import <Name>Form from './<Name>Form';
+import get<Name>Columns from './<name>.columns';
+
+export default function <Name>() {
+  const { t } = useTranslation();
   return (
-    <Section
-      title="<Display Name>"
+    <Section<<Type>>
+      title={t('<name>.title')}
       collectionName="<name>"
       Collection={<Name>Collection}
       FormComponent={<Name>Form}
-      filterFactory={filterFactory}
-      columnsFactory={columnsFactory}
-      permissionModule="<name>"
+      columnsFactory={get<Name>Columns}
     />
   );
 }
 ```
 
-### 3. Create Form Component
+If the permission module differs from the collection name, pass `permissionModule="<module>"`.
 
-Use `/form <name>` to generate the form.
+### 5. Form — `/form <name>`
 
-### 4. Register Collection
+### 6. Navigation
+Register the page in `imports/ui/navigation/` so it's reachable, and add its i18n keys to `imports/i18n/translations.ts`.
 
-Use `/collection <name>` if collection doesn't exist.
+## Column examples
 
-### 5. Add Navigation
-
-Add to navigation in `imports/ui/navigation/` to make the page accessible.
-
-## Column Examples
-
-### Text Column
-```javascript
-{ title: 'Name', dataIndex: 'name', key: 'name' }
+### Date
+```tsx
+{ title: t('columns.date'), dataIndex: 'date', key: 'date',
+  render: (date: Date | undefined) => (date ? new Date(date).toLocaleDateString() : '-') }
 ```
 
-### Date Column
-```javascript
-{
-  title: 'Date',
-  dataIndex: 'date',
-  key: 'date',
-  render: date => date ? new Date(date).toLocaleDateString() : '-',
-}
-```
-
-### Boolean Column
-```javascript
-{
-  title: 'Active',
-  dataIndex: 'active',
-  key: 'active',
-  render: active => active ? 'Yes' : 'No',
-}
-```
-
-### Reference Column
-```javascript
-{
-  title: 'Member',
-  dataIndex: 'memberId',
-  key: 'memberId',
-  render: memberId => {
-    const member = useTracker(() => MembersCollection.findOne(memberId), [memberId]);
-    return member?.profile?.name || '-';
-  },
-}
+### Color tag — preserve the color render (`color || 'transparent'`, never `?? undefined`)
+```tsx
+{ title: t('common.color'), dataIndex: 'color', key: 'color',
+  render: (color: string | undefined) => <Tag color={color || 'transparent'}>{color || '-'}</Tag> }
 ```
 
 ## Guidelines
 
-- Use Section component for standard CRUD pages
-- Define filterFactory for search functionality
-- Define columnsFactory with permission-aware actions
-- Set permissionModule to control access
+- Use the `Section<T>` generic for standard CRUD pages.
+- Columns live in a `ColumnsFactory<T>` whose signature is `(handleEdit, handleDelete, permissions, t)`.
+- Use `TableActions` for the permission-aware edit/delete buttons.
+- Plain function components — **no `React.FC`, no PropTypes** (lint-enforced).

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -34,6 +34,7 @@ import './server/questionnaireInterval.test';
 import './server/readSecurityHardening.test';
 import './server/registrationsMethods.test';
 import './server/runMethodCall.test';
+import './server/scaffolderSkills.test';
 import './server/settingsMethods.test';
 import './server/shouldConfirmTemplateOverwrite.test';
 import './server/specializationsMethods.test';

--- a/tests/server/scaffolderSkills.test.ts
+++ b/tests/server/scaffolderSkills.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Scaffolder skills (.claude/skills/*.md) generate new code, so when they drift
+// from current conventions every generated file inherits the staleness. A markdown
+// skill can't be executed deterministically without an agent, but its CONTENT can
+// be pinned: this guard fails the build if a scaffolder reintroduces a retired
+// pattern or drops a current one. It is the regression test behind issue #277,
+// where all four scaffolders had gone stale (.js + PropTypes + obsolete
+// COLLECTION_TO_MODULE / DrawerContext APIs).
+//
+// Meteor virtualises __dirname inside the test bundle, so resolve from the
+// project root (mirrors tests/server/integrityCoverage.test.ts).
+const SKILLS_DIR = join(process.env.PWD || process.cwd(), '.claude', 'skills');
+
+function readSkill(name: string): string {
+  return readFileSync(join(SKILLS_DIR, `${name}.md`), 'utf8');
+}
+
+const SCAFFOLDERS = ['collection', 'component', 'form', 'section'] as const;
+
+// Stale file paths / architecture names that should appear NOWHERE — there is no
+// legitimate reason to mention them even in guidance.
+const FORBIDDEN_ANYWHERE: ReadonlyArray<{ pattern: RegExp; why: string }> = [
+  { pattern: /\.collection\.js\b/, why: 'collections are .collection.ts, not .js' },
+  { pattern: /crud\.lib\.js\b/, why: 'server/crud.lib.ts, not .js' },
+  { pattern: /server\/main\.js\b/, why: 'server/main.ts, not .js' },
+  { pattern: /\.jsx\b/, why: 'components are .tsx, not .jsx' },
+  { pattern: /COLLECTION_TO_MODULE/, why: 'replaced by COLLECTION_REGISTRY' },
+];
+
+// Retired APIs that must not appear in GENERATED CODE (fenced blocks). They may
+// still be named in prose where a skill warns against them, so these are checked
+// only inside code blocks — that is what the scaffolder actually emits.
+const FORBIDDEN_IN_CODE: ReadonlyArray<{ pattern: RegExp; why: string }> = [
+  { pattern: /PropTypes|prop-types/, why: 'props are typed with TypeScript interfaces' },
+  { pattern: /React\.FC|\.propTypes\b/, why: 'no React.FC / PropTypes in this codebase' },
+  { pattern: /\bDrawerContext\b|\bSubdrawerContext\b|\buseSubdrawer\b|\bsetOpen\b/, why: 'replaced by the DrawerStack (useDrawerFrame / useEntityForm)' },
+];
+
+// Concatenate the contents of every fenced code block (the generated output).
+function codeBlocks(markdown: string): string {
+  const matches = markdown.match(/```[\s\S]*?```/g) || [];
+  return matches.join('\n');
+}
+
+// Current patterns each scaffolder must mention, so a rewrite can't quietly drop
+// the load-bearing architecture.
+const REQUIRED: Record<(typeof SCAFFOLDERS)[number], readonly string[]> = {
+  collection: ['CrudCollectionMap', 'COLLECTION_REGISTRY', '.collection.ts'],
+  component: ['interface', '.tsx', 'useMethod'],
+  form: ['useEntityForm', 'FormFooter'],
+  section: ['ColumnsFactory', 'Section<'],
+};
+
+describe('scaffolder skills stay current (#277)', () => {
+  for (const name of SCAFFOLDERS) {
+    describe(`/${name}`, () => {
+      const body = readSkill(name);
+      const code = codeBlocks(body);
+
+      for (const { pattern, why } of FORBIDDEN_ANYWHERE) {
+        it(`contains no stale reference ${pattern} (${why})`, () => {
+          assert.ok(!pattern.test(body), `.claude/skills/${name}.md matches stale reference ${pattern} — ${why}`);
+        });
+      }
+
+      for (const { pattern, why } of FORBIDDEN_IN_CODE) {
+        it(`emits no retired API ${pattern} in code blocks (${why})`, () => {
+          assert.ok(!pattern.test(code), `.claude/skills/${name}.md generates code matching retired API ${pattern} — ${why}`);
+        });
+      }
+
+      for (const token of REQUIRED[name]) {
+        it(`mentions current pattern "${token}"`, () => {
+          assert.ok(body.includes(token), `.claude/skills/${name}.md is missing required current pattern "${token}"`);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
All four scaffolder skills (`/collection`, `/component`, `/form`, `/section`) had drifted badly from the codebase — following them produced non-compiling, convention-violating, architecturally-obsolete code:
- emitted `.js` files, `import PropTypes`, `.propTypes`, and `React.FC`
- registered collections in the **removed `COLLECTION_TO_MODULE`** (now `COLLECTION_REGISTRY`)
- wired forms with the **retired `setOpen`/`useSubdrawer`/`DrawerContext`** API (replaced by DrawerStack + `useEntityForm`)

### Rewrites
Each skill now emits current TypeScript-strict code and **references the live shapes by file path** (the `CrudCollectionMap` union, `COLLECTION_REGISTRY`, `useEntityForm`, `Section<T>`, `ColumnsFactory<T>`) instead of a frozen template that re-rots:
- **`/collection`** — typed `Mongo.Collection<T>`, `.collection.ts`, registration via `CrudCollectionMap` + `COLLECTIONS` + `server/main.ts` `collectionNames` + a `COLLECTION_REGISTRY` entry.
- **`/component`** — function component with a props `interface` above it (no `React.FC`, no PropTypes); `useMethod` / `App.useApp` patterns.
- **`/form`** — the `useEntityForm` seam; `FormFooter`; `valuePropName="checked"` for Switch/Checkbox.
- **`/section`** — generic `Section<T>` + a typed `ColumnsFactory<T>` columns file.

### Drift guard — `tests/server/scaffolderSkills.test.ts`
A markdown skill can't be executed deterministically without an agent, so the eval pins the skills' **content** (the actual failure mode that bit here):
- stale file-paths/architecture names (`.collection.js`, `COLLECTION_TO_MODULE`, `.jsx`, …) are banned **anywhere**;
- retired APIs (`PropTypes`, `React.FC`, `setOpen`, `DrawerContext`, …) are banned **inside generated code blocks** but still allowed in "don't use X" prose;
- each skill must mention its load-bearing current patterns.

Wired into the existing mocha CI job (no `ci.yml` change → no conflict with #295).

## Test Plan
1. `npm run typecheck` → 0 errors.
2. `npm test` → **523 passing** (was 481; +42 guard assertions).

## Note
A deeper eval that actually *runs* a scaffolder and typechecks its output requires an agent in the loop; this PR delivers the deterministic content-drift guard. Agent-driven generation eval can be a follow-up.

## Related Issue
Closes #277