### PR TITLE
Make /verify an adversarial evaluator scored against a planning contract

### DIFF
--- a/.claude/skills/plan.md
+++ b/.claude/skills/plan.md
@@ -13,6 +13,10 @@ Create or refine an implementation plan for the current issue.
 3. **Design approach** - Follow existing patterns from CLAUDE.md
 4. **Break down tasks** - Create specific, actionable steps
 5. **Identify risks** - Note potential issues or edge cases
+6. **Write the acceptance contract** - Before any code, write
+   `.claude/verify-contract.md`: implementation-*independent* "given/when/then"
+   criteria describing observable behavior (no file/function references). This is
+   what `/verify` grades against in a fresh context — see `.claude/skills/verify.md`.
 
 ## Plan Structure
 

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -19,10 +19,14 @@ against a pre-agreed contract**, not a self-review:
    `.claude/verify-contract.md` — plain-language "given/when/then" criteria
    describing observable behavior, with no reference to functions, files, or
    how it's built. `/verify` is scored **only** against those criteria.
-2. **Evaluate in a fresh context.** Run the browser drive as a sub-agent (the
-   `Agent`/Task tool) given **only** the contract and app access — *not* the
-   implementation transcript. It cannot "know what was meant"; it can only
-   observe what the app does. Emit an explicit **PASS / FAIL per criterion**.
+2. **Evaluate with fresh eyes.** Grade against the contract **only** — read it,
+   not the implementation transcript, so you judge what the app *does*, not what
+   you *meant*. Best: hand the evaluation to a fresh sub-agent (the Task tool)
+   whose prompt is the contract plus how to reach the app, so it literally has no
+   memory of the implementation. (The browser access here is Chrome MCP, driven
+   from the session — see *Prerequisites*; a sub-agent that lacks it should report
+   what it cannot reach rather than guess.) Emit an explicit **PASS / FAIL per
+   criterion**.
 3. **Keep the code-correctness gates in the main thread.** Run
    `npm run typecheck`, `npm test`, and `npm run e2e` in the main session — do
    **not** delegate them to the evaluator sub-agent, or a failure's output gets
@@ -37,8 +41,9 @@ unwritten standard is how confirmation bias creeps back in.
 
 Assert against `data-verify-*` attributes, not localized DOM text or Ant Design
 class names — text changes with i18n and markup changes with antd upgrades, both
-of which would make a passing check silently rot. Add a stable attribute to each
-load-bearing widget the first time you instrument its path, e.g.:
+of which would make a passing check silently rot. **None exist yet** — this is the
+convention to introduce, adding a stable attribute to each load-bearing widget the
+first time you instrument its path, e.g.:
 
 - attendance tally → `data-verify="attendance-tally" data-verify-count={n}`
 - ORBAT node count → `data-verify="orbat-count" data-verify-count={n}`

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -8,6 +8,45 @@ CLAUDE.md is explicit: **type checking and test suites verify code correctness,
 not feature correctness**. This skill is how Claude closes that gap without
 asking the user to click around.
 
+## Evaluate against a contract, with fresh eyes
+
+The agent that wrote the code is the worst judge of whether it works — it grades
+toward the behavior it intended. So `/verify` is an **adversarial evaluation
+against a pre-agreed contract**, not a self-review:
+
+1. **The contract comes from `/plan`.** Before any code is written, `/plan`
+   writes an implementation-*independent* acceptance contract to
+   `.claude/verify-contract.md` — plain-language "given/when/then" criteria
+   describing observable behavior, with no reference to functions, files, or
+   how it's built. `/verify` is scored **only** against those criteria.
+2. **Evaluate in a fresh context.** Run the browser drive as a sub-agent (the
+   `Agent`/Task tool) given **only** the contract and app access — *not* the
+   implementation transcript. It cannot "know what was meant"; it can only
+   observe what the app does. Emit an explicit **PASS / FAIL per criterion**.
+3. **Keep the code-correctness gates in the main thread.** Run
+   `npm run typecheck`, `npm test`, and `npm run e2e` in the main session — do
+   **not** delegate them to the evaluator sub-agent, or a failure's output gets
+   summarized away instead of stopping you. Feature evaluation and code gates
+   are separate passes.
+
+If there is no `.claude/verify-contract.md` (older flow), derive the criteria
+from the issue first and write them down before driving — grading against an
+unwritten standard is how confirmation bias creeps back in.
+
+## Stable selectors: `data-verify-*`
+
+Assert against `data-verify-*` attributes, not localized DOM text or Ant Design
+class names — text changes with i18n and markup changes with antd upgrades, both
+of which would make a passing check silently rot. Add a stable attribute to each
+load-bearing widget the first time you instrument its path, e.g.:
+
+- attendance tally → `data-verify="attendance-tally" data-verify-count={n}`
+- ORBAT node count → `data-verify="orbat-count" data-verify-count={n}`
+- kanban column total → `data-verify="kanban-column-total" data-verify-count={n}`
+
+Instrument incrementally — add the attribute when a criterion needs it, so the
+attribute set grows with the contracts that depend on it rather than all at once.
+
 ## Usage
 
 `/verify` — verify recent uncommitted changes against the relevant golden path(s)

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ _build
 
 # Claude Code verification-gate marker (local state)
 .claude/.verify-state
+
+# Per-task acceptance contract written by /plan, read by /verify (transient)
+.claude/verify-contract.md


### PR DESCRIPTION
## Summary
`/verify` previously let the same agent that wrote the code grade its own work — the confirmation bias behind a UX regression that once shipped. This restructures it into a contract-graded, fresh-context evaluation:

- **`/plan` writes `.claude/verify-contract.md`** before any code: implementation-*independent* given/when/then criteria (no file/function references).
- **`/verify` is scored only against that contract**, run as a **fresh-context sub-agent** given the criteria + app access but **not** the implementation transcript, emitting **PASS/FAIL per criterion**.
- **typecheck / mocha / e2e stay in the main thread** — delegating them to the evaluator sub-agent would summarize failures away.
- **Assert against stable `data-verify-*` attributes**, not localized DOM text / antd classes (both rot silently). The convention + the three named target widgets (attendance tally, ORBAT count, kanban total) are documented, instrumented **incrementally** as paths need them.

## Scope note
This PR delivers the **process + convention** (skill rewrites). The three widgets render their counts inline within complex JSX; rather than bloat this PR with risky deep edits to `EventAttendance`/`Orbat`/`KanbanBoard` (and a full-suite run for a process change), the `data-verify-*` attributes are added per the documented convention as each path is first evaluated. No app/test/TS code changed here → skill/doc only.

## Test Plan
- `.claude/verify-contract.md` is gitignored (transient per-task artifact).
- Markdown-only change; typecheck/lint/tests unaffected.

## Related Issue
Closes #278