### PR TITLE
Fix: install devDependencies in Docker builder (rspack needs them for meteor build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY .meteor .meteor
 
-RUN meteor npm ci
+# --include=dev is required: the rspack bundler (@meteorjs/rspack, @rspack/*)
+# lives in devDependencies but is needed at build time by `meteor build`. The
+# meteor-base image runs with NODE_ENV=production, which npm treats as
+# --omit=dev — without this flag the build fails with a misleading
+# "Could not find rspack.config.js" (it means node_modules/@meteorjs/rspack).
+RUN meteor npm ci --include=dev
 
 COPY . .
 


### PR DESCRIPTION
The `geoffreybooth/meteor-base` builder runs with `NODE_ENV=production`, so `meteor npm ci` omitted devDependencies — but the **rspack bundler** (`@meteorjs/rspack`, `@rspack/*`) lives in devDependencies and is required at build time by `meteor build`. The build failed with a misleading "Could not find rspack.config.js" (the rspack plugin was looking for `node_modules/@meteorjs/rspack`). Fix: `meteor npm ci --include=dev`.

**Verified:** a build on this branch ran the full Meteor build and the deploy job brought the stack up healthy on the host (run 26724853864).