### PR TITLE
Ignore major version bumps in Dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,11 @@ updates:
     ignore:
       # engines.node is pinned to 22.x to match Meteor 3.4.1's bundled node.
       - dependency-name: "node"
-      # @types/node is deliberately held at v20 to match Meteor's bundled node
-      # typings, not the v22 runtime — never auto-bump its major.
-      - dependency-name: "@types/node"
+      # Major bumps are opt-in across the board: they need a deliberate migration
+      # (react 18->19, rspack 1->2, eslint 9->10 all break the build/tests).
+      # Minor/patch still flow via the groups above. This also keeps @types/node
+      # on its current major (v20), matching Meteor's bundled node typings.
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
   # --- GitHub Actions (keeps the SHA/major pins in the workflows current) ---


### PR DESCRIPTION
## Why
The family groups (react, rspack, eslint, …) were sweeping up **major** version bumps, which each need a deliberate migration and break CI when auto-grouped (react 18→19, rspack 1→2, eslint 9→10). Those PRs (#316, #319, #321) can't be safely merged.

## Change
Add a global `ignore` for `version-update:semver-major` on the **npm** ecosystem, so:
- **Minor/patch** updates keep flowing via the existing groups.
- **Majors** become opt-in — you upgrade react/rspack/eslint intentionally when ready.
- Also subsumes the old narrower `@types/node` major-ignore (keeps it on v20).

`github-actions` and `docker` ecosystems are unchanged (action majors like codeql v3→v4 merged fine).

## Effect
Takes effect once on `main`. Existing open major PRs (#316/#319/#321) stay as-is for you to drive; Dependabot will stop opening new major PRs and will recreate the minor/patch group cleanly against current main.