### PR TITLE
CD pipeline (2/2): per-branch preview-environment deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,19 @@ ROOT_URL=https://example.com
 TRAEFIK_ENTRYPOINT=websecure
 TRAEFIK_CERTRESOLVER=letsencrypt
 
+# --- Per-branch preview stacks (set by scripts/deploy.sh; leave unset for a
+#     classic single-host prod deploy, which falls back to STACK=community-manager
+#     routed at $DOMAIN) ---
+# STACK         unique stack/router slug, e.g. feature-issue-123
+# STACK_HOST    public host for this stack, e.g. feature-issue-123.preview.example.com
+# ROOT_URL must equal https://$STACK_HOST exactly (Meteor requirement)
+# BASE_DOMAIN   wildcard base the deploy workflow appends the slug to (preview.example.com)
+# IMAGE         digest-pinned GHCR ref to run, e.g. ghcr.io/sentinel-web/community-manager@sha256:...
+# STACK=
+# STACK_HOST=
+# BASE_DOMAIN=preview.example.com
+# IMAGE=
+
 # --- MongoDB credentials (required) ---
 # Generate strong values, e.g. `openssl rand -base64 24`
 MONGO_INITDB_ROOT_USERNAME=communitymanager

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+
+updates:
+  # --- Application dependencies (root package.json) ---
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Families that should move together so a single PR keeps them in sync and
+      # cuts review noise. Most-specific patterns first — Dependabot assigns each
+      # dependency to the first matching group.
+      react:
+        patterns: ["react", "react-dom", "@types/react-dom", "react-refresh"]
+      tiptap:
+        patterns: ["@tiptap/*"]
+      rspack:
+        patterns: ["@rspack/*", "@rsdoctor/*", "@meteorjs/rspack"]
+      eslint:
+        patterns: ["eslint", "eslint-*", "@eslint/*", "typescript-eslint", "globals"]
+      types:
+        patterns: ["@types/*"]
+      # Everything else: bundle minor/patch bumps so they don't each open a PR.
+      # Majors still come through individually for deliberate review.
+      misc-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # engines.node is pinned to 22.x to match Meteor 3.4.1's bundled node.
+      - dependency-name: "node"
+      # @types/node is deliberately held at v20 to match Meteor's bundled node
+      # typings, not the v22 runtime — never auto-bump its major.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  # --- GitHub Actions (keeps the SHA/major pins in the workflows current) ---
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # --- Dockerfile base images ---
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # Both base images are hand-coupled to METEOR@3.4.1 and must only move as
+      # part of a deliberate Meteor upgrade (see CLAUDE.md node-version pinning).
+      - dependency-name: "node"
+      - dependency-name: "geoffreybooth/meteor-base"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Categorises the notes that `gh release create --generate-notes` produces
+# (release.yml workflow) by each merged PR's labels. First matching category
+# wins, so the "*" catch-all must stay last.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 🔧 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,139 @@
+name: build-publish
+
+# Reusable workflow: build the Meteor app image, publish it to GHCR, scan it
+# with Trivy, and attach an SBOM + provenance attestation. Every workflow that
+# needs an image (deploy, release) calls THIS one, so the privileged surface —
+# the only place that logs into the registry and runs the scanner — lives in a
+# single auditable file.
+#
+# It is deliberately tag-agnostic: the CALLER passes the exact docker/metadata
+# tag directives. metadata-action otherwise derives tags from the trigger
+# context (github.ref / github.sha), which is wrong when we build a branch other
+# than the one that triggered the run (deploy builds a feature branch while the
+# workflow itself is read from the default branch). See deploy.yml / release.yml.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref or SHA to check out and build.
+        required: true
+        type: string
+      tags:
+        description: >-
+          docker/metadata-action `tags:` directives (newline-separated). The
+          caller owns tagging so context-derived tags can never mislabel a
+          cross-branch build.
+        required: true
+        type: string
+      push:
+        description: Push to GHCR (false = build-only validation, no scan/attest).
+        type: boolean
+        default: true
+      trivy-exit-code:
+        description: >-
+          '1' fails the build on CRITICAL/HIGH findings; '0' is report-only
+          (SARIF still uploads). Start at '0', flip to '1' once .trivyignore is
+          curated.
+        type: string
+        default: '0'
+    outputs:
+      image:
+        description: Digest-pinned image reference (name@sha256:...) for downstream deploy.
+        value: ${{ jobs.build.outputs.image }}
+
+# Defence in depth: grant nothing at the top level, scope per job.
+permissions: {}
+
+jobs:
+  build:
+    name: build & publish
+    runs-on: ubuntu-latest
+    # The geoffreybooth/meteor-base builder image is large and `meteor build`
+    # is slow on a cold gha cache; give the first run plenty of headroom.
+    timeout-minutes: 60
+    permissions:
+      contents: read # checkout
+      packages: write # push to GHCR
+      security-events: write # upload Trivy SARIF to the Security tab
+      id-token: write # sign SBOM / provenance attestations
+      attestations: write # attach attestations to the pushed image
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # GHCR rejects uppercase path segments and github.repository casing is not
+      # guaranteed, so lowercase it before anything consumes it.
+      - name: Compute lowercase image name
+        id: name
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.name.outputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Build & push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: production
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Reuse Meteor builder layers across runs; mode=max also caches the
+          # heavy intermediate builder stage, not just the final image.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Attestations need the id-token/attestations permissions above; when
+          # push is false there is no registry to attach them to.
+          provenance: ${{ inputs.push }}
+          sbom: ${{ inputs.push }}
+
+      # Pin downstream deploys to the immutable digest so the artifact that gets
+      # scanned is byte-for-byte the artifact that gets deployed — a moving
+      # branch tag can never cause drift between scan and run.
+      - name: Resolve digest-pinned reference
+        id: image
+        if: ${{ inputs.push }}
+        run: echo "ref=${{ steps.name.outputs.image }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      # Trivy pulls the just-pushed image using the docker login credentials
+      # established above. Findings go to the Security tab regardless of whether
+      # they fail the build (exit-code is caller-controlled).
+      - name: Scan image with Trivy
+        if: ${{ inputs.push }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.ref }}
+          format: sarif
+          output: trivy.sarif
+          severity: CRITICAL,HIGH
+          exit-code: ${{ inputs.trivy-exit-code }}
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF
+        if: ${{ always() && inputs.push }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,173 @@
+name: deploy
+
+# Per-branch preview deploy. A developer dispatches this with a branch name (or
+# a push to main fires it automatically); it builds + publishes the image, then
+# deploys it as an isolated stack at <slug>.<base-domain> on the single Docker +
+# Traefik host. main is just another stack (main.<base-domain>) — no gate.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to deploy as a preview environment
+        required: true
+        default: main
+        type: string
+  push:
+    branches: [main]
+
+permissions: {}
+
+# Serialize repeat deploys of the same branch so two `compose up`s never race on
+# the host; a newer dispatch supersedes an in-flight one.
+concurrency:
+  group: deploy-${{ github.event.inputs.branch || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  # Validate the (possibly user-supplied) branch name, then resolve it to a slug
+  # + commit SHA. Everything downstream uses these sanitized values, never the
+  # raw input.
+  resolve:
+    name: resolve target
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.r.outputs.sha }}
+      short_sha: ${{ steps.r.outputs.short_sha }}
+      slug: ${{ steps.r.outputs.slug }}
+    steps:
+      - name: Validate branch name
+        id: pre
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          PUSH_BRANCH: ${{ github.ref_name }}
+        run: |
+          BRANCH="${INPUT_BRANCH:-$PUSH_BRANCH}"
+          # Plausible git branch only: no shell metacharacters, no leading dash,
+          # no '..'. Rejected before it can reach checkout or a shell.
+          if ! printf '%s' "$BRANCH" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$' \
+             || printf '%s' "$BRANCH" | grep -q '\.\.'; then
+            echo "Rejected branch name: '$BRANCH'" >&2
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pre.outputs.branch }}
+
+      - name: Resolve slug & SHA
+        id: r
+        env:
+          BRANCH: ${{ steps.pre.outputs.branch }}
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          SHORT="$(git rev-parse --short HEAD)"
+          # shellcheck source=scripts/lib-slug.sh
+          . scripts/lib-slug.sh
+          SLUG="$(slugify "$BRANCH" "b-$SHORT")"
+          {
+            echo "sha=$SHA"
+            echo "short_sha=$SHORT"
+            echo "slug=$SLUG"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved '$BRANCH' -> slug=$SLUG sha=$SHORT"
+
+  # Build the resolved commit and publish to GHCR with explicit slug + sha tags
+  # (the reusable workflow is context-agnostic — see build-publish.yml).
+  build:
+    name: build & publish
+    needs: resolve
+    uses: ./.github/workflows/build-publish.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      push: true
+      tags: |
+        type=raw,value=${{ needs.resolve.outputs.slug }}
+        type=raw,value=sha-${{ needs.resolve.outputs.short_sha }}
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+    secrets: inherit
+
+  deploy:
+    name: deploy to host
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    # No GitHub write scopes needed — the SSH secrets do the work.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy preview stack
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          SLUG: ${{ needs.resolve.outputs.slug }}
+          BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
+          TRAEFIK_ENTRYPOINT: ${{ vars.TRAEFIK_ENTRYPOINT }}
+          TRAEFIK_CERTRESOLVER: ${{ vars.TRAEFIK_CERTRESOLVER }}
+          MONGO_USER: ${{ secrets.MONGO_INITDB_ROOT_USERNAME }}
+          MONGO_PASS: ${{ secrets.MONGO_INITDB_ROOT_PASSWORD }}
+          METEOR_SETTINGS: ${{ secrets.METEOR_SETTINGS }}
+          MAX_STACKS: ${{ vars.MAX_PREVIEW_STACKS }}
+        run: |
+          set -euo pipefail
+          : "${BASE_DOMAIN:?BASE_DOMAIN repository variable is not set}"
+          CM_ROOT="/opt/cm"
+          STACK_DIR="$CM_ROOT/$SLUG"
+          STACK_HOST="$SLUG.$BASE_DOMAIN"
+          SSH="ssh -i $HOME/.ssh/id_deploy -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes $DEPLOY_USER@$DEPLOY_HOST"
+
+          echo "Deploying $SLUG -> https://$STACK_HOST"
+
+          # Render the per-stack .env locally (secrets come from env, not argv).
+          umask 077
+          {
+            echo "STACK=$SLUG"
+            echo "STACK_HOST=$STACK_HOST"
+            echo "DOMAIN=$STACK_HOST"
+            echo "ROOT_URL=https://$STACK_HOST"
+            echo "IMAGE=$IMAGE"
+            echo "MONGO_INITDB_ROOT_USERNAME=$MONGO_USER"
+            echo "MONGO_INITDB_ROOT_PASSWORD=$MONGO_PASS"
+            echo "METEOR_SETTINGS=$METEOR_SETTINGS"
+            echo "TRAEFIK_ENTRYPOINT=${TRAEFIK_ENTRYPOINT:-websecure}"
+            echo "TRAEFIK_CERTRESOLVER=${TRAEFIK_CERTRESOLVER:-letsencrypt}"
+          } > stack.env
+
+          # Ship the stack files, then the secret-bearing .env (mode 600).
+          $SSH "mkdir -p '$STACK_DIR/backups'"
+          scp -i "$HOME/.ssh/id_deploy" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            docker-compose.yml scripts/deploy.sh scripts/teardown.sh \
+            "$DEPLOY_USER@$DEPLOY_HOST:$STACK_DIR/"
+          scp -i "$HOME/.ssh/id_deploy" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            stack.env "$DEPLOY_USER@$DEPLOY_HOST:$STACK_DIR/.env"
+          rm -f stack.env
+
+          # Log the host into GHCR — token over stdin, never in argv/process list.
+          printf '%s' "$GHCR_TOKEN" | $SSH "docker login ghcr.io -u '$GHCR_USER' --password-stdin"
+
+          # Run the deploy (backup -> pull -> up -> health) on the host.
+          $SSH "MAX_STACKS='${MAX_STACKS:-6}' bash '$STACK_DIR/deploy.sh' --slug '$SLUG' --dir '$STACK_DIR' --backup"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+
+# Cutting a release is deliberately decoupled from deploying. Pushing a `v*`
+# tag (1) publishes a version-tagged + `latest` image via build-publish, and
+# (2) creates a GitHub Release with auto-generated notes. It does NOT deploy —
+# shipping a release to a host is a separate, explicit action (deploy.yml).
+on:
+  push:
+    tags: ['v*']
+
+permissions: {}
+
+jobs:
+  # The tag IS the trigger here, so github.ref / github.sha already point at the
+  # tagged commit — metadata-action's semver derivation is correct, unlike the
+  # cross-branch deploy case.
+  build:
+    uses: ./.github/workflows/build-publish.yml
+    with:
+      ref: ${{ github.ref }}
+      push: true
+      tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=sha,prefix=sha-,format=short
+        type=raw,value=latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+    secrets: inherit
+
+  release:
+    name: github release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+    steps:
+      # Checkout is needed so `gh release create` can read .github/release.yml
+      # for note categorisation.
+      - uses: actions/checkout@v6
+
+      # --generate-notes buckets merged PRs per .github/release.yml; --verify-tag
+      # confirms the pushed tag exists on the remote before publishing.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --generate-notes --verify-tag

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -1,0 +1,89 @@
+name: teardown
+
+# Tear down a preview stack — manually (pick a branch) or automatically when a
+# branch is deleted. Keeps RAM/disk in check on the single host (each stack runs
+# its own app + mongo). mongodump backups on the host are always preserved.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch whose preview stack to tear down
+        required: true
+        type: string
+      purge:
+        description: Also delete the stack's MongoDB volume (data is lost)
+        type: boolean
+        default: false
+  delete:
+
+permissions: {}
+
+jobs:
+  teardown:
+    name: teardown stack
+    runs-on: ubuntu-latest
+    # `delete` also fires for tags; only act on branch deletes.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.ref_type == 'branch' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Validate branch name
+        id: pre
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          DELETED_REF: ${{ github.event.ref }}
+        run: |
+          BRANCH="${INPUT_BRANCH:-$DELETED_REF}"
+          if ! printf '%s' "$BRANCH" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$' \
+             || printf '%s' "$BRANCH" | grep -q '\.\.'; then
+            echo "Rejected branch name: '$BRANCH'" >&2
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # Checks out the default branch (where this workflow runs from) for the
+      # slug helper + teardown script — the target branch itself may be gone.
+      - uses: actions/checkout@v6
+
+      - name: Resolve slug
+        id: r
+        env:
+          BRANCH: ${{ steps.pre.outputs.branch }}
+        run: |
+          # shellcheck source=scripts/lib-slug.sh
+          . scripts/lib-slug.sh
+          echo "slug=$(slugify "$BRANCH")" >> "$GITHUB_OUTPUT"
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Tear down on host
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          SLUG: ${{ steps.r.outputs.slug }}
+          # Branch-delete purges the volume (data is disposable then); a manual
+          # teardown purges only if the dispatcher opted in.
+          PURGE: ${{ (github.event_name == 'delete' || github.event.inputs.purge == 'true') && '--purge' || '' }}
+        run: |
+          set -euo pipefail
+          STACK_DIR="/opt/cm/$SLUG"
+          SSH="ssh -i $HOME/.ssh/id_deploy -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes $DEPLOY_USER@$DEPLOY_HOST"
+
+          echo "Tearing down stack cm-$SLUG (purge: ${PURGE:-no})"
+
+          # Ship a fresh teardown script (the stack dir may predate it or be
+          # absent if the branch was never deployed), then run it. The script
+          # no-ops cleanly when the stack isn't running.
+          $SSH "mkdir -p '$STACK_DIR'"
+          scp -i "$HOME/.ssh/id_deploy" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            scripts/teardown.sh "$DEPLOY_USER@$DEPLOY_HOST:$STACK_DIR/teardown.sh"
+          $SSH "bash '$STACK_DIR/teardown.sh' --slug '$SLUG' --dir '$STACK_DIR' $PURGE"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Trivy CVE allowlist for the build-publish image scan.
+#
+# This file is intentionally empty. Add a CVE ID ONLY with a documented
+# justification and a review-by date, so every suppression stays auditable and
+# nothing lingers silently. Format (one finding per line):
+#
+#   CVE-2024-12345  # transitive via <pkg>; no upstream fix yet, reassess 2026-09-01
+#
+# The scan currently runs report-only (build-publish input trivy-exit-code: '0').
+# Once this list is curated for the base image's known noise, flip callers to
+# '1' so CRITICAL/HIGH findings fail the build.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
-    image: community-manager:latest
+    # Deploys set IMAGE to a digest-pinned GHCR reference and `pull` it; local
+    # dev leaves IMAGE unset and builds via the `build:` block above.
+    image: ${IMAGE:-community-manager:latest}
     environment:
       ROOT_URL: ${ROOT_URL}
       MONGO_URL: ${MONGO_URL:-mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo:27017/community-manager?authSource=admin}
@@ -45,14 +47,19 @@ services:
       timeout: 5s
       retries: 3
       start_period: 60s
+    # Router/service name (STACK) and host (STACK_HOST) are per-stack so many
+    # branch deploys can share one Traefik without router-name collisions. The
+    # defaults reproduce the original single-host behaviour
+    # (STACK=community-manager, host=$DOMAIN), so an existing prod deploy that
+    # sets neither variable is unaffected.
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik"
-      - "traefik.http.routers.community-manager.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.community-manager.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
-      - "traefik.http.routers.community-manager.tls=true"
-      - "traefik.http.routers.community-manager.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}"
-      - "traefik.http.services.community-manager.loadbalancer.server.port=3000"
+      - "traefik.http.routers.${STACK:-community-manager}.rule=Host(`${STACK_HOST:-${DOMAIN}}`)"
+      - "traefik.http.routers.${STACK:-community-manager}.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.${STACK:-community-manager}.tls=true"
+      - "traefik.http.routers.${STACK:-community-manager}.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}"
+      - "traefik.http.services.${STACK:-community-manager}.loadbalancer.server.port=3000"
 
   mongo:
     image: mongo:7.0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,23 +1,88 @@
 # Deployment
 
-**Docker with Traefik** (production)
+Two ways to run the app, both Docker + Traefik:
+
+- **[Single-host production](#single-host-production)** — one canonical instance at your domain.
+- **[Per-branch preview environments](#per-branch-preview-environments)** — any branch (incl. `main`) deployed as an isolated stack at `<slug>.<base-domain>` from a GitHub Actions workflow. The single host runs them all side by side.
+
+The images are built and published by CI (`.github/workflows/build-publish.yml`) to **GHCR** (`ghcr.io/sentinel-web/community-manager`). The host never builds — it pulls a digest-pinned image.
+
+## Single-host production
 
 ```bash
-# Required environment variables
+# Required environment variables (.env)
 ROOT_URL=https://yourdomain.com
 DOMAIN=yourdomain.com
-MONGO_URL=mongodb://mongo:27017/community-manager  # default
+MONGO_INITDB_ROOT_USERNAME=...           # required, no default
+MONGO_INITDB_ROOT_PASSWORD=...           # required, no default
 
-# Optional Traefik settings
-TRAEFIK_ENTRYPOINT=websecure                       # default
-TRAEFIK_CERTRESOLVER=letsencrypt                   # default
+# Optional
+TRAEFIK_ENTRYPOINT=websecure             # default
+TRAEFIK_CERTRESOLVER=letsencrypt         # default
+# IMAGE=ghcr.io/sentinel-web/community-manager:latest   # else builds locally
 
-# Build and run
+docker network create traefik            # once, if not present
 docker compose up -d
 ```
 
-- Multi-stage Dockerfile: builds Meteor app, runs on Node 22
-- Requires external `traefik` network (assumes Traefik reverse proxy)
-- MongoDB 7 with health checks and persistent volume
+- Multi-stage Dockerfile: builds the Meteor app, runs on Node 22.
+- Requires the external `traefik` network (assumes a Traefik reverse proxy).
+- MongoDB 7 with health checks and a persistent volume.
+- With `STACK` / `STACK_HOST` unset, the Traefik router is named `community-manager` and routes `$DOMAIN` — the original behaviour, unchanged.
 
 See `docker-compose.yml` for the full configuration.
+
+## Per-branch preview environments
+
+A developer triggers **Actions → deploy → Run workflow**, picks a branch, and that branch goes live at `https://<slug>.<base-domain>`. Pushing to `main` deploys `main.<base-domain>` automatically. `main` is treated like any other stack — no gate.
+
+```
+deploy.yml ── resolve (validate branch → slug + SHA)
+           └─ build  (build-publish.yml → GHCR, digest-pinned)
+           └─ deploy (SSH: render .env → backup DB → compose -p cm-<slug> up -d)
+
+Traefik   https://<slug>.<base-domain>  →  cm-<slug>-app   (router/service name = <slug>)
+```
+
+### How isolation works
+
+- **Stack** = one Compose project `cm-<slug>`, where `<slug>` is the branch name sanitized to a DNS label (`feature/Issue-12` → `feature-issue-12`). Compose namespaces the containers, network, **and the `mongo` volume** per project, so each branch gets its own app **and its own MongoDB** for free.
+- **Traefik** routers/services are named per `<slug>` (parameterized in `docker-compose.yml`), so many stacks share one Traefik without router-name collisions.
+- Each stack lives in `/opt/cm/<slug>/` on the host (its `docker-compose.yml` + a mode-600 `.env` + `backups/`).
+
+### One-time host setup
+
+1. Docker Engine + Compose v2, the external `traefik` network, and a running Traefik with the `letsencrypt` (HTTP-01) cert resolver — same as production.
+2. A deploy user whose `~/.ssh/authorized_keys` holds the public half of `DEPLOY_SSH_KEY`, and which can run `docker`.
+3. **Wildcard DNS:** `*.<base-domain>` → the host's IP. Traefik then mints a per-host cert for each `<slug>.<base-domain>` on first request via HTTP-01 — no wildcard certificate needed. (Watch Let's Encrypt's 50-certs/registered-domain/week limit; switch Traefik to a DNS-01 wildcard cert if branch churn is high.)
+4. First GHCR publish creates the package — in its settings, link it to this repo so the workflow's `GITHUB_TOKEN` retains pull access.
+
+### GitHub secrets & variables
+
+Set under **Settings → Secrets and variables → Actions**.
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `DEPLOY_SSH_KEY` | secret | Private key for the deploy user. |
+| `DEPLOY_HOST` | secret | Host/IP to SSH into. |
+| `DEPLOY_USER` | secret | SSH user that owns the stacks. |
+| `SSH_KNOWN_HOSTS` | secret | Output of `ssh-keyscan <host>` — pins the host key (strict checking). |
+| `MONGO_INITDB_ROOT_USERNAME` | secret | Mongo root user for the stacks. |
+| `MONGO_INITDB_ROOT_PASSWORD` | secret | Mongo root password. |
+| `METEOR_SETTINGS` | secret (optional) | Compact (single-line) JSON for `Meteor.settings`. |
+| `BASE_DOMAIN` | variable | Wildcard base, e.g. `preview.example.com`. `STACK_HOST = <slug>.<base>`. |
+| `TRAEFIK_ENTRYPOINT` | variable (optional) | Defaults to `websecure`. |
+| `TRAEFIK_CERTRESOLVER` | variable (optional) | Defaults to `letsencrypt`. |
+| `MAX_PREVIEW_STACKS` | variable (optional) | Cap on concurrent stacks (default 6). Guards host RAM — each stack runs its own app + mongo (~1 GB). |
+
+GHCR push/pull uses the built-in `GITHUB_TOKEN`; no registry secret is required.
+
+### Deploying & tearing down
+
+- **Deploy:** Actions → **deploy** → Run workflow → enter a branch. (Or merge to `main`.) The job backs up the stack's DB (`mongodump`, kept under `/opt/cm/<slug>/backups/`, last 10 retained) **before** pulling, then `docker compose -p cm-<slug> up -d` and waits for the container healthcheck.
+- **Tear down:** Actions → **teardown** → Run workflow → enter a branch (tick *purge* to also drop its Mongo volume). Deleting a branch on GitHub auto-tears-down its stack (and purges the volume, since the data is disposable then). Backups are always preserved.
+- **List stacks on the host:** `bash /opt/cm/<any-slug>/teardown.sh --list`.
+
+### Releases
+
+Pushing a `v*` tag (`release.yml`) publishes a versioned + `latest` image and creates a GitHub Release with generated notes. It does **not** deploy — ship a release by merging to `main` or dispatching **deploy**.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Per-branch preview deploy — runs ON THE HOST, invoked by
+# .github/workflows/deploy.yml over SSH. Idempotent per slug: re-running
+# redeploys the same stack in place.
+#
+# The workflow scp's into the stack directory ($--dir) beforehand:
+#   - docker-compose.yml   (from the target branch)
+#   - .env                 (rendered compose variables, chmod 600)
+# and logs the host into ghcr.io (token piped over SSH stdin) so `pull` can
+# fetch the private image. Secrets never appear in this script's argv.
+#
+# Usage: deploy.sh --slug <slug> --dir <stack-dir> [--backup]
+set -euo pipefail
+
+SLUG="" DIR="" BACKUP=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --slug) SLUG="$2"; shift 2 ;;
+    --dir) DIR="$2"; shift 2 ;;
+    --backup) BACKUP=1; shift ;;
+    *) echo "deploy.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SLUG" ] || { echo "deploy.sh: --slug is required" >&2; exit 2; }
+[ -n "$DIR" ]  || { echo "deploy.sh: --dir is required" >&2; exit 2; }
+
+PROJECT="cm-${SLUG}"
+MAX_STACKS="${MAX_STACKS:-6}"
+
+log() { printf '\n\033[1;34m▶ %s\033[0m\n' "$*"; }
+
+# --- Preflight -------------------------------------------------------------
+command -v docker >/dev/null 2>&1 || { echo "docker not found on host" >&2; exit 1; }
+docker compose version >/dev/null 2>&1 || { echo "docker compose v2 is required" >&2; exit 1; }
+
+cd "$DIR"
+[ -f docker-compose.yml ] || { echo "missing $DIR/docker-compose.yml" >&2; exit 1; }
+[ -f .env ]               || { echo "missing $DIR/.env" >&2; exit 1; }
+chmod 600 .env 2>/dev/null || true
+
+# Explicit -f suppresses auto-loading of any docker-compose.override.yml (the
+# dev override that disables Traefik); --env-file feeds per-stack variables.
+COMPOSE=(docker compose -p "$PROJECT" -f docker-compose.yml --env-file .env)
+
+stack_exists() {
+  docker compose ls --all --format '{{.Name}}' 2>/dev/null | grep -qx "$PROJECT"
+}
+
+# --- Stack cap (only blocks brand-new stacks; redeploys always proceed) ----
+if ! stack_exists; then
+  count="$(docker compose ls --all --format '{{.Name}}' 2>/dev/null | grep -c '^cm-' || true)"
+  if [ "${count:-0}" -ge "$MAX_STACKS" ]; then
+    echo "Refusing to create a new stack: ${count}/${MAX_STACKS} preview stacks already exist." >&2
+    echo "Tear one down (teardown.yml) or raise MAX_STACKS." >&2
+    exit 1
+  fi
+fi
+
+# --- Back up the existing DB before changing anything ----------------------
+# mongodump runs inside the mongo container, so the root credentials stay in
+# the container's own env and never touch this host shell.
+if [ "$BACKUP" -eq 1 ]; then
+  if "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx mongo; then
+    log "Backing up MongoDB for $PROJECT"
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    mkdir -p backups
+    if "${COMPOSE[@]}" exec -T mongo sh -c \
+      'mongodump --quiet --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --db community-manager --archive --gzip' \
+      > "backups/${ts}.archive.gz"; then
+      echo "  wrote backups/${ts}.archive.gz"
+      # Retain the 10 most recent archives for this stack.
+      ls -1t backups/*.archive.gz 2>/dev/null | tail -n +11 | xargs -r rm -f
+    else
+      echo "  mongodump failed — aborting before deploy" >&2
+      exit 1
+    fi
+  else
+    log "No running mongo for $PROJECT yet — first deploy, nothing to back up"
+  fi
+fi
+
+# --- Pull + deploy ---------------------------------------------------------
+log "Pulling image for $PROJECT"
+"${COMPOSE[@]}" pull
+
+log "Starting $PROJECT"
+"${COMPOSE[@]}" up -d --remove-orphans
+
+# --- Wait for health -------------------------------------------------------
+log "Waiting for $PROJECT app to become healthy"
+cid="$("${COMPOSE[@]}" ps -q app)"
+[ -n "$cid" ] || { echo "app container not found after 'up'" >&2; exit 1; }
+deadline=$(( SECONDS + 150 ))
+while :; do
+  status="$(docker inspect -f '{{ if .State.Health }}{{ .State.Health.Status }}{{ else }}{{ .State.Status }}{{ end }}' "$cid" 2>/dev/null || echo unknown)"
+  case "$status" in
+    healthy) echo "  app is healthy"; break ;;
+    unhealthy)
+      echo "  app reported unhealthy" >&2
+      "${COMPOSE[@]}" logs --tail 60 app >&2 || true
+      exit 1 ;;
+  esac
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "  app did not become healthy within 150s (last: $status)" >&2
+    "${COMPOSE[@]}" logs --tail 60 app >&2 || true
+    exit 1
+  fi
+  sleep 5
+done
+
+# --- Tidy ------------------------------------------------------------------
+# Dangling-only: other live stacks share base layers, so never `system prune -a`.
+log "Pruning dangling images"
+docker image prune -f >/dev/null 2>&1 || true
+
+host="$(sed -n 's/^STACK_HOST=//p' .env | head -1)"
+log "Deployed $PROJECT  →  https://${host}"

--- a/scripts/lib-slug.sh
+++ b/scripts/lib-slug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared slug derivation — the single source of truth for turning a git branch
+# name into a DNS-label-safe stack identity. Sourced by the `resolve` step of
+# both .github/workflows/deploy.yml and teardown.yml so the project name,
+# Traefik router name, subdomain and ROOT_URL are always derived identically.
+#
+# Rules: lowercase → non-[a-z0-9] runs collapse to '-' → strip leading/trailing
+# '-' → truncate to 40 chars (leaves room under the 63-char DNS label limit once
+# the base domain is appended) → re-strip any trailing '-' left by truncation.
+# If the result is empty (pathological branch name), fall back to the 2nd arg.
+
+# slugify <branch-name> [fallback] -> prints the slug
+slugify() {
+  local input="$1" fallback="${2:-stack}" slug
+  slug="$(printf '%s' "$input" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 \
+    | sed -E 's/-+$//')"
+  [ -n "$slug" ] || slug="$fallback"
+  printf '%s' "$slug"
+}

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Tear down a preview stack — runs ON THE HOST, invoked by
+# .github/workflows/teardown.yml. mongodump backups under <dir>/backups are
+# always preserved.
+#
+# Usage:
+#   teardown.sh --slug <slug> --dir <stack-dir> [--purge]   # stop a stack
+#   teardown.sh --list                                       # list cm-* stacks
+#
+# --purge also removes the stack's volumes (its MongoDB data). The workflow
+# passes it on branch-delete (data is disposable then) but not on a manual
+# teardown (so the stack can be redeployed with its data intact).
+set -euo pipefail
+
+SLUG="" DIR="" PURGE=0 LIST=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --slug) SLUG="$2"; shift 2 ;;
+    --dir) DIR="$2"; shift 2 ;;
+    --purge) PURGE=1; shift ;;
+    --list) LIST=1; shift ;;
+    *) echo "teardown.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+docker compose version >/dev/null 2>&1 || { echo "docker compose v2 is required" >&2; exit 1; }
+
+if [ "$LIST" -eq 1 ]; then
+  echo "Active preview stacks:"
+  docker compose ls --all --format '{{.Name}}\t{{.Status}}' 2>/dev/null | grep '^cm-' || echo "  (none)"
+  exit 0
+fi
+
+[ -n "$SLUG" ] || { echo "teardown.sh: --slug is required" >&2; exit 2; }
+PROJECT="cm-${SLUG}"
+
+down=(down --remove-orphans)
+[ "$PURGE" -eq 1 ] && down+=(--volumes)
+
+# Prefer the stack's own compose file + env if still present; otherwise tear
+# down by project name alone (Compose matches running resources by label).
+if [ -n "$DIR" ] && [ -f "$DIR/docker-compose.yml" ]; then
+  cd "$DIR"
+  if [ -f .env ]; then
+    docker compose -p "$PROJECT" -f docker-compose.yml --env-file .env "${down[@]}"
+  else
+    docker compose -p "$PROJECT" -f docker-compose.yml "${down[@]}"
+  fi
+else
+  docker compose -p "$PROJECT" "${down[@]}"
+fi
+
+echo "Tore down $PROJECT (volumes purged: ${PURGE}). Backups under the stack dir are kept."


### PR DESCRIPTION
## What & why

Second of two PRs completing the CD pipeline. Builds on **#313** (the publish half). This adds **per-branch preview environments**: any developer dispatches a deploy of any branch, and the single Docker + Traefik host runs them all side by side at `https://<slug>.<base-domain>`. Pushing to `main` auto-deploys `main.<base-domain>`. `main` is just another stack — no gate.

> **Stacked on #313.** Base is `feature/cicd-publish-pipeline` so the diff is deploy-only. Merge #313 first, then this retargets to `main`.

## Changes

- **`docker-compose.yml`** — parameterize the app `image` (`IMAGE`) and the Traefik router/service name (`STACK`) + host (`STACK_HOST`). **Defaults reproduce the original single-host behaviour**, so an existing prod deploy that sets neither var is unaffected (verified with `docker compose config`).
- **`scripts/lib-slug.sh`** — shared branch→DNS-safe-slug derivation (single source of truth for stack identity; sourced by both workflows).
- **`scripts/deploy.sh`** — host-side: stack cap → `mongodump` backup *before* pull → `compose -p cm-<slug> pull && up -d` → healthcheck wait → dangling-image prune.
- **`scripts/teardown.sh`** — stop a stack (optionally purge its volume), keep backups, `--list` active stacks.
- **`.github/workflows/deploy.yml`** — `workflow_dispatch(branch)` + `push: main`. Validates the branch name, resolves slug + SHA, builds via `build-publish.yml`, SSH-deploys.
- **`.github/workflows/teardown.yml`** — `workflow_dispatch(branch)` + auto on branch delete.
- **`docs/deployment.md`** + **`.env.example`** — model, host setup, wildcard-DNS prereq, secrets/variables matrix.

## Design notes

- **Per-branch MongoDB** comes free from Compose project namespacing (`-p cm-<slug>` isolates the `mongo` service + `mongo-data` volume). Each stack ≈ 1 GB RAM → `MAX_PREVIEW_STACKS` (default 6) guards the host; branch-delete auto-teardown reclaims them.
- **Security:** the dispatch `branch` input is regex-validated (`^[A-Za-z0-9][A-Za-z0-9._/-]*$`, no `..`) before it touches checkout or a shell, then reduced to a sanitized slug + git-resolved SHA. SSH is configured manually (no third-party action in the privileged path); the GHCR token is piped over stdin; mongo creds live only in a mode-600 `.env` and the mongo container's own env (the `mongodump` runs inside the container).
- **No override leakage:** `deploy.sh` runs `docker compose -f docker-compose.yml` explicitly, so `docker-compose.override.yml` (the dev/Traefik-off file) is never auto-loaded.

## Prerequisites (operator, before first deploy)

1. Set the secrets/vars in the table in `docs/deployment.md` (`DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER`, `SSH_KNOWN_HOSTS`, `MONGO_*`, `BASE_DOMAIN`, …).
2. **Wildcard DNS** `*.<base-domain>` → host IP (Traefik mints per-host certs via HTTP-01).
3. Deploy user's `authorized_keys` holds `DEPLOY_SSH_KEY`'s public half and can run `docker`; Compose v2 + the `traefik` network present.
4. Link the GHCR package to this repo so `GITHUB_TOKEN` keeps pull access.

## Verification

Static checks done locally: YAML parses; `bash -n` on all scripts; `slugify` edge cases (`feature/Issue-123_Foo` → `feature-issue-123-foo`, empty → `b-<sha>`); `docker compose config` for both legacy and per-branch interpolation. (`actionlint` couldn't run here — no Docker daemon/binary; first GitHub run is the live check.)

End-to-end (after prereqs):
1. **deploy** a feature branch → `https://<slug>.<base-domain>` serves over valid TLS, isolated from other stacks; a timestamped archive lands in `/opt/cm/<slug>/backups/`.
2. Push to `main` → `cm-main` deploys to `main.<base-domain>`.
3. Deploy a 2nd branch → both run concurrently, distinct Traefik routers + separate Mongo data.
4. **teardown** (dispatch) and a branch delete → stack removed, backups retained.
