### PR TITLE
CD pipeline (1/2): image build, publish, scan, release & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+
+updates:
+  # --- Application dependencies (root package.json) ---
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Families that should move together so a single PR keeps them in sync and
+      # cuts review noise. Most-specific patterns first — Dependabot assigns each
+      # dependency to the first matching group.
+      react:
+        patterns: ["react", "react-dom", "@types/react-dom", "react-refresh"]
+      tiptap:
+        patterns: ["@tiptap/*"]
+      rspack:
+        patterns: ["@rspack/*", "@rsdoctor/*", "@meteorjs/rspack"]
+      eslint:
+        patterns: ["eslint", "eslint-*", "@eslint/*", "typescript-eslint", "globals"]
+      types:
+        patterns: ["@types/*"]
+      # Everything else: bundle minor/patch bumps so they don't each open a PR.
+      # Majors still come through individually for deliberate review.
+      misc-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # engines.node is pinned to 22.x to match Meteor 3.4.1's bundled node.
+      - dependency-name: "node"
+      # @types/node is deliberately held at v20 to match Meteor's bundled node
+      # typings, not the v22 runtime — never auto-bump its major.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  # --- GitHub Actions (keeps the SHA/major pins in the workflows current) ---
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # --- Dockerfile base images ---
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Both base images are hand-coupled to METEOR@3.4.1 and must only move as
+      # part of a deliberate Meteor upgrade (see CLAUDE.md node-version pinning).
+      - dependency-name: "node"
+      - dependency-name: "geoffreybooth/meteor-base"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Categorises the notes that `gh release create --generate-notes` produces
+# (release.yml workflow) by each merged PR's labels. First matching category
+# wins, so the "*" catch-all must stay last.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 🔧 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,139 @@
+name: build-publish
+
+# Reusable workflow: build the Meteor app image, publish it to GHCR, scan it
+# with Trivy, and attach an SBOM + provenance attestation. Every workflow that
+# needs an image (deploy, release) calls THIS one, so the privileged surface —
+# the only place that logs into the registry and runs the scanner — lives in a
+# single auditable file.
+#
+# It is deliberately tag-agnostic: the CALLER passes the exact docker/metadata
+# tag directives. metadata-action otherwise derives tags from the trigger
+# context (github.ref / github.sha), which is wrong when we build a branch other
+# than the one that triggered the run (deploy builds a feature branch while the
+# workflow itself is read from the default branch). See deploy.yml / release.yml.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref or SHA to check out and build.
+        required: true
+        type: string
+      tags:
+        description: >-
+          docker/metadata-action `tags:` directives (newline-separated). The
+          caller owns tagging so context-derived tags can never mislabel a
+          cross-branch build.
+        required: true
+        type: string
+      push:
+        description: Push to GHCR (false = build-only validation, no scan/attest).
+        type: boolean
+        default: true
+      trivy-exit-code:
+        description: >-
+          '1' fails the build on CRITICAL/HIGH findings; '0' is report-only
+          (SARIF still uploads). Start at '0', flip to '1' once .trivyignore is
+          curated.
+        type: string
+        default: '0'
+    outputs:
+      image:
+        description: Digest-pinned image reference (name@sha256:...) for downstream deploy.
+        value: ${{ jobs.build.outputs.image }}
+
+# Defence in depth: grant nothing at the top level, scope per job.
+permissions: {}
+
+jobs:
+  build:
+    name: build & publish
+    runs-on: ubuntu-latest
+    # The geoffreybooth/meteor-base builder image is large and `meteor build`
+    # is slow on a cold gha cache; give the first run plenty of headroom.
+    timeout-minutes: 60
+    permissions:
+      contents: read # checkout
+      packages: write # push to GHCR
+      security-events: write # upload Trivy SARIF to the Security tab
+      id-token: write # sign SBOM / provenance attestations
+      attestations: write # attach attestations to the pushed image
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # GHCR rejects uppercase path segments and github.repository casing is not
+      # guaranteed, so lowercase it before anything consumes it.
+      - name: Compute lowercase image name
+        id: name
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.name.outputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Build & push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: production
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Reuse Meteor builder layers across runs; mode=max also caches the
+          # heavy intermediate builder stage, not just the final image.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Attestations need the id-token/attestations permissions above; when
+          # push is false there is no registry to attach them to.
+          provenance: ${{ inputs.push }}
+          sbom: ${{ inputs.push }}
+
+      # Pin downstream deploys to the immutable digest so the artifact that gets
+      # scanned is byte-for-byte the artifact that gets deployed — a moving
+      # branch tag can never cause drift between scan and run.
+      - name: Resolve digest-pinned reference
+        id: image
+        if: ${{ inputs.push }}
+        run: echo "ref=${{ steps.name.outputs.image }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      # Trivy pulls the just-pushed image using the docker login credentials
+      # established above. Findings go to the Security tab regardless of whether
+      # they fail the build (exit-code is caller-controlled).
+      - name: Scan image with Trivy
+        if: ${{ inputs.push }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.ref }}
+          format: sarif
+          output: trivy.sarif
+          severity: CRITICAL,HIGH
+          exit-code: ${{ inputs.trivy-exit-code }}
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF
+        if: ${{ always() && inputs.push }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+
+# Cutting a release is deliberately decoupled from deploying. Pushing a `v*`
+# tag (1) publishes a version-tagged + `latest` image via build-publish, and
+# (2) creates a GitHub Release with auto-generated notes. It does NOT deploy —
+# shipping a release to a host is a separate, explicit action (deploy.yml).
+on:
+  push:
+    tags: ['v*']
+
+permissions: {}
+
+jobs:
+  # The tag IS the trigger here, so github.ref / github.sha already point at the
+  # tagged commit — metadata-action's semver derivation is correct, unlike the
+  # cross-branch deploy case.
+  build:
+    uses: ./.github/workflows/build-publish.yml
+    with:
+      ref: ${{ github.ref }}
+      push: true
+      tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=sha,prefix=sha-,format=short
+        type=raw,value=latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+    secrets: inherit
+
+  release:
+    name: github release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+    steps:
+      # Checkout is needed so `gh release create` can read .github/release.yml
+      # for note categorisation.
+      - uses: actions/checkout@v6
+
+      # --generate-notes buckets merged PRs per .github/release.yml; --verify-tag
+      # confirms the pushed tag exists on the remote before publishing.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --generate-notes --verify-tag

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Trivy CVE allowlist for the build-publish image scan.
+#
+# This file is intentionally empty. Add a CVE ID ONLY with a documented
+# justification and a review-by date, so every suppression stays auditable and
+# nothing lingers silently. Format (one finding per line):
+#
+#   CVE-2024-12345  # transitive via <pkg>; no upstream fix yet, reassess 2026-09-01
+#
+# The scan currently runs report-only (build-publish input trivy-exit-code: '0').
+# Once this list is curated for the base image's known noise, flip callers to
+# '1' so CRITICAL/HIGH findings fail the build.


### PR DESCRIPTION
## What & why

The repo already has solid **CI** (`ci.yml`: typecheck + lint + mocha + e2e). It has **no CD** — nothing builds or publishes the Docker image. This is the first of two PRs that add per-branch preview-environment deployment. **This PR is the "publish" half** and is fully verifiable without any deployment host.

## Changes

- **`.github/workflows/build-publish.yml`** — reusable `workflow_call`. Builds the `production` image with Buildx (GitHub Actions layer cache), publishes to **GHCR** (`ghcr.io/sentinel-web/community-manager`) via the built-in `GITHUB_TOKEN`, **pins the downstream deploy reference to the immutable image digest**, scans with **Trivy** (SARIF → Security tab), and attaches an **SBOM + provenance attestation**. Tagging is *caller-driven* so a cross-branch build can't mislabel another branch's tag (see note below).
- **`.github/workflows/release.yml`** — on a `v*` tag, builds a versioned + `latest` image and creates a GitHub Release with generated notes. **Decoupled from deploy.**
- **`.github/dependabot.yml`** — weekly npm / github-actions / docker updates, grouped to cut PR noise. `node` and `geoffreybooth/meteor-base` base images are pinned to the Meteor release; `@types/node` major is held at v20.
- **`.github/release.yml`** — changelog categories keyed on PR labels.
- **`.trivyignore`** — documented, empty CVE allowlist.

`ci.yml` is **unchanged**.

## Design notes

- **Trivy starts report-only** (`trivy-exit-code: '0'`): SARIF still uploads, but base-image CVEs won't block the very first build. Flip callers to `'1'` once `.trivyignore` is curated.
- **Caller-driven tags:** `docker/metadata-action` derives tags from the trigger context, which is wrong when building a branch other than the one that triggered the run (the deploy case, PR 2/2). So `build-publish.yml` takes explicit `tags:` — `release.yml` passes `type=semver`, the upcoming `deploy.yml` will pass explicit `type=raw` slug + SHA.
- **Action pinning:** the security-critical Trivy action is SHA-pinned (`ed142fd… # v0.36.0`); trusted first-party Docker/CodeQL actions use major tags, kept current by the `github-actions` Dependabot group.

## Verification

`actionlint` couldn't run locally (no Docker daemon / binary in the dev env); YAML syntax validated with PyYAML. Definitive checks once merged:

1. **Workflow parses & runs:** push a throwaway branch and `gh workflow run` is not wired yet in this PR — `release.yml` can be exercised by pushing a `v0.0.1-test` tag → confirm a versioned image at `ghcr.io/sentinel-web/community-manager` and a GitHub Release with notes.
2. **SBOM present:** `docker buildx imagetools inspect ghcr.io/sentinel-web/community-manager:v0.0.1-test --format '{{json .SBOM}}'`.
3. **Trivy SARIF:** appears under **Security → Code scanning**.
4. **Dependabot enabled:** Insights → Dependency graph → Dependabot lists the three ecosystems and opens grouped PRs.

> ⚠️ First GHCR push creates the package — link it to this repo (Package settings) so `GITHUB_TOKEN` retains pull access for the deploy half.

## Next (PR 2/2)
Per-branch deploy: parameterized `docker-compose.yml`, `scripts/deploy.sh`/`teardown.sh`, and `deploy.yml`/`teardown.yml` (SSH to the single Docker + Traefik host). Needs deploy secrets + wildcard DNS, documented there.
