### PR TITLE
Harden production Docker image: upgrade Debian base libs, bundled npm CLI, and pin patched underscore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,11 @@ RUN meteor build --server-only --directory /built-app
 FROM node:22-slim AS production
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends tini curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@latest \
+    && npm cache clean --force \
     && groupadd --system --gid 1001 meteor \
     && useradd --system --uid 1001 --gid meteor --home /app --shell /usr/sbin/nologin meteor
 
@@ -36,6 +39,7 @@ WORKDIR /app/programs/server
 # Meteor's server bundle ships only package.json (no lockfile), so `npm ci`
 # cannot be used here — install resolves deps from package.json directly.
 RUN npm install --omit=dev --no-audit --no-fund \
+    && npm install --no-audit --no-fund underscore@1.13.8 \
     && npm cache clean --force
 
 WORKDIR /app


### PR DESCRIPTION
## What

Three Trivy-driven fixes, all confined to the production stage of `Dockerfile` (`FROM node:22-slim AS production`). They live in the same file, so they ship as one PR.

### 1. Debian base libs (`apt-get upgrade -y`)
Added `apt-get upgrade -y` to the existing apt RUN so the bookworm system libs move past their fixed versions:
- `libgnutls30` >= `3.7.9-2+deb12u7`
- `libgcrypt20` >= `1.10.1-3+deb12u1`

Fixes: CVE-2026-41989, CVE-2026-33845, CVE-2026-42010, CVE-2026-33846, CVE-2026-3833, CVE-2026-42009, CVE-2026-42011, CVE-2026-42012, CVE-2026-42013, CVE-2026-42014, CVE-2026-42015 (Trivy alerts 1-11).

### 2. Bundled npm CLI (`npm install -g npm@latest`)
`node:22-slim` ships an older npm whose bundled deps under `usr/local/lib/node_modules/npm/...` are flagged. Installing `npm@latest` (currently 11.16.0) bundles:
- `picomatch` >= `4.0.4`
- `brace-expansion` >= `2.0.3`
- `ip-address` >= `10.1.1`

Fixes: CVE-2026-33750, CVE-2026-42338, CVE-2026-33671, CVE-2026-33672 (Trivy alerts 12, 13, 18, 20).

### 3. App-dep underscore (`npm install underscore@1.13.8`)
The flagged `underscore` lives at `app/programs/server/node_modules/underscore` — a transitive dep written into Meteor's generated server-bundle `package.json` at build time. The app `package.json` has no `overrides` and does not list `underscore`, and the bundle ships no lockfile, so the only viable fix is forcing the patched version after the standard production install. `1.13.7` -> `1.13.8` is a same-major patch bump.

Fixes: CVE-2026-5260, CVE-2026-5419, CVE-2026-27601 (Trivy alerts 27, 28, 51).

## Exact change
- In the production-stage apt RUN: added `apt-get upgrade -y`, `npm install -g npm@latest`, and `npm cache clean --force`.
- In the `WORKDIR /app/programs/server` install RUN: added `npm install --no-audit --no-fund underscore@1.13.8` between the production install and the cache clean.

No changes to `package.json` or any lockfile. Dockerfile-only.

## Verification
**Done locally:**
- Dockerfile edits applied exactly as specified; line-continuation integrity checked (every continued line ends with `\`, each RUN block's last line does not).
- Layer/privilege ordering confirmed: both new installs run as root (before `USER meteor`); the underscore install runs in the same RUN layer immediately after the production install, so the patched copy is not pruned afterward.
- Registry facts confirmed against the live npm registry: `underscore@1.13.8` exists and is a same-major patch over `1.13.7` (highest published 1.13.x); `npm@latest` = `11.16.0`; its bundled `picomatch` (4.0.4), `brace-expansion` (5.0.6), `ip-address` (10.2.0) all meet/exceed the fixed versions.
- Confirmed the app `package.json` has no `overrides` key and does not list `underscore` (so the bundle-time install is the only path).

**Not done locally:**
- `docker build` was NOT executed: the docker binary is present but no daemon/socket is reachable in this environment. The image build, `dpkg-query` version checks, `npm -v`/`npm ls -g`, the bundle's `underscore/package.json` version, and the Trivy re-scan should be confirmed in CI on the built image.