### PR TITLE
Add a /wtf friction channel + weekly clustering routine

### DIFF
--- a/.claude/skills/wtf.md
+++ b/.claude/skills/wtf.md
@@ -1,0 +1,55 @@
+# /wtf
+
+Record a moment of friction — a place the agent workflow fought you — so it can
+be clustered into a fix later. The name is the feeling; the purpose is signal.
+
+## Usage
+`/wtf <what just bit you>` — append a friction entry
+`/wtf` — prompt for the description, then append
+
+## When to fire it
+
+At the end of `/implement` or `/verify`, or any time you had to **deviate from
+what a skill or doc told you**, or hit a contradiction. Concretely:
+
+- a scaffolder / skill emitted output you had to rewrite (e.g. wrong file type, stale API)
+- `CLAUDE.md` said one thing and the code did another
+- a documented path/file/flag didn't exist or had moved
+- a hook, gate, or check fired as a false positive (or failed to fire when it should have)
+- a step in a skill was impossible as written
+
+Each looks different, so deterministic log-parsing misses them — but clustered
+together they reveal the stale scaffolder, the contradicting rule, the rotted doc.
+
+## What it does
+
+Appends a structured, dated entry to [`docs/agents/friction-log.md`](../../docs/agents/friction-log.md):
+
+```markdown
+### YYYY-MM-DD — <one-line summary>
+- **Where:** <skill / doc / file the friction came from>
+- **Expected:** <what the skill/doc said or implied>
+- **Actual:** <what really happened / what you had to do instead>
+- **Deviation:** <the workaround you applied, if any>
+```
+
+Use today's date. Keep it to the four lines — it's a signal capture, not a
+post-mortem. Do not "fix" anything from `/wtf`; just record.
+
+## Weekly clustering routine
+
+A scheduled sweep turns the raw entries into actionable backlog:
+
+```
+Read docs/agents/friction-log.md entries since the last sweep (and recent
+session transcripts). Cluster them by root cause (stale skill, contradicting
+CLAUDE.md rule, rotted doc, false-positive gate). For each recurring cluster
+(>= 2 entries), open ONE GitHub issue describing the root cause and the fix,
+and cite the entries. Single one-off entries: list, don't file.
+Then pipe the digest to: scripts/post-digest.sh friction-clustering
+```
+
+Feed each cluster into `/validate` (which proposes `CLAUDE.md` updates) or the
+GC cadence (`docs/agents/gc.md`) so the recurring ones get promoted into an
+ESLint rule / hook / guard test rather than just re-noted. Clear or archive
+entries once their cluster has an issue, so the log reflects *open* friction.

--- a/.claude/skills/wtf.md
+++ b/.claude/skills/wtf.md
@@ -9,8 +9,8 @@ be clustered into a fix later. The name is the feeling; the purpose is signal.
 
 ## When to fire it
 
-At the end of `/implement` or `/verify`, or any time you had to **deviate from
-what a skill or doc told you**, or hit a contradiction. Concretely:
+After implementing a change or running `/verify`, or any time you had to
+**deviate from what a skill or doc told you**, or hit a contradiction. Concretely:
 
 - a scaffolder / skill emitted output you had to rewrite (e.g. wrong file type, stale API)
 - `CLAUDE.md` said one thing and the code did another
@@ -46,10 +46,12 @@ session transcripts). Cluster them by root cause (stale skill, contradicting
 CLAUDE.md rule, rotted doc, false-positive gate). For each recurring cluster
 (>= 2 entries), open ONE GitHub issue describing the root cause and the fix,
 and cite the entries. Single one-off entries: list, don't file.
-Then pipe the digest to: scripts/post-digest.sh friction-clustering
+Then deliver the digest (once #280 lands, pipe it to
+`scripts/post-digest.sh friction-clustering`).
 ```
 
 Feed each cluster into `/validate` (which proposes `CLAUDE.md` updates) or the
-GC cadence (`docs/agents/gc.md`) so the recurring ones get promoted into an
-ESLint rule / hook / guard test rather than just re-noted. Clear or archive
-entries once their cluster has an issue, so the log reflects *open* friction.
+GC cadence (`docs/agents/gc.md`, proposed in #283) so the recurring ones get
+promoted into an ESLint rule / hook / guard test rather than just re-noted. Clear
+or archive entries once their cluster has an issue, so the log reflects *open*
+friction.

--- a/docs/agents/friction-log.md
+++ b/docs/agents/friction-log.md
@@ -1,0 +1,24 @@
+# Friction log
+
+Raw, dated entries recording where the agent workflow fought a contributor —
+appended by the [`/wtf`](../../.claude/skills/wtf.md) skill. Each entry is signal,
+not a fix. A weekly clustering routine (see `/wtf`) groups recurring entries into
+GitHub issues and feeds them to `/validate` and the GC cadence
+([`gc.md`](gc.md)) for promotion into an enforced rule.
+
+Entry format:
+
+```markdown
+### YYYY-MM-DD — <one-line summary>
+- **Where:** <skill / doc / file>
+- **Expected:** <what the skill/doc said or implied>
+- **Actual:** <what really happened>
+- **Deviation:** <the workaround applied, if any>
+```
+
+Archive an entry once its cluster has an issue, so this file reflects *open*
+friction. Keep newest at the top.
+
+---
+
+<!-- /wtf appends new entries below this line -->

--- a/docs/agents/friction-log.md
+++ b/docs/agents/friction-log.md
@@ -3,8 +3,8 @@
 Raw, dated entries recording where the agent workflow fought a contributor —
 appended by the [`/wtf`](../../.claude/skills/wtf.md) skill. Each entry is signal,
 not a fix. A weekly clustering routine (see `/wtf`) groups recurring entries into
-GitHub issues and feeds them to `/validate` and the GC cadence
-([`gc.md`](gc.md)) for promotion into an enforced rule.
+GitHub issues and feeds them to `/validate` and the GC cadence (`gc.md`, proposed
+in #283) for promotion into an enforced rule.
 
 Entry format:
 


### PR DESCRIPTION
## Summary
Skill drift and contradicting rules are caught only by chance today. `/wtf` captures the moments the workflow fights a contributor so they can be clustered into fixes:

- **`.claude/skills/wtf.md`** — append a structured, dated entry (where / expected / actual / deviation) whenever an agent deviates from a skill or doc, or hits a contradiction. Signal capture, not a post-mortem — it never fixes anything.
- **`docs/agents/friction-log.md`** — the committed log the entries accumulate in (seeded with format + housekeeping).
- **A weekly clustering routine** groups recurring entries (≥2) into ONE GitHub issue each, delivered via `scripts/post-digest.sh friction-clustering` (#280), and feeds them to `/validate` + the GC cadence (#283) for promotion into an enforced rule.

## Scope note
There's no `/implement` skill to wire into, so `/wtf` is invoked at the end of `/implement`/`/verify` or ad hoc (documented in the skill). Skill + doc only.

## Test Plan
No code/tests affected.

## Depends on
#280 (`scripts/post-digest.sh`) for delivery; complements #283 (GC promotion).

## Related Issue
Closes #282