### PR TITLE
Enforce openssl/libssl3 security floor in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,16 @@ FROM node:22-slim AS production
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends tini curl ca-certificates \
+    # Security floor: fail the build if apt-get upgrade did not reach the
+    # bookworm release fixing CVE-2026-45447 et al. in openssl/libssl3. The CI
+    # layer cache (cache-from: type=gha) replays this RUN's old result until
+    # its text changes, so apt-get upgrade alone can silently keep shipping
+    # stale packages — bump the floor version here to force a fresh layer.
+    && for pkg in openssl libssl3; do \
+        v="$(dpkg-query -W -f='${Version}' "$pkg")"; \
+        dpkg --compare-versions "$v" ge "3.0.20-1~deb12u2" \
+            || { echo "$pkg $v is older than required 3.0.20-1~deb12u2" >&2; exit 1; }; \
+    done \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g npm@latest \
     && npm cache clean --force \


### PR DESCRIPTION
## Summary

Clears the 18 open Trivy code-scanning alerts for `openssl`/`libssl3` (#55–#72, incl. HIGH CVE-2026-45447): the production stage already runs `apt-get upgrade -y`, but the GHA layer cache replays that layer until its text changes, so published images kept shipping `3.0.20-1~deb12u1` even though Debian fixed everything in `3.0.20-1~deb12u2`.

This adds a `dpkg --compare-versions` floor assertion after the upgrade:

- **busts the stale cached layer now** (the RUN text changed), so the next build picks up `deb12u2` — confirmed published in the bookworm security pool
- **fails the build** if the upgraded packages are ever below the floor, instead of silently shipping a vulnerable image — the deploy build itself becomes the verification
- uses `ge` comparison, so future Debian point releases pass without edits (no hard-pin supersede breakage)

The remaining 36 alerts (tar/nodemailer/qs/etc. under `app/programs/server/...`) are vendored inside Meteor 3.4.1's release packages and bundled deps (`inBundle`) — not resolvable from this repo's manifests; they are being dismissed separately as upstream-controlled.

## Verification

- `3.0.20-1~deb12u2` confirmed present in `security.debian.org` bookworm pool
- Floor-check loop tested locally under `sh` with dpkg: pass path, fail path (exit 1), and `deb12u1 < deb12u2`, `u2 >= u2`, future-version comparisons all behave correctly
- Final proof lands with the post-merge deploy: the build asserts the floor and Trivy rescans the published image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production security by enforcing minimum patched versions for OpenSSL/libssl3 dependencies to prevent vulnerable packages in deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->