### PR TITLE
Document sub-agent conventions: read-only reviewers, no skill inheritance

### DIFF
--- a/docs/agents/subagents.md
+++ b/docs/agents/subagents.md
@@ -1,0 +1,43 @@
+# Sub-agent conventions
+
+When a task spawns sub-agents (the `Agent`/Task tool) — for review, research, or
+fan-out — two repo-specific rules keep them safe and effective.
+
+## 1. Reviewers and researchers get read-only tools
+
+A sub-agent whose job is to *judge* or *gather* must not also be able to *change*
+the thing it's judging. Give review and research sub-agents only **Read, Grep,
+Glob** (and read-only `git`) — never **Edit / Write / Bash-that-mutates**:
+
+- A reviewer that can edit will "fix and pass" its own finding, defeating the
+  point of an independent pass (this is why `/review`'s persona passes are
+  read-only — see `.claude/skills/review.md`).
+- A research/scout sub-agent only needs to read and report; write access is
+  attack surface and a footgun, nothing more.
+
+Reserve Edit/Write for sub-agents explicitly tasked with *implementing*, ideally
+in their own worktree (`docs/agents/worktrees.md`).
+
+## 2. Sub-agents don't inherit project skills
+
+A spawned sub-agent starts fresh — it does **not** automatically have this repo's
+`.claude/skills/`. If a sub-agent needs a project skill, **name the file and the
+relevant rules in its prompt**. Common cases:
+
+- A sub-agent validating a change should be pointed at `/validate`
+  (`.claude/skills/validate.md`) and the CLAUDE.md conventions it enforces.
+- A sub-agent reasoning about access control should be given `/permissions`
+  (`.claude/skills/permissions.md`) and the `COLLECTION_REGISTRY` rules.
+- A sub-agent doing feature verification should get the relevant
+  `.claude/skills/verify.md` criteria (or a `verify-contract.md`), not be expected
+  to "know the golden paths."
+
+Don't assume inheritance — quote or reference what the sub-agent must follow,
+and keep that reference near the front of its prompt (see
+`docs/agents/prompt-cache.md`).
+
+## Quick checklist when spawning a sub-agent
+
+- [ ] Is it judging/gathering? → Read/Grep/Glob only, no Edit/Write.
+- [ ] Does it need a project skill or convention? → name the file + rules in the prompt.
+- [ ] Is it implementing in parallel? → give it an isolated worktree.

--- a/docs/agents/subagents.md
+++ b/docs/agents/subagents.md
@@ -10,8 +10,8 @@ the thing it's judging. Give review and research sub-agents only **Read, Grep,
 Glob** (and read-only `git`) — never **Edit / Write / Bash-that-mutates**:
 
 - A reviewer that can edit will "fix and pass" its own finding, defeating the
-  point of an independent pass (this is why `/review`'s persona passes are
-  read-only — see `.claude/skills/review.md`).
+  point of an independent pass (the same reason the `/review` persona passes
+  proposed in #281 never apply fixes — see `.claude/skills/review.md`).
 - A research/scout sub-agent only needs to read and report; write access is
   attack surface and a footgun, nothing more.
 


### PR DESCRIPTION
Two repo-specific rules for spawned (`Agent`/Task) sub-agents:

1. **Review/research sub-agents get Read/Grep/Glob only** (no Edit/Write) — a sub-agent that judges or gathers must not also mutate what it's judging, or it'll "fix and pass" its own finding. Mirrors `/review`'s read-only persona passes (#281).
2. **Sub-agents don't inherit `.claude/skills/`** — name the skill file + rules in their prompt when they need `/validate`, `/permissions`, or verify criteria; keep the reference near the prompt's front (prompt-cache, #291).

Standalone doc `docs/agents/subagents.md` (avoids the in-flight `review.md`). Doc-only.

Closes #293