### PR TITLE
Add git-worktree isolation + branch-context guard for parallel work

### DIFF
--- a/.claude/skills/branch.md
+++ b/.claude/skills/branch.md
@@ -36,3 +36,22 @@ git checkout -b <branch-name>
 ```
 
 After creating the branch, suggest running `/plan` if no implementation plan exists.
+
+## Isolation for parallel / autonomous work
+
+Concurrent or AFK sessions share one working directory and can land commits on the
+wrong branch (see `docs/agents/worktrees.md`). When a task may run alongside another,
+create an **isolated git worktree** instead of switching the primary checkout:
+
+```bash
+scripts/new-worktree.sh <branch-name>   # off main; cd into the printed path
+```
+
+This shares `node_modules` with the primary checkout (no reinstall) and gives the
+worktree its own `.meteor/local` so concurrent Meteor processes don't collide.
+
+- **Default autonomous runs to serial feature execution** — run one feature task at a
+  time. Reserve parallel worktree sessions for read-only work (review, research) or
+  genuinely independent features.
+- Before committing, `/commit` and `/pr` run `scripts/check-branch.sh <issue#>` to refuse
+  acting on the wrong branch.

--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -8,10 +8,13 @@ Create a commit with a clean, descriptive message.
 
 ## Instructions
 
-1. **Review changes** using `git status` and `git diff`
-2. **Stage relevant files** - Be selective, don't use `git add -A`
-3. **Write commit message** following conventions
-4. **Create commit**
+1. **Verify branch context** — run `scripts/check-branch.sh <issue-number>` first. In a
+   shared checkout used by parallel/autonomous sessions a task can drift onto the wrong
+   branch; this refuses to proceed on a mismatch (or on `main`). See `docs/agents/worktrees.md`.
+2. **Review changes** using `git status` and `git diff`
+3. **Stage relevant files** - Be selective, don't use `git add -A`
+4. **Write commit message** following conventions
+5. **Create commit**
 
 ## Commit Message Format
 

--- a/.claude/skills/pr.md
+++ b/.claude/skills/pr.md
@@ -8,6 +8,7 @@ Create a pull request with summary and testing steps.
 ## Instructions
 
 1. **Check branch status**
+   - Verify branch context: `scripts/check-branch.sh <issue-number>` (refuses the wrong branch or `main` — see `docs/agents/worktrees.md`)
    - Ensure all changes are committed
    - Verify branch is pushed to remote
    - Check tests pass (`npm test`)

