### PR TITLE
Fix: grant deploy job packages: read for GHCR pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,9 +98,12 @@ jobs:
     name: deploy to host
     needs: [resolve, build]
     runs-on: ubuntu-latest
-    # No GitHub write scopes needed — the SSH secrets do the work.
+    # The job's GITHUB_TOKEN is relayed to the host to `docker login`/`pull` the
+    # private image, so it needs packages: read; contents: read covers checkout.
+    # No write scopes — the SSH secrets do the deploy itself.
     permissions:
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The `deploy` job relays `GITHUB_TOKEN` to the host for `docker login`/`docker pull`, but the job only had `contents: read`. Pulling the **private** GHCR image needs `packages: read` — otherwise the host pull 403s even after the package is linked to the repo. One-line permissions fix; no behaviour change otherwise.