### PR TITLE
Deliver scheduled-routine digests to GitHub issues

### DIFF
--- a/docs/agents/routines.md
+++ b/docs/agents/routines.md
@@ -23,7 +23,7 @@ dedicated GitHub issue per routine** (`[routine] <name>`, label
 <command that prints the digest> | scripts/post-digest.sh <routine-name>
 ```
 
-- **Idempotent** — re-runs append a timestamped comment to the same issue
+- **Idempotent** — re-runs append a comment to the same issue (GitHub timestamps it)
   instead of opening a new one, so the tracker doesn't fill with duplicates.
 - **Actionable-only** — an empty / whitespace digest produces nothing, so the
   maintainer is pinged (via GitHub's own issue notifications — the "push" with

--- a/docs/agents/routines.md
+++ b/docs/agents/routines.md
@@ -12,6 +12,30 @@ Recurring agent work that doesn't need a human in the loop. Two shapes:
 Both invoke regular slash commands and skills — they're just delivery
 mechanisms. Recipes for this repo live below.
 
+## Delivery
+
+A routine's digest is no longer trapped in the session transcript. Pipe it
+through `scripts/post-digest.sh <routine-name>`, which **upserts a single
+dedicated GitHub issue per routine** (`[routine] <name>`, label
+`routine-digest`):
+
+```
+<command that prints the digest> | scripts/post-digest.sh <routine-name>
+```
+
+- **Idempotent** — re-runs append a timestamped comment to the same issue
+  instead of opening a new one, so the tracker doesn't fill with duplicates.
+- **Actionable-only** — an empty / whitespace digest produces nothing, so the
+  maintainer is pinged (via GitHub's own issue notifications — the "push" with
+  no extra connector) only when there is something to act on.
+- **Read-only elsewhere** — the script touches *only* its own digest issue. It
+  never labels, closes, comments on, or merges any other issue or PR. Routines
+  ingest untrusted issue/PR text (lethal trifecta), so they must not act on
+  arbitrary objects; surfacing stays the whole job.
+
+Dry-run a routine's delivery with `… | scripts/post-digest.sh <name> --dry-run`
+before scheduling.
+
 ## Daily triage routine
 
 Keeps the GitHub Issues inbox at `sentinel-web/community-manager` visible
@@ -45,9 +69,13 @@ activity). Counts + one-line per issue, oldest first. Do not edit labels,
 close issues, or post comments — surface only.
 ```
 
-**Output** — read the routine's session transcript from the Claude Code
-desktop / web app when you sit down. No notifications wired up yet (see
-*Open questions* below).
+**Output** — pipe the digest to `scripts/post-digest.sh daily-triage` so it
+lands on the `[routine] daily-triage` issue (only when non-empty). See
+**Delivery** above. Append to the scheduled prompt:
+
+```
+Then pipe the digest to: scripts/post-digest.sh daily-triage
+```
 
 ### Try it locally first
 
@@ -95,8 +123,9 @@ while you're heads-down on something else.
 
 **What it does not do** — no auto-rebase, no auto-merge, no review
 dismissals, no comments on the PRs themselves. Surface only, same
-principle as the triage routine. The digest goes to the routine's session
-transcript; the human still drives the next action.
+principle as the triage routine. Pipe the digest to
+`scripts/post-digest.sh pr-babysitter` (see **Delivery**); the human still
+drives the next action.
 
 **Cadence** — 3× per workday. Suggested: 09:30, 13:30, 17:30 Mon–Fri in
 the scheduler's timezone — adjust the cron for your local TZ at
@@ -290,10 +319,10 @@ Suggested values:
 
 ## Open questions
 
-- **Where does the digest land?** Today the routine's transcript lives in
-  the Claude Code session list. Options for active delivery (email, Slack,
-  GitHub issue comment) need a connector that isn't wired up yet — pick
-  one before the routine becomes load-bearing.
+- **Where does the digest land?** *Resolved (#280)* — digests are delivered to
+  a per-routine GitHub issue via `scripts/post-digest.sh` (see **Delivery**
+  above), with no external connector. If email/Slack is wanted later, add it as
+  a second hop after the issue upsert rather than replacing it.
 - **Quota / cost** — remote routines burn tokens on a schedule. Re-evaluate
   the cadence once we see real usage. Daily is a sane starting point;
   hourly is almost certainly too much for this repo's traffic.

--- a/scripts/post-digest.sh
+++ b/scripts/post-digest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Deliver a scheduled routine's digest to GitHub instead of leaving it to die in
+# the session transcript (docs/agents/routines.md "Open questions"). It upserts a
+# single dedicated digest issue per routine — idempotent, so re-runs append to the
+# same issue rather than spamming new ones — and ONLY when the digest is non-empty.
+# An empty digest stays silent, so the maintainer is notified (via GitHub's own
+# issue notifications) only on an actionable transition.
+#
+# Safety: this is READ-ONLY with respect to every OTHER issue and PR. It never
+# labels, closes, comments on, or merges anything except its own `[routine] <name>`
+# digest issue. Routines ingest untrusted issue/PR text (lethal trifecta), so they
+# must never act on arbitrary objects — surfacing is the whole job.
+#
+# Usage: <command that prints the digest> | scripts/post-digest.sh <routine-name> [--dry-run]
+#   gh pr list ... | format ... | scripts/post-digest.sh pr-babysitter
+
+set -euo pipefail
+
+REPO="sentinel-web/community-manager"
+LABEL="routine-digest"
+
+NAME="${1:?usage: post-digest.sh <routine-name> [--dry-run]}"
+MODE="${2:-}"
+BODY=$(cat)
+
+# Empty / whitespace-only digest => nothing actionable => stay silent.
+if ! printf '%s' "$BODY" | grep -q '[^[:space:]]'; then
+  echo "post-digest: digest for '$NAME' is empty — nothing to deliver." >&2
+  exit 0
+fi
+
+TITLE="[routine] ${NAME}"
+FOOTER="— delivered by scripts/post-digest.sh ($NAME)"
+
+if [ "$MODE" = "--dry-run" ]; then
+  echo "[dry-run] would upsert issue titled '$TITLE' (label '$LABEL') with body:"
+  printf '%s\n%s\n' "$BODY" "$FOOTER"
+  exit 0
+fi
+
+# Ensure the digest label exists (idempotent).
+gh label create "$LABEL" --repo "$REPO" --color BFD4F2 --description "Automated routine digest (post-digest.sh)" >/dev/null 2>&1 || true
+
+# Find an existing open digest issue for this routine (exact title match).
+NUM=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --json number,title \
+        -q "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+
+if [ -n "$NUM" ]; then
+  gh issue comment "$NUM" --repo "$REPO" --body "$(printf '%s\n\n%s' "$BODY" "$FOOTER")"
+  echo "post-digest: appended digest to issue #$NUM"
+else
+  gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
+    --body "$(printf '%s\n\n%s' "$BODY" "$FOOTER")"
+fi

--- a/scripts/post-digest.sh
+++ b/scripts/post-digest.sh
@@ -24,6 +24,13 @@ NAME="${1:?usage: post-digest.sh <routine-name> [--dry-run]}"
 MODE="${2:-}"
 BODY=$(cat)
 
+# Routine name is interpolated into a jq title filter and an issue title; keep it
+# to a safe slug so it can't break the filter or produce a surprise title.
+if ! printf '%s' "$NAME" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+  echo "post-digest: invalid routine name '$NAME' (expected a lowercase slug, e.g. pr-babysitter)." >&2
+  exit 1
+fi
+
 # Empty / whitespace-only digest => nothing actionable => stay silent.
 if ! printf '%s' "$BODY" | grep -q '[^[:space:]]'; then
   echo "post-digest: digest for '$NAME' is empty — nothing to deliver." >&2


### PR DESCRIPTION
## Summary
Resolves the "where does the digest land?" open question in `docs/agents/routines.md` — routine output no longer dies in the session transcript.

- **`scripts/post-digest.sh`** upserts **one dedicated GitHub issue per routine** (`[routine] <name>`, label `routine-digest`):
  - **idempotent** — re-runs append a comment to the same issue (no duplicates);
  - **actionable-only** — an empty/whitespace digest produces nothing, so GitHub's own issue notifications ping the maintainer only when there's something to act on (the "push", no external connector);
  - **read-only toward every other issue/PR** — touches only its own digest issue (lethal-trifecta safe, since routines ingest untrusted text).
- **`routines.md`** — new **Delivery** section; triage + pr-babysitter `Output` lines pipe through the script; the Open Question is marked *resolved (#280)* with a note that email/Slack can be a later second hop.

Default per the decision: **GitHub-only, no external connector.**

## Test Plan
1. `bash -n scripts/post-digest.sh` clean.
2. `--dry-run` with a non-empty digest → would upsert `[routine] pr-babysitter`.
3. `--dry-run` with an empty digest → stays silent (exit 0).
4. No app/test/TS code changed (shell + docs).

## Unblocks
#282 and #283 (both depend on this delivery mechanism).

## Related Issue
Closes #280