--- a/docs/agents/worktrees.md
+++ b/docs/agents/worktrees.md
@@ -1,0 +1,69 @@
+# Worktree isolation for parallel / autonomous work
+
+Claude Code sessions share one git working directory. When two run concurrently —
+or an AFK/autonomous run is interrupted and resumed — they can collide: commits
+land on the wrong branch, or one session's checkout switch strands another's work
+(`feedback_shared_workdir_branch_collision`). This guide is the project's defence.
+
+## TL;DR
+
+- One feature task at a time. **Autonomous runs default to serial feature execution.**
+- For anything that may run alongside another session, work in an **isolated worktree**:
+  ```bash
+  scripts/new-worktree.sh feature/issue-123-thing   # then cd into the printed path
+  ```
+- `/commit` and `/pr` run `scripts/check-branch.sh <issue#>` first and refuse to act on
+  the wrong branch (or on `main`).
+
+## Why worktrees, not branch switching
+
+`git checkout` mutates the single shared working tree, so a second session sees the
+first's files and branch. A `git worktree` is a separate directory bound to the same
+repository with its **own** checked-out branch — two sessions never tread on each other.
+
+Worktrees live under `.claude/worktrees/<branch-leaf>/`.
+
+## What is shared, and what is not
+
+`scripts/new-worktree.sh`:
+
+- **Shares `node_modules`** with the primary checkout via a symlink. Dependencies are
+  large and effectively read-only, so this skips a multi-minute reinstall per worktree.
+- **Does NOT share `.meteor/local`.** That is a *stateful* build cache, and a shared one
+  desyncs concurrent Meteor processes — the same failure documented in
+  `reference_meteor_test_collides_with_dev_server` (a `meteor test` colliding with a
+  running dev server through one `.meteor/local`). Each worktree gets its own, rebuilt on
+  first boot. Correctness (Security > Performance) wins over saving the first-boot time.
+
+## Lifecycle
+
+```bash
+# create (off main by default; pass a base ref as the 2nd arg)
+scripts/new-worktree.sh feature/issue-123-thing
+cd .claude/worktrees/issue-123-thing
+
+# ...implement, commit (check-branch.sh runs via /commit), push, open PR...
+
+# after the PR is merged, remove the worktree
+git worktree remove .claude/worktrees/issue-123-thing
+```
+
+Do not delete the branch with `gh pr merge --delete-branch` while a stacked child PR is
+open (`feedback_stacked_pr_merge`); merge first, delete later.
+
+## The branch guard
+
+`scripts/check-branch.sh <expected>` exits non-zero unless the current branch matches:
+
+- an exact branch name, or
+- a bare issue number that the current branch references (`feature/issue-<N>-…`).
+
+It also hard-fails on `main`/`master`, so a task can never commit to the default branch.
+This is the "commits land on the intended branch" check called for by issue #279.
+
+## When parallel is and isn't appropriate
+
+- **Good for parallel:** read-only work (code review, research, audits) and genuinely
+  independent features that touch disjoint files.
+- **Keep serial:** the normal autonomous feature loop. Interleaving feature edits across
+  sessions is where the wrong-branch-commit and merge-conflict pain comes from.

--- a/scripts/check-branch.sh
+++ b/scripts/check-branch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Guard run before commit / push / PR: confirm the working tree is on the branch
+# the current task expects. In a shared checkout used by parallel/autonomous
+# sessions, a task can drift onto the wrong branch and land commits there
+# (feedback_shared_workdir_branch_collision). This makes that a hard stop.
+#
+# Usage: scripts/check-branch.sh <expected-branch | issue-number>
+#   scripts/check-branch.sh feature/issue-123-foo
+#   scripts/check-branch.sh 123        # current branch must reference issue 123
+
+set -euo pipefail
+
+EXPECTED="${1:?usage: scripts/check-branch.sh <expected-branch | issue-number>}"
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+
+# Exact branch match.
+if [ "$CURRENT" = "$EXPECTED" ]; then
+  exit 0
+fi
+
+# Bare issue number: the current branch must reference issue-<N> (feature/issue-N-...).
+if printf '%s' "$EXPECTED" | grep -qE '^[0-9]+$' && printf '%s' "$CURRENT" | grep -qE "issue-${EXPECTED}(-|$)"; then
+  exit 0
+fi
+
+# Never let an accidental commit land on the default branch either.
+if [ "$CURRENT" = "main" ] || [ "$CURRENT" = "master" ]; then
+  echo "BRANCH MISMATCH: on the default branch '$CURRENT' — never commit a task here." >&2
+else
+  echo "BRANCH MISMATCH: on '$CURRENT' but this task expects '$EXPECTED'." >&2
+fi
+echo "Switch to the right branch (or its worktree) before committing — see docs/agents/worktrees.md." >&2
+exit 1

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Create an isolated git worktree for a task, so parallel/autonomous agent
+# sessions don't collide on the shared primary checkout (commits landing on the
+# wrong branch — see feedback_shared_workdir_branch_collision / docs/agents/worktrees.md).
+#
+# node_modules (large, effectively read-only) is shared from the primary checkout
+# via a symlink so we don't pay a fresh install per worktree. .meteor/local is
+# DELIBERATELY NOT shared: it is a stateful build cache, and a shared one desyncs
+# concurrent Meteor processes (reference_meteor_test_collides_with_dev_server).
+# Each worktree therefore gets its own .meteor/local, rebuilt on first boot.
+#
+# Usage: scripts/new-worktree.sh <branch-name> [base-ref]
+#   scripts/new-worktree.sh feature/issue-123-foo        # off main
+#   scripts/new-worktree.sh fix/issue-9-bar origin/main
+
+set -euo pipefail
+
+BRANCH="${1:?usage: scripts/new-worktree.sh <branch-name> [base-ref]}"
+BASE="${2:-main}"
+
+ROOT=$(git rev-parse --show-toplevel)
+LEAF=$(basename "$BRANCH")
+WT="$ROOT/.claude/worktrees/$LEAF"
+
+if [ -e "$WT" ]; then
+  echo "Worktree already exists: $WT" >&2
+  exit 1
+fi
+
+git -C "$ROOT" worktree add -b "$BRANCH" "$WT" "$BASE"
+
+# Share node_modules (read-only deps) to skip a multi-minute reinstall.
+if [ -d "$ROOT/node_modules" ] && [ ! -e "$WT/node_modules" ]; then
+  ln -s "$ROOT/node_modules" "$WT/node_modules"
+  echo "Linked node_modules -> primary checkout (shared)."
+fi
+
+echo
+echo "Worktree ready: $WT"
+echo "  branch '$BRANCH' off '$BASE', isolated from the primary checkout."
+echo "  node_modules: shared    .meteor/local: own (built on first boot)"
+echo
+echo "Work in it with:"
+echo "  cd \"$WT\""
+echo
+echo "When done, after the branch is merged, remove it with:"
+echo "  git worktree remove \"$WT\""


### PR DESCRIPTION
## Summary
Concurrent and autonomous sessions share one git working directory, so a task can land commits on the wrong branch (`feedback_shared_workdir_branch_collision`). This adds the isolation + guard that `/branch`, `/commit`, and `/pr` now use.

- **`scripts/new-worktree.sh`** — create an isolated worktree under `.claude/worktrees/`. Shares `node_modules` from the primary checkout via symlink (no reinstall), but gives each worktree its **own `.meteor/local`**.
- **`scripts/check-branch.sh`** — refuse commit/push/PR unless on the expected branch (exact name or `issue-<N>` reference); hard-fails on `main`/`master` so a task can never commit to the default branch. This is the "commits land on the intended branch" check from #279.
- **`/branch`** — documents worktree isolation + **serial-by-default** autonomous execution (parallel reserved for read-only work).
- **`/commit`, `/pr`** — run `check-branch.sh` as their first step.
- **`docs/agents/worktrees.md`** — the full workflow.

## Key design call
The issue suggested sharing **both** `node_modules` and `.meteor/local`. But a shared `.meteor/local` is precisely what desyncs concurrent Meteor processes (`reference_meteor_test_collides_with_dev_server`), so sharing it would reintroduce the collision the isolation prevents. Each worktree therefore gets its **own** `.meteor/local` (rebuilt on first boot) — correctness over first-boot speed. `node_modules` (large, read-only) is still shared.

## Test Plan
1. `check-branch.sh`: 4/4 cases — exact match ✓, issue-number match ✓, wrong number rejected ✓, wrong branch rejected ✓; mismatch message verified.
2. `new-worktree.sh`: end-to-end smoke test — worktree created, `node_modules` symlinked to primary, `.meteor/local` absent (own cache), branch correct, `git worktree remove` clean.
3. `bash -n` clean. No app/test/TypeScript code changed.

## Notes
- Independent of #294/#295/#296 — branches off `main`, touches only `scripts/`, skill markdown, and `docs/` (no `settings.json`/`package.json`/`ci.yml`), so no stacking or merge-order constraints.
- There are several **stale worktrees** under `.claude/worktrees/` from prior sessions (`agent-*`, etc.) — worth a manual `git worktree prune`/`remove` sweep, left out of this PR.

## Related Issue
Closes #